### PR TITLE
Release: Draft-only releases, Docker Dev builds, Include stacks in image

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -21,8 +21,8 @@ jobs:
         id: drafter
         with:
           config-name: release-drafter.yml
-          # Publish release when pushing to main (after PR merge)
-          publish: ${{ github.event_name == 'push' }}
+          # Draft only - manually publish when ready
+          publish: false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/docs/CI-CD/Workflows.md
+++ b/docs/CI-CD/Workflows.md
@@ -84,15 +84,16 @@ Deployed die PublicWeb Dokumentationsseite zu Cloudflare Pages:
 
 ## Release Drafter (release-drafter.yml)
 
-**Trigger:** Push auf `main` (published Release) und Pull Requests (Draft aktualisieren)
+**Trigger:** Push auf `main` und Pull Requests
 
-Automatisiert den gesamten Release-Prozess:
+Erstellt Release-Drafts die manuell veröffentlicht werden:
 
 - **Bei PRs:** Aktualisiert Draft Release, setzt Labels via Autolabeler
-- **Bei Push auf main:** Veröffentlicht das Release mit Tag
+- **Bei Push auf main:** Aktualisiert Draft (kein Auto-Publish)
 - Kategorisiert Änderungen (Features, Bug Fixes, etc.)
 - Generiert Release Notes aus PR-Titeln
 - Berechnet Version aus PR-Labels (major/minor/patch)
+- **Manuell "Publish release" klicken** → Tag wird erstellt → Docker + Cloudflare triggern
 - Konfiguration in `.github/release-drafter.yml`
 
 ---
@@ -143,13 +144,16 @@ Push zu main/develop
 
 Push zu main
        │
-       ├──► Release Drafter (published Release + Tag)
-       │           │
-       │           └──► Tag v* triggert:
-       │                    ├──► Docker (Version-Tag)
-       │                    └──► Cloudflare Pages
+       ├──► Release Drafter (Draft aktualisieren)
        │
        └──► Wiki Sync (wenn docs/ geändert)
+
+Manuell "Publish release" klicken
+       │
+       └──► Tag v* wird erstellt
+                 │
+                 ├──► Docker (Version-Tag)
+                 └──► Cloudflare Pages
 ```
 
 ## Secrets-Übersicht

--- a/docs/Development/Git-Workflow.md
+++ b/docs/Development/Git-Workflow.md
@@ -118,31 +118,37 @@ Nur verwenden wenn Production akut betroffen ist!
 
 ---
 
-## Release erstellen (automatisch)
+## Release erstellen (Draft + manuell Publish)
 
-Der Release-Prozess ist vollständig automatisiert. Nach dem Merge eines PRs in `main`:
+PRs werden gesammelt und können gebündelt released werden:
 
 ```
-PR merge nach main ──► Release Drafter published ──► Tag erstellt ──► Docker Build + PublicWeb Deploy
-                              │
-                              └── Version aus PR-Labels ermittelt
+PR merge nach main ──► Release Drafter Draft ──► (weitere PRs) ──► Manuell Publish ──► Docker + PublicWeb
+                              │                                           │
+                              └── Version aus PR-Labels berechnet ────────┘
 ```
 
 ### Ablauf
 
-1. **PR erstellen**: `develop` → `main`
-   - Labels prüfen/setzen (bestimmt die Version)
-   - Mindestens ein Label für Kategorisierung
+1. **PRs erstellen und mergen**: `develop` → `main`
+   - Labels setzen (bestimmt die Version)
+   - Mehrere PRs können gesammelt werden
 
-2. **PR mergen**: Nach Review den PR mergen
+2. **Draft prüfen**: GitHub → Releases → Draft ansehen
+   - Alle PRs seit letztem Release sind aufgelistet
+   - Version wird automatisch berechnet
 
-3. **Automatisch passiert dann**:
-   - Release Drafter ermittelt die Version aus Labels
-   - GitHub Release wird veröffentlicht (mit Tag)
-   - Docker Workflow baut Images:
-     - `latest` Tag (von `main`)
-     - Version Tag (z.B. `0.7.0`)
-   - PublicWeb wird deployed (holt Release Notes von GitHub API)
+3. **Release veröffentlichen**: "Publish release" klicken
+   - Tag wird erstellt
+   - Docker Workflow baut Images
+   - PublicWeb wird deployed
+
+### Vorteile
+
+- **Bündeln**: Mehrere PRs in einem Release
+- **Kontrolle**: Doku-Änderungen lösen kein Release aus
+- **Keine manuelle Version**: Wird automatisch berechnet
+- **Kein manueller Tag**: Wird beim Publish erstellt
 
 ### Version-Bestimmung durch Labels
 


### PR DESCRIPTION
## Summary
- Switch to draft-only releases (manual publish when ready)
- Add Docker Dev builds to ghcr.io
- Include example stacks in Docker image
- Update workflow documentation

## Changes
- **Release Drafter**: Changed to `publish: false` - releases are now drafts until manually published
- **Docker Dev Build**: New workflow that builds to ghcr.io after successful CI on develop
- **Docker Image**: Example stacks are now included in the image and copied to volume on first mount
- **Documentation**: Updated Git-Workflow.md and Workflows.md

## Test plan
- [ ] Fresh install with install.sh shows example stacks
- [ ] Manual release publish triggers Docker and Cloudflare workflows
- [ ] Develop builds appear on ghcr.io with commit SHA label