### PR TITLE
Feature 1: Separate Init-Container-Zählung

### DIFF
--- a/docs/Plans/PLAN-init-container-ux.md
+++ b/docs/Plans/PLAN-init-container-ux.md
@@ -1,0 +1,89 @@
+# Phase: Init Container UI/UX Improvements (v0.18)
+
+## Ziel
+Init Container Handling in der UI verbessern: Separate Zählung, Log-Streaming, Health-Monitoring-Ausschluss und automatische Bereinigung. Die Benutzererfahrung bei Deployments mit Init-Containern soll deutlich verbessert werden.
+
+## Analyse
+
+### Bestehende Init-Container-Implementierung
+- **Domain**: `ServiceLifecycle` Enum (`Service`, `Init`) in `Domain/StackManagement/Manifests/ServiceLifecycle.cs`
+- **Manifest**: Services mit `lifecycle: init` werden als Init-Container behandelt
+- **DeploymentEngine**: Trennt Init-Container von regulären Services, führt Init-Container zuerst aus (Phase 70-80%), danach reguläre Services (80-100%)
+- **Container Labels**: `rsgo.lifecycle=init` bzw. `rsgo.lifecycle=service` auf jedem Container
+- **Restart Policy**: Init-Container nutzen `restart: no`, reguläre Services `restart: unless-stopped`
+- **Wait-Mechanismus**: `StartInitContainerAndWaitAsync()` pollt alle 500ms mit 5-Min-Timeout
+
+### Aktuelle Schwächen
+1. **Zählung**: `totalSteps = plan.Steps.Count` mischt Init- und reguläre Container. UI zeigt "Services: 1/5" ohne Unterscheidung
+2. **Logs**: Init-Container-Logs werden nur bei Fehlern abgerufen (letzte 50 Zeilen). Kein Echtzeit-Streaming
+3. **Health Monitoring**: Init-Container werden in `CollectSelfHealthAsync()` mitgezählt. Exited(0) = Healthy, aber sie tauchen im Gesamtcount auf
+4. **Cleanup**: Keine automatische Bereinigung beendeter Init-Container
+5. **UI**: Kein visueller Unterschied zwischen Init-Containern und regulären Services in der Container-Ansicht
+
+### Betroffene Architektur-Schichten
+- **Frontend** (React/TSX): `DeployStack.tsx`, `DeploymentDetail.tsx`, `Containers.tsx`, `HealthDashboard.tsx`, `useDeploymentHub.ts`
+- **SignalR**: `DeploymentHub.cs`, `IDeploymentNotificationService.cs`
+- **Application**: `IDeploymentService.cs`, `DeploymentService.cs`, `HealthMonitoringService.cs`
+- **Infrastructure**: `DeploymentEngine.cs`, `DockerService.cs`
+- **Domain**: `DeployedService.cs`, `Deployment.cs`
+
+## Features / Schritte
+
+Reihenfolge basierend auf Abhängigkeiten und logischem Aufbau:
+
+- [x] **Feature 1: Separate Init-Container-Zählung im Deployment-Progress** – Init-Container und reguläre Services getrennt zählen und in der UI anzeigen
+  - Betroffene Dateien:
+    - `src/ReadyStackGo.Infrastructure/Services/Deployment/DeploymentEngine.cs` (Progress-Callback erweitern)
+    - `src/ReadyStackGo.Infrastructure/Services/Deployment/IDeploymentEngine.cs` (Callback-Delegate)
+    - `src/ReadyStackGo.Application/Services/IDeploymentService.cs` (Callback-Delegate)
+    - `src/ReadyStackGo.Application/Services/IDeploymentNotificationService.cs` (Notification-Methoden)
+    - `src/ReadyStackGo.Api/Hubs/DeploymentNotificationService.cs` (SignalR-Implementierung)
+    - `src/ReadyStackGo.WebUi/src/hooks/useDeploymentHub.ts` (DTO erweitern)
+    - `src/ReadyStackGo.WebUi/src/pages/Deployments/DeployStack.tsx` (UI-Anzeige)
+    - `src/ReadyStackGo.WebUi/src/pages/Deployments/UpgradeStack.tsx` (UI-Anzeige)
+    - `src/ReadyStackGo.WebUi/src/pages/Deployments/RollbackStack.tsx` (UI-Anzeige)
+  - Abhängig von: -
+
+- [ ] **Feature 2: Real-time Init-Container-Logs während Deployment** – Init-Container-Logs über SignalR an die UI streamen
+  - Betroffene Dateien:
+    - `src/ReadyStackGo.Infrastructure.Docker/DockerService.cs` (Log-Streaming-Methode)
+    - `src/ReadyStackGo.Application/Services/IDockerService.cs` (Interface)
+    - `src/ReadyStackGo.Infrastructure/Services/Deployment/DeploymentEngine.cs` (Log-Callback)
+    - `src/ReadyStackGo.Application/Services/IDeploymentNotificationService.cs` (Log-Notification)
+    - `src/ReadyStackGo.Api/Hubs/DeploymentNotificationService.cs` (SignalR Log-Event)
+    - `src/ReadyStackGo.WebUi/src/hooks/useDeploymentHub.ts` (Log-Event-Handler)
+    - `src/ReadyStackGo.WebUi/src/pages/Deployments/DeployStack.tsx` (Log-Panel in UI)
+  - Abhängig von: Feature 1
+
+- [ ] **Feature 3: Init-Container aus Health Monitoring ausschließen** – Init-Container nicht als reguläre Services im Health Dashboard zählen
+  - Betroffene Dateien:
+    - `src/ReadyStackGo.Application/Services/Impl/HealthMonitoringService.cs` (Filter erweitern)
+    - `src/ReadyStackGo.Domain/Deployment/Deployments/DeployedService.cs` (IsInitContainer Property)
+    - `src/ReadyStackGo.Domain/Deployment/Deployments/Deployment.cs` (Service-Zählung)
+    - `src/ReadyStackGo.WebUi/src/components/health/HealthStackCard.tsx` (Anzeige)
+    - `src/ReadyStackGo.WebUi/src/components/dashboard/HealthWidget.tsx` (Anzeige)
+  - Abhängig von: -
+
+- [ ] **Feature 4: Automatische Bereinigung beendeter Init-Container** – Nach erfolgreichem Deployment Init-Container entfernen
+  - Betroffene Dateien:
+    - `src/ReadyStackGo.Infrastructure/Services/Deployment/DeploymentEngine.cs` (Cleanup-Phase)
+    - `src/ReadyStackGo.Domain/Deployment/Deployments/Deployment.cs` (Service-Management)
+  - Abhängig von: Feature 1
+
+- [ ] **Dokumentation & Website** – Wiki, Public Website, Roadmap
+- [ ] **Phase abschließen** – Alle Tests grün, PR gegen main
+
+## Offene Punkte
+- [x] **Log-Streaming Ansatz** → SignalR-Streaming gewählt
+- [x] **Health-Monitoring-Ausschluss** → Komplett ausschließen gewählt
+- [x] **Cleanup-Zeitpunkt** → Am Ende der Init-Phase, nach erfolgreicher Completion aller Init-Container
+- [x] **Deployment-Detail-Ansicht** → Erfolgs-/Fehlerstatus mit Möglichkeit, Logs anzuschauen
+- [x] **TODO im Code entfernen**: `DeploymentEngine.cs:349` hat `// TODO: Remove this delay after testing` – `Task.Delay(2000)` entfernt
+
+## Entscheidungen
+| Entscheidung | Optionen | Gewählt | Begründung |
+|---|---|---|---|
+| Log-Streaming | A) SignalR-Event, B) API-Polling | A) SignalR | Echtzeit-Charakter wichtig für UX während Init-Phase |
+| Health-Ausschluss | A) Komplett entfernen, B) Separat anzeigen | A) Komplett | Init-Container sind keine langlebigen Services, gehören nicht ins Health Dashboard |
+| Cleanup-Zeitpunkt | A) Sofort nach Exit, B) Nach Init-Phase, C) Kein Cleanup | B) Nach Init-Phase | Logs bleiben verfügbar falls einzelne Init-Container fehlschlagen. Container werden am Ende der gesamten Init-Phase entfernt. |
+| UI-Darstellung Init | A) Separate Sektion, B) Badge/Icon, C) Minimal | C) Minimal | Nur Erfolg/Fehler-Status anzeigen mit Option die Logs einzusehen. Kein Bloat in der Deployment-Detail-Ansicht. |

--- a/src/ReadyStackGo.Api/Services/DeploymentNotificationService.cs
+++ b/src/ReadyStackGo.Api/Services/DeploymentNotificationService.cs
@@ -29,6 +29,8 @@ public class DeploymentNotificationService : IDeploymentNotificationService
         string? currentService,
         int totalServices,
         int completedServices,
+        int totalInitContainers,
+        int completedInitContainers,
         CancellationToken cancellationToken = default)
     {
         var groupName = $"deployment:{sessionId}";
@@ -46,6 +48,8 @@ public class DeploymentNotificationService : IDeploymentNotificationService
             CurrentService = currentService,
             TotalServices = totalServices,
             CompletedServices = completedServices,
+            TotalInitContainers = totalInitContainers,
+            CompletedInitContainers = completedInitContainers,
             Status = "InProgress"
         };
 

--- a/src/ReadyStackGo.Application/Services/IDeploymentNotificationService.cs
+++ b/src/ReadyStackGo.Application/Services/IDeploymentNotificationService.cs
@@ -14,8 +14,10 @@ public interface IDeploymentNotificationService
     /// <param name="message">Human-readable status message.</param>
     /// <param name="percentComplete">Progress percentage (0-100).</param>
     /// <param name="currentService">Name of the service currently being deployed.</param>
-    /// <param name="totalServices">Total number of services in the deployment.</param>
-    /// <param name="completedServices">Number of services successfully deployed.</param>
+    /// <param name="totalServices">Total number of regular services in the deployment.</param>
+    /// <param name="completedServices">Number of regular services successfully deployed.</param>
+    /// <param name="totalInitContainers">Total number of init containers.</param>
+    /// <param name="completedInitContainers">Number of init containers completed.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task NotifyProgressAsync(
         string sessionId,
@@ -25,6 +27,8 @@ public interface IDeploymentNotificationService
         string? currentService,
         int totalServices,
         int completedServices,
+        int totalInitContainers,
+        int completedInitContainers,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/ReadyStackGo.Application/Services/IDeploymentService.cs
+++ b/src/ReadyStackGo.Application/Services/IDeploymentService.cs
@@ -12,7 +12,9 @@ public delegate Task DeploymentServiceProgressCallback(
     int progressPercent,
     string? currentService,
     int totalServices,
-    int completedServices);
+    int completedServices,
+    int totalInitContainers,
+    int completedInitContainers);
 
 /// <summary>
 /// Service for managing Docker Compose stack deployments.

--- a/src/ReadyStackGo.Application/UseCases/Deployments/DeployCompose/DeployComposeHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/DeployCompose/DeployComposeHandler.cs
@@ -39,7 +39,7 @@ public class DeployComposeHandler : IRequestHandler<DeployComposeCommand, Deploy
         DeploymentServiceProgressCallback? progressCallback = null;
         if (_notificationService != null)
         {
-            progressCallback = async (phase, message, percent, currentService, totalServices, completedServices) =>
+            progressCallback = async (phase, message, percent, currentService, totalServices, completedServices, totalInitContainers, completedInitContainers) =>
             {
                 await _notificationService.NotifyProgressAsync(
                     sessionId,
@@ -49,6 +49,8 @@ public class DeployComposeHandler : IRequestHandler<DeployComposeCommand, Deploy
                     currentService,
                     totalServices,
                     completedServices,
+                    totalInitContainers,
+                    completedInitContainers,
                     cancellationToken);
             };
         }

--- a/src/ReadyStackGo.Application/UseCases/Deployments/DeployStack/DeployStackHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/DeployStack/DeployStackHandler.cs
@@ -83,7 +83,7 @@ public class DeployStackHandler : IRequestHandler<DeployStackCommand, DeployStac
         DeploymentServiceProgressCallback? progressCallback = null;
         if (_notificationService != null)
         {
-            progressCallback = async (phase, message, percent, currentService, totalServices, completedServices) =>
+            progressCallback = async (phase, message, percent, currentService, totalServices, completedServices, totalInitContainers, completedInitContainers) =>
             {
                 await _notificationService.NotifyProgressAsync(
                     sessionId,
@@ -93,6 +93,8 @@ public class DeployStackHandler : IRequestHandler<DeployStackCommand, DeployStac
                     currentService,
                     totalServices,
                     completedServices,
+                    totalInitContainers,
+                    completedInitContainers,
                     cancellationToken);
             };
         }

--- a/src/ReadyStackGo.Application/UseCases/Deployments/RemoveDeployment/RemoveDeploymentHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/RemoveDeployment/RemoveDeploymentHandler.cs
@@ -47,7 +47,7 @@ public class RemoveDeploymentByIdHandler : IRequestHandler<RemoveDeploymentByIdC
             request.DeploymentId, request.SessionId);
 
         // Create progress callback that sends SignalR notifications
-        DeploymentServiceProgressCallback progressCallback = async (phase, message, percent, currentService, totalServices, completedServices) =>
+        DeploymentServiceProgressCallback progressCallback = async (phase, message, percent, currentService, totalServices, completedServices, totalInitContainers, completedInitContainers) =>
         {
             if (phase == "Complete")
             {
@@ -74,7 +74,9 @@ public class RemoveDeploymentByIdHandler : IRequestHandler<RemoveDeploymentByIdC
                     percent,
                     currentService,
                     totalServices,
-                    completedServices);
+                    completedServices,
+                    totalInitContainers,
+                    completedInitContainers);
             }
         };
 

--- a/src/ReadyStackGo.Infrastructure/Services/Deployment/IDeploymentEngine.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Deployment/IDeploymentEngine.cs
@@ -10,15 +10,19 @@ namespace ReadyStackGo.Infrastructure.Services.Deployment;
 /// <param name="message">Human-readable progress message</param>
 /// <param name="progressPercent">Progress percentage (0-100)</param>
 /// <param name="currentService">Currently processing service name</param>
-/// <param name="totalServices">Total number of services to deploy</param>
-/// <param name="completedServices">Number of services already deployed</param>
+/// <param name="totalServices">Total number of regular services to deploy</param>
+/// <param name="completedServices">Number of regular services already deployed</param>
+/// <param name="totalInitContainers">Total number of init containers</param>
+/// <param name="completedInitContainers">Number of init containers already completed</param>
 public delegate Task DeploymentProgressCallback(
     string phase,
     string message,
     int progressPercent,
     string? currentService,
     int totalServices,
-    int completedServices);
+    int completedServices,
+    int totalInitContainers,
+    int completedInitContainers);
 
 /// <summary>
 /// Service for deploying stacks based on manifests

--- a/src/ReadyStackGo.WebUi/src/hooks/useDeploymentHub.ts
+++ b/src/ReadyStackGo.WebUi/src/hooks/useDeploymentHub.ts
@@ -13,6 +13,8 @@ export interface DeploymentProgressUpdate {
   currentService?: string;
   totalServices: number;
   completedServices: number;
+  totalInitContainers: number;
+  completedInitContainers: number;
   status: string;
   // Added by frontend handlers
   isComplete?: boolean;

--- a/src/ReadyStackGo.WebUi/src/pages/Deployments/DeployStack.tsx
+++ b/src/ReadyStackGo.WebUi/src/pages/Deployments/DeployStack.tsx
@@ -451,9 +451,14 @@ export default function DeployStack() {
                 </p>
 
                 {/* Service Progress */}
-                {progressUpdate && progressUpdate.totalServices > 0 && (
+                {progressUpdate && (progressUpdate.totalServices > 0 || progressUpdate.totalInitContainers > 0) && (
                   <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
-                    {progressUpdate.phase === 'PullingImages' ? 'Images' : 'Services'}: {progressUpdate.completedServices} / {progressUpdate.totalServices}
+                    {progressUpdate.phase === 'PullingImages'
+                      ? `Images: ${progressUpdate.completedServices} / ${progressUpdate.totalServices}`
+                      : progressUpdate.phase === 'InitializingContainers'
+                        ? `Init Containers: ${progressUpdate.completedInitContainers} / ${progressUpdate.totalInitContainers}`
+                        : `Services: ${progressUpdate.completedServices} / ${progressUpdate.totalServices}`
+                    }
                     {progressUpdate.currentService && (
                       <span className="ml-2">
                         (current: <span className="font-mono">{progressUpdate.currentService}</span>)

--- a/src/ReadyStackGo.WebUi/src/pages/Deployments/RollbackStack.tsx
+++ b/src/ReadyStackGo.WebUi/src/pages/Deployments/RollbackStack.tsx
@@ -244,9 +244,14 @@ export default function RollbackStack() {
                   {progressUpdate?.message || 'Starting rollback...'}
                 </p>
 
-                {progressUpdate && progressUpdate.totalServices > 0 && (
+                {progressUpdate && (progressUpdate.totalServices > 0 || progressUpdate.totalInitContainers > 0) && (
                   <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
-                    {progressUpdate.phase === 'PullingImages' ? 'Images' : 'Services'}: {progressUpdate.completedServices} / {progressUpdate.totalServices}
+                    {progressUpdate.phase === 'PullingImages'
+                      ? `Images: ${progressUpdate.completedServices} / ${progressUpdate.totalServices}`
+                      : progressUpdate.phase === 'InitializingContainers'
+                        ? `Init Containers: ${progressUpdate.completedInitContainers} / ${progressUpdate.totalInitContainers}`
+                        : `Services: ${progressUpdate.completedServices} / ${progressUpdate.totalServices}`
+                    }
                     {progressUpdate.currentService && (
                       <span className="ml-2">
                         (current: <span className="font-mono">{progressUpdate.currentService}</span>)

--- a/src/ReadyStackGo.WebUi/src/pages/Deployments/UpgradeStack.tsx
+++ b/src/ReadyStackGo.WebUi/src/pages/Deployments/UpgradeStack.tsx
@@ -406,9 +406,14 @@ export default function UpgradeStack() {
                   {progressUpdate?.message || 'Starting upgrade...'}
                 </p>
 
-                {progressUpdate && progressUpdate.totalServices > 0 && (
+                {progressUpdate && (progressUpdate.totalServices > 0 || progressUpdate.totalInitContainers > 0) && (
                   <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
-                    {progressUpdate.phase === 'PullingImages' ? 'Images' : 'Services'}: {progressUpdate.completedServices} / {progressUpdate.totalServices}
+                    {progressUpdate.phase === 'PullingImages'
+                      ? `Images: ${progressUpdate.completedServices} / ${progressUpdate.totalServices}`
+                      : progressUpdate.phase === 'InitializingContainers'
+                        ? `Init Containers: ${progressUpdate.completedInitContainers} / ${progressUpdate.totalInitContainers}`
+                        : `Services: ${progressUpdate.completedServices} / ${progressUpdate.totalServices}`
+                    }
                     {progressUpdate.currentService && (
                       <span className="ml-2">
                         (current: <span className="font-mono">{progressUpdate.currentService}</span>)


### PR DESCRIPTION
## Summary
- Init-Container und reguläre Services werden getrennt gezählt und in der UI separat angezeigt
- `DeploymentProgressCallback` und `DeploymentServiceProgressCallback` um `totalInitContainers`/`completedInitContainers` erweitert
- SignalR-Payload enthält neue Felder `TotalInitContainers`/`CompletedInitContainers`
- Frontend zeigt phasenabhängig: "Init Containers: X/Y" vs "Services: X/Y" vs "Images: X/Y"
- `Task.Delay(2000)` TODO aus DeploymentEngine entfernt

## Geänderte Dateien
- **Backend Interfaces**: `IDeploymentEngine.cs`, `IDeploymentService.cs`, `IDeploymentNotificationService.cs`
- **Backend Implementierung**: `DeploymentEngine.cs`, `DeploymentService.cs`, `DeploymentNotificationService.cs`
- **Handler**: `DeployStackHandler.cs`, `DeployComposeHandler.cs`, `RemoveDeploymentHandler.cs`
- **Frontend**: `useDeploymentHub.ts`, `DeployStack.tsx`, `UpgradeStack.tsx`, `RollbackStack.tsx`
- **Tests**: `DeploymentEngineTests.cs` (4 neue Tests)
- **Docs**: `PLAN-init-container-ux.md` erstellt

## Test plan
- [x] Build erfolgreich (0 Errors, 0 Warnings)
- [x] 1381 Unit Tests grün (4 neue Tests für Init-Container-Zählung)
- [ ] Manueller Test: Stack mit Init-Containern deployen, Progress prüfen