### PR TITLE
Fix: Skip loading manifest fragments as standalone products

### DIFF
--- a/src/ReadyStackGo.Infrastructure/Services/StackSources/LocalDirectoryProductSourceProvider.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/StackSources/LocalDirectoryProductSourceProvider.cs
@@ -210,6 +210,13 @@ public class LocalDirectoryProductSourceProvider : IProductSourceProvider
             // Parse RSGo Manifest from file to resolve includes for multi-stack manifests
             var manifest = await _manifestParser.ParseFromFileAsync(filePath, cancellationToken);
 
+            // Skip fragments (manifests without productVersion) - they are only loaded via include
+            if (!manifest.IsProduct)
+            {
+                _logger.LogDebug("Skipping fragment {File} - no productVersion set", filePath);
+                return null;
+            }
+
             return CreateProductFromManifest(manifest, sourceId, yamlContent, filePath, relativePath, fileName);
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary
- Fragments (YAML files without `productVersion`) were incorrectly loaded as standalone products
- Now fragments are only loaded via `include` from parent product manifests

## Test plan
- [x] Multi-stack products show as single product in catalog
- [x] Fragments are not listed as separate products
- [x] Included stacks are correctly resolved within the product