### PR TITLE
Fix shared networks not propagated to sub-stacks in multi-stack products

### DIFF
--- a/src/ReadyStackGo.Infrastructure/Services/StackSources/LocalDirectoryProductSourceProvider.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/StackSources/LocalDirectoryProductSourceProvider.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.Extensions.Logging;
@@ -309,6 +310,19 @@ public class LocalDirectoryProductSourceProvider : IProductSourceProvider
         var services = ExtractServiceTemplatesFromStackEntry(stackEntry);
         var volumes = ExtractVolumeDefinitionsFromStackEntry(stackEntry);
         var networks = ExtractNetworkDefinitionsFromStackEntry(stackEntry);
+
+        // Include shared networks from manifest (similar to sharedVariables)
+        if (manifest.Networks != null)
+        {
+            foreach (var (networkName, networkDef) in manifest.Networks)
+            {
+                // Only add if not already defined in stack (stack-specific takes precedence)
+                if (!networks.Any(n => n.Name == networkName))
+                {
+                    networks.Add(ConvertToNetworkDefinition(networkName, networkDef));
+                }
+            }
+        }
 
         // Extract variables: shared + stack-specific
         var variables = new List<Variable>();


### PR DESCRIPTION
## Summary
- Networks defined at the product level (in the main manifest) were not being included in sub-stacks
- This caused Docker network errors when deploying individual stacks that reference these networks
- Now networks from the main manifest are merged into each sub-stack, similar to how `sharedVariables` already works
- Stack-specific network definitions take precedence over product-level ones

## Test plan
- [ ] Deploy a multi-stack product with networks defined in the main manifest
- [ ] Verify sub-stacks can access the shared networks without `external: true` declarations
- [ ] Verify stack-specific network definitions still override shared ones