### PR TITLE
Add Context7 MCP server configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -421,6 +421,9 @@ rsgo.*.json
 # Claude Code local settings
 .claude/settings.local.json
 
+# MCP server config (contains API keys)
+.mcp.json
+
 # Private stack manifests (not for public repo)
 stacks/ams.project/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,12 @@
   - `docker compose down -v` - Container stoppen und Volumes löschen
 - **Port: 8080** - Die Anwendung läuft auf http://localhost:8080 (NICHT 5080!)
 
+## Context7 (MCP Server)
+
+- Bei Fragen zu externen Libraries (Playwright, ASP.NET, Blazor, Docker, YamlDotNet, MediatR, FluentAssertions, Astro/Starlight, etc.) immer **Context7** verwenden um aktuelle Dokumentation abzurufen
+- Syntax: `use context7` im Prompt oder direkt die Context7 MCP Tools nutzen
+- Besonders wichtig bei: Library-Updates, neuen API-Methoden, versionsspezifischen Features
+
 ## Sonstiges
 
 - SSL-Verifizierung für Git ist deaktiviert (abgelaufenes TFS-Zertifikat)


### PR DESCRIPTION
## Summary
- Context7 Regel in CLAUDE.md: Automatisch aktuelle Library-Docs abrufen
- .mcp.json in .gitignore (enthält API Key)