### PR TITLE
Update: Deploy PublicWeb on every release

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - 'src/ReadyStackGo.PublicWeb/**'
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Deploy PublicWeb to Cloudflare on every release tag (v*), not just when PublicWeb files change.