### PR TITLE
Fix Roadmap: Sync with actual releases

### DIFF
--- a/docs/Reference/Roadmap.md
+++ b/docs/Reference/Roadmap.md
@@ -103,7 +103,10 @@ Rough outlook on planned versions and features.
   - Upgrade detection shows all available higher versions
   - Git Repository Stack Source Provider (Load Stacks from Git Repos)
   - Stack Sources Management UI (Add/Edit/Delete sources, credentials for private repos)
-- **v0.16** – TLS & Certificate Management + Release Info (2025-01-22)
+- **v0.16** – Remove Deployment + Progress Notifications (2026-01-20)
+  - Remove Deployment page with SignalR progress notifications
+  - DDD Redesign and Rollback Progress Notifications
+- **v0.17** – TLS & Certificate Management + Release Info (2026-01-22)
   - Settings UI refactoring with tab navigation (General, TLS, Registries, Stack Sources)
   - TLS Certificate Management
     - Self-signed certificate (auto-generated on first start)
@@ -126,36 +129,38 @@ Rough outlook on planned versions and features.
     - Link to GitHub release notes
     - Dismissable notification with localStorage persistence
   - Public Website TLS Documentation (DE/EN)
+  - Stack Sources Git Credentials Support
+  - Registry Management improvements
 
 ## Planned
 
-### v0.17 – Init Container UI/UX Improvements
+### v0.18 – Init Container UI/UX Improvements
 - Deployment removal status feedback (show progress when removing containers)
 - Real-time init container logs during deployment (visible in UI)
 - Separate init container counting (not counted as regular services)
 - Init containers excluded from health monitoring (only shown during deployment)
 - Optional: Automatic cleanup of exited init containers after successful deployment
 
-### v0.18 – Docker Volumes Management
+### v0.19 – Docker Volumes Management
 - Docker Volumes View (List All Volumes per Environment)
 - Volume Details (Size, Mount Points, Labels)
 - Create/Delete Volumes
 - Detect Orphaned Volumes
 
-### v0.19 – Metrics & Audit
+### v0.20 – Metrics & Audit
 - Metrics & Alerting
 - Audit Logs
 
-### v0.20 – CI/CD Integration
+### v0.21 – CI/CD Integration
 - Webhooks for External CI/CD Systems
 - API for Automated Deployments
 
-### v0.21 – Multi-User Support
+### v0.22 – Multi-User Support
 - User Management UI
 - Create/Edit Users
 - Password Reset Flow
 
-### v0.22 – Feature Flags
+### v0.23 – Feature Flags
 - Feature Flags UI in Admin
 - Feature Toggle at Organization Level
 - Environment Variables for Feature Flags


### PR DESCRIPTION
## Summary
Synchronize the roadmap with actual released versions.

## Problem
- v0.17.0 was released on 2026-01-22 but was still listed under "Planned" in the roadmap
- v0.16 entry in roadmap didn't match the actual v0.16.0 release content
- Planned version numbers were off by one

## Changes
**Added to Released:**
- **v0.16** (2026-01-20): Remove Deployment + Progress Notifications
  - Remove Deployment page with SignalR progress notifications
  - DDD Redesign and Rollback Progress Notifications
  
- **v0.17** (2026-01-22): TLS & Certificate Management + Release Info
  - Settings UI refactoring with tab navigation
  - TLS Certificate Management (self-signed, custom upload, Let's Encrypt)
  - Reverse Proxy Support (SSL Termination/Passthrough/Re-Encryption)
  - Release Info in Sidebar with update notifications
  - Public Website TLS Documentation
  - Stack Sources Git Credentials Support
  - Registry Management improvements

**Updated Planned Versions:**
- v0.17 → v0.18: Init Container UI/UX Improvements
- v0.18 → v0.19: Docker Volumes Management
- v0.19 → v0.20: Metrics & Audit
- v0.20 → v0.21: CI/CD Integration
- v0.21 → v0.22: Multi-User Support
- v0.22 → v0.23: Feature Flags

## Verification
```bash
git tag --list "v0.1*"
# v0.16.0 - 2026-01-20
# v0.17.0 - 2026-01-22
```