### PR TITLE
Feature: Operation Mode with Container Lifecycle Management

### DIFF
--- a/docs/Reference/ReadyStackGo-Health-Spec.md
+++ b/docs/Reference/ReadyStackGo-Health-Spec.md
@@ -286,6 +286,30 @@ Die Health-Engine liest immer zuerst `OperationMode` und interpretiert Container
 - `OperationMode=Normal` + viele kaputte Container → echte Störung.
 - `OperationMode=Migrating` + Dienste down → erwartete Einschränkung (Degraded).
 
+### 5.3 Container-Lifecycle bei Maintenance Mode
+
+Beim Wechsel in den Maintenance-Modus werden Container automatisch gestoppt:
+
+```
+Normal → Maintenance: Alle Stack-Container werden gestoppt
+Maintenance → Normal: Alle Stack-Container werden gestartet
+```
+
+**Ausnahme:** Container mit dem Label `rsgo.maintenance=ignore` werden nicht gestoppt/gestartet.
+Dies ist nützlich für Infrastruktur-Container (z.B. Datenbanken), die während der Wartung weiterlaufen sollen.
+
+Beispiel in docker-compose.yml:
+```yaml
+services:
+  postgres:
+    image: postgres:16
+    labels:
+      rsgo.stack: my-app
+      rsgo.maintenance: ignore  # Container bleibt bei Maintenance aktiv
+```
+
+Die Container-Lifecycle-Verwaltung erfolgt über die Docker API und wird durch den `ChangeOperationModeHandler` koordiniert.
+
 ---
 
 ## 6. API


### PR DESCRIPTION
## Summary
- Add Container-Lifecycle documentation for Maintenance Mode
- Documents the automatic container stop/start behavior when entering/exiting maintenance mode
- Documents the `rsgo.maintenance=ignore` label for excluding containers

## Features
- **Container Stop on Maintenance**: Entering maintenance mode stops all stack containers
- **Container Start on Exit**: Exiting maintenance mode starts all stack containers
- **Exclusion Label**: Containers with `rsgo.maintenance=ignore` are not affected

## Implementation Details
- `IDockerService.StopStackContainersAsync()` - Stops containers by `rsgo.stack` label
- `IDockerService.StartStackContainersAsync()` - Starts containers by `rsgo.stack` label
- `ChangeOperationModeHandler` coordinates the lifecycle transitions
- SignalR notifications for real-time UI updates