### PR TITLE
Registry Management UX Improvements

### DIFF
--- a/src/ReadyStackGo.WebUi/src/App.tsx
+++ b/src/ReadyStackGo.WebUi/src/App.tsx
@@ -22,6 +22,7 @@ import {
   RegistriesList,
   AddRegistry,
   EditRegistry,
+  DeleteRegistry,
   TlsOverview,
   TlsConfigSelect,
   ConfigureLetsEncrypt,
@@ -170,6 +171,7 @@ export default function App() {
                 <Route path="/settings/registries" element={<RegistriesList />} />
                 <Route path="/settings/registries/add" element={<AddRegistry />} />
                 <Route path="/settings/registries/:id/edit" element={<EditRegistry />} />
+                <Route path="/settings/registries/:id/delete" element={<DeleteRegistry />} />
                 <Route path="/settings/tls" element={<TlsOverview />} />
                 <Route path="/settings/tls/configure" element={<TlsConfigSelect />} />
                 <Route path="/settings/tls/letsencrypt" element={<ConfigureLetsEncrypt />} />

--- a/src/ReadyStackGo.WebUi/src/pages/Settings/Registries/AddRegistry.tsx
+++ b/src/ReadyStackGo.WebUi/src/pages/Settings/Registries/AddRegistry.tsx
@@ -2,17 +2,36 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { createRegistry, type CreateRegistryRequest } from "../../../api/registries";
 
+const KNOWN_REGISTRIES = [
+  { label: "Docker Hub", url: "https://index.docker.io/v1/" },
+  { label: "GitHub Container Registry", url: "https://ghcr.io" },
+  { label: "GitLab Container Registry", url: "https://registry.gitlab.com" },
+  { label: "Quay.io", url: "https://quay.io" },
+  { label: "Custom", url: "" },
+];
+
 export default function AddRegistry() {
   const navigate = useNavigate();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [formData, setFormData] = useState({
-    name: "",
-    url: "",
+    name: "Docker Hub",
+    url: "https://index.docker.io/v1/",
     username: "",
     password: "",
   });
   const [patternsInput, setPatternsInput] = useState("");
+  const [selectedRegistry, setSelectedRegistry] = useState<string>("https://index.docker.io/v1/");
+
+  const handleRegistryChange = (value: string) => {
+    setSelectedRegistry(value);
+    const registry = KNOWN_REGISTRIES.find((r) => r.url === value);
+    if (registry && registry.url !== "") {
+      setFormData({ ...formData, url: registry.url, name: registry.label });
+    } else {
+      setFormData({ ...formData, url: "", name: "" });
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -89,6 +108,27 @@ export default function AddRegistry() {
           )}
 
           <div className="space-y-6 max-w-2xl">
+            {/* Registry Selection */}
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Registry Type <span className="text-red-500">*</span>
+              </label>
+              <select
+                value={selectedRegistry}
+                onChange={(e) => handleRegistryChange(e.target.value)}
+                className="w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:text-white"
+              >
+                {KNOWN_REGISTRIES.map((registry) => (
+                  <option key={registry.url || "custom"} value={registry.url}>
+                    {registry.label}
+                  </option>
+                ))}
+              </select>
+              <p className="mt-1 text-xs text-gray-500">
+                Select a known registry or choose Custom to enter your own URL
+              </p>
+            </div>
+
             {/* Basic Info */}
             <div>
               <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -102,6 +142,9 @@ export default function AddRegistry() {
                 required
                 className="w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:text-white"
               />
+              <p className="mt-1 text-xs text-gray-500">
+                Custom name for this registry (can be changed even for known registries)
+              </p>
             </div>
 
             <div>
@@ -117,7 +160,7 @@ export default function AddRegistry() {
                 className="w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 text-sm font-mono focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:text-white"
               />
               <p className="mt-1 text-xs text-gray-500">
-                Examples: https://index.docker.io/v1/, https://ghcr.io
+                Registry URL (can be adjusted if needed)
               </p>
             </div>
 

--- a/src/ReadyStackGo.WebUi/src/pages/Settings/Registries/DeleteRegistry.tsx
+++ b/src/ReadyStackGo.WebUi/src/pages/Settings/Registries/DeleteRegistry.tsx
@@ -1,0 +1,254 @@
+import { useEffect, useState } from "react";
+import { useParams, Link, useNavigate } from "react-router-dom";
+import { getRegistry, deleteRegistry, type RegistryDto } from "../../../api/registries";
+
+type DeleteState = "loading" | "confirm" | "deleting" | "success" | "error";
+
+export default function DeleteRegistry() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+
+  const [state, setState] = useState<DeleteState>("loading");
+  const [registry, setRegistry] = useState<RegistryDto | null>(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (!id) {
+      setState("error");
+      setError("No registry ID provided");
+      return;
+    }
+
+    const loadRegistry = async () => {
+      try {
+        setState("loading");
+        setError("");
+
+        const response = await getRegistry(id);
+        if (response.success && response.registry) {
+          setRegistry(response.registry);
+          setState("confirm");
+        } else {
+          setError(response.message || "Registry not found");
+          setState("error");
+        }
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load registry");
+        setState("error");
+      }
+    };
+
+    loadRegistry();
+  }, [id]);
+
+  const handleDelete = async () => {
+    if (!id) {
+      setError("No registry to delete");
+      return;
+    }
+
+    setState("deleting");
+    setError("");
+
+    try {
+      const response = await deleteRegistry(id);
+
+      if (response.success) {
+        setState("success");
+        // Navigate back after 2 seconds
+        setTimeout(() => {
+          navigate("/settings/registries");
+        }, 2000);
+      } else {
+        setError(response.message || "Failed to delete registry");
+        setState("error");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete registry");
+      setState("error");
+    }
+  };
+
+  // Loading state
+  if (state === "loading") {
+    return (
+      <div className="mx-auto max-w-screen-2xl p-4 md:p-6 2xl:p-10">
+        <div className="flex items-center justify-center py-16">
+          <p className="text-gray-500 dark:text-gray-400">Loading registry...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Error state
+  if (state === "error" && !registry) {
+    return (
+      <div className="mx-auto max-w-screen-2xl p-4 md:p-6 2xl:p-10">
+        <div className="mb-6 flex items-center gap-2 text-sm">
+          <Link to="/settings" className="text-gray-500 hover:text-brand-600 dark:text-gray-400">
+            Settings
+          </Link>
+          <span className="text-gray-400">/</span>
+          <Link to="/settings/registries" className="text-gray-500 hover:text-brand-600 dark:text-gray-400">
+            Container Registries
+          </Link>
+          <span className="text-gray-400">/</span>
+          <span className="text-gray-900 dark:text-white">Delete</span>
+        </div>
+
+        <div className="rounded-2xl border border-gray-200 bg-white p-8 dark:border-gray-800 dark:bg-white/[0.03]">
+          <div className="flex flex-col items-center justify-center py-8">
+            <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-red-100 dark:bg-red-900/30">
+              <svg className="h-8 w-8 text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </div>
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">Error</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">{error}</p>
+            <Link
+              to="/settings/registries"
+              className="rounded-md bg-brand-600 px-6 py-2 text-sm font-medium text-white hover:bg-brand-700"
+            >
+              Back to Registries
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Success state
+  if (state === "success") {
+    return (
+      <div className="mx-auto max-w-screen-2xl p-4 md:p-6 2xl:p-10">
+        <div className="mb-6 flex items-center gap-2 text-sm">
+          <Link to="/settings" className="text-gray-500 hover:text-brand-600 dark:text-gray-400">
+            Settings
+          </Link>
+          <span className="text-gray-400">/</span>
+          <Link to="/settings/registries" className="text-gray-500 hover:text-brand-600 dark:text-gray-400">
+            Container Registries
+          </Link>
+          <span className="text-gray-400">/</span>
+          <span className="text-gray-900 dark:text-white">Delete</span>
+        </div>
+
+        <div className="rounded-2xl border border-gray-200 bg-white p-8 dark:border-gray-800 dark:bg-white/[0.03]">
+          <div className="flex flex-col items-center justify-center py-8">
+            <div className="mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/30">
+              <svg className="h-8 w-8 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">Registry Deleted</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-2">
+              The registry has been deleted successfully.
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-500">
+              Redirecting back to registries...
+            </p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Confirm state
+  return (
+    <div className="mx-auto max-w-screen-2xl p-4 md:p-6 2xl:p-10">
+      <div className="mb-6 flex items-center gap-2 text-sm">
+        <Link to="/settings" className="text-gray-500 hover:text-brand-600 dark:text-gray-400">
+          Settings
+        </Link>
+        <span className="text-gray-400">/</span>
+        <Link to="/settings/registries" className="text-gray-500 hover:text-brand-600 dark:text-gray-400">
+          Container Registries
+        </Link>
+        <span className="text-gray-400">/</span>
+        <span className="text-gray-900 dark:text-white">Delete</span>
+      </div>
+
+      <div className="rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03]">
+        <div className="px-6 py-6 border-b border-gray-200 dark:border-gray-700">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 flex items-center justify-center rounded-full bg-red-100 text-red-600 dark:bg-red-900/30 dark:text-red-400">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+              </svg>
+            </div>
+            <div>
+              <h4 className="text-xl font-semibold text-black dark:text-white">
+                Delete Registry
+              </h4>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Confirm deletion of this container registry
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <div className="p-6">
+          {error && (
+            <div className="mb-6 rounded-md bg-red-50 p-4 dark:bg-red-900/20">
+              <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
+            </div>
+          )}
+
+          <div className="mb-6 rounded-lg border border-yellow-200 bg-yellow-50 p-4 dark:border-yellow-800 dark:bg-yellow-900/20">
+            <div className="flex gap-3">
+              <svg className="h-5 w-5 flex-shrink-0 text-yellow-600 dark:text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+              <div>
+                <h3 className="text-sm font-medium text-yellow-800 dark:text-yellow-200">
+                  Warning: This action cannot be undone
+                </h3>
+                <p className="mt-1 text-sm text-yellow-700 dark:text-yellow-300">
+                  You are about to delete the registry. This will remove all configuration and credentials.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {registry && (
+            <div className="mb-6 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/50">
+              <dl className="space-y-2">
+                <div>
+                  <dt className="text-xs font-medium text-gray-500 dark:text-gray-400">Registry Name</dt>
+                  <dd className="mt-1 text-sm text-gray-900 dark:text-white font-medium">{registry.name}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs font-medium text-gray-500 dark:text-gray-400">Registry URL</dt>
+                  <dd className="mt-1 text-sm text-gray-900 dark:text-white font-mono">{registry.url}</dd>
+                </div>
+                {registry.isDefault && (
+                  <div>
+                    <span className="inline-flex items-center rounded-full bg-brand-100 px-2.5 py-0.5 text-xs font-medium text-brand-800 dark:bg-brand-900/30 dark:text-brand-300">
+                      Default Registry
+                    </span>
+                  </div>
+                )}
+              </dl>
+            </div>
+          )}
+
+          <div className="flex items-center justify-between border-t border-gray-200 dark:border-gray-700 pt-6">
+            <Link
+              to="/settings/registries"
+              className="rounded-md px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+            >
+              Cancel
+            </Link>
+            <button
+              onClick={handleDelete}
+              disabled={state === "deleting"}
+              className="rounded-md bg-red-600 px-6 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {state === "deleting" ? "Deleting..." : "Delete Registry"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ReadyStackGo.WebUi/src/pages/Settings/Registries/EditRegistry.tsx
+++ b/src/ReadyStackGo.WebUi/src/pages/Settings/Registries/EditRegistry.tsx
@@ -7,6 +7,14 @@ import {
   type UpdateRegistryRequest,
 } from "../../../api/registries";
 
+const KNOWN_REGISTRIES = [
+  { label: "Docker Hub", url: "https://index.docker.io/v1/" },
+  { label: "GitHub Container Registry", url: "https://ghcr.io" },
+  { label: "GitLab Container Registry", url: "https://registry.gitlab.com" },
+  { label: "Quay.io", url: "https://quay.io" },
+  { label: "Custom", url: "" },
+];
+
 export default function EditRegistry() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
@@ -22,6 +30,15 @@ export default function EditRegistry() {
   });
   const [patternsInput, setPatternsInput] = useState("");
   const [clearCredentials, setClearCredentials] = useState(false);
+  const [selectedRegistry, setSelectedRegistry] = useState<string>("custom");
+
+  const handleRegistryChange = (value: string) => {
+    setSelectedRegistry(value);
+    const registry = KNOWN_REGISTRIES.find((r) => r.url === value);
+    if (registry && registry.url !== "") {
+      setFormData({ ...formData, url: registry.url, name: registry.label });
+    }
+  };
 
   useEffect(() => {
     const loadRegistry = async () => {
@@ -156,6 +173,27 @@ export default function EditRegistry() {
           )}
 
           <div className="space-y-6 max-w-2xl">
+            {/* Registry Selection */}
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Quick Select Registry
+              </label>
+              <select
+                value={selectedRegistry}
+                onChange={(e) => handleRegistryChange(e.target.value)}
+                className="w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:text-white"
+              >
+                {KNOWN_REGISTRIES.map((registry) => (
+                  <option key={registry.url || "custom"} value={registry.url}>
+                    {registry.label}
+                  </option>
+                ))}
+              </select>
+              <p className="mt-1 text-xs text-gray-500">
+                Quick fill from known registries or keep your custom configuration
+              </p>
+            </div>
+
             {/* Basic Info */}
             <div>
               <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
@@ -169,6 +207,9 @@ export default function EditRegistry() {
                 required
                 className="w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:text-white"
               />
+              <p className="mt-1 text-xs text-gray-500">
+                Custom name for this registry
+              </p>
             </div>
 
             <div>
@@ -183,6 +224,9 @@ export default function EditRegistry() {
                 required
                 className="w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 text-sm font-mono focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:text-white"
               />
+              <p className="mt-1 text-xs text-gray-500">
+                Registry URL (can be adjusted if needed)
+              </p>
             </div>
 
             {/* Credentials */}

--- a/src/ReadyStackGo.WebUi/src/pages/Settings/Registries/RegistriesList.tsx
+++ b/src/ReadyStackGo.WebUi/src/pages/Settings/Registries/RegistriesList.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   getRegistries,
-  deleteRegistry,
   setDefaultRegistry,
   type RegistryDto,
 } from "../../../api/registries";
@@ -41,26 +40,6 @@ export default function RegistriesList() {
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to set default registry");
-    } finally {
-      setActionLoading(null);
-    }
-  };
-
-  const handleDelete = async (id: string, name: string) => {
-    if (!confirm(`Are you sure you want to delete the registry "${name}"?`)) {
-      return;
-    }
-
-    try {
-      setActionLoading(id);
-      const response = await deleteRegistry(id);
-      if (response.success) {
-        await loadRegistries();
-      } else {
-        setError(response.message || "Failed to delete registry");
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to delete registry");
     } finally {
       setActionLoading(null);
     }
@@ -214,13 +193,12 @@ export default function RegistriesList() {
                         {actionLoading === registry.id ? "..." : "Set Default"}
                       </button>
                     )}
-                    <button
-                      onClick={() => handleDelete(registry.id, registry.name)}
-                      disabled={actionLoading === registry.id}
-                      className="inline-flex items-center justify-center rounded bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                    <Link
+                      to={`/settings/registries/${registry.id}/delete`}
+                      className="inline-flex items-center justify-center rounded bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700"
                     >
-                      {actionLoading === registry.id ? "..." : "Delete"}
-                    </button>
+                      Delete
+                    </Link>
                   </div>
                 </div>
               </div>

--- a/src/ReadyStackGo.WebUi/src/pages/Settings/Registries/index.ts
+++ b/src/ReadyStackGo.WebUi/src/pages/Settings/Registries/index.ts
@@ -1,3 +1,4 @@
 export { default as RegistriesList } from "./RegistriesList";
 export { default as AddRegistry } from "./AddRegistry";
 export { default as EditRegistry } from "./EditRegistry";
+export { default as DeleteRegistry } from "./DeleteRegistry";


### PR DESCRIPTION
## Summary
- Added registry type dropdown with pre-configured entries (Docker Hub, GitHub Container Registry, GitLab Container Registry, Quay.io)
- Docker Hub is pre-selected with fields filled by default
- All fields remain editable for customization (name and URL can be changed)
- Replaced browser confirm dialog with custom delete confirmation page
- Delete page includes proper states: loading, confirm, deleting, success, error
- Warning banner on delete page: "This action cannot be undone"

## Test Plan
- [ ] Add Registry page shows Docker Hub pre-selected with filled fields
- [ ] Switching registry type auto-fills name and URL
- [ ] Fields remain editable after selecting a registry type
- [ ] Custom registry option allows free input
- [ ] Delete button navigates to custom delete page (not browser dialog)
- [ ] Delete page shows registry details and warning
- [ ] Delete operation works correctly
- [ ] Success state redirects back to list after 2 seconds