### PR TITLE
Add API Key domain model, data access and permissions

### DIFF
--- a/src/ReadyStackGo.Domain/IdentityAccess/ApiKeys/ApiKey.cs
+++ b/src/ReadyStackGo.Domain/IdentityAccess/ApiKeys/ApiKey.cs
@@ -1,0 +1,154 @@
+namespace ReadyStackGo.Domain.IdentityAccess.ApiKeys;
+
+using ReadyStackGo.Domain.IdentityAccess.Organizations;
+using ReadyStackGo.Domain.SharedKernel;
+
+/// <summary>
+/// Aggregate root representing an API key for CI/CD pipeline authentication.
+/// API keys authenticate webhook requests via X-Api-Key header.
+/// </summary>
+public class ApiKey : AggregateRoot<ApiKeyId>
+{
+    public OrganizationId OrganizationId { get; private set; } = null!;
+    public string Name { get; private set; } = null!;
+    public string KeyHash { get; private set; } = null!;
+    public string KeyPrefix { get; private set; } = null!;
+    public Guid? EnvironmentId { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+    public DateTime? LastUsedAt { get; private set; }
+    public DateTime? ExpiresAt { get; private set; }
+    public bool IsRevoked { get; private set; }
+    public DateTime? RevokedAt { get; private set; }
+    public string? RevokedReason { get; private set; }
+
+    private readonly List<string> _permissions = new();
+    public IReadOnlyList<string> Permissions => _permissions.AsReadOnly();
+
+    // For EF Core
+    protected ApiKey() { }
+
+    private ApiKey(
+        ApiKeyId id,
+        OrganizationId organizationId,
+        string name,
+        string keyHash,
+        string keyPrefix,
+        IEnumerable<string> permissions,
+        Guid? environmentId,
+        DateTime? expiresAt)
+    {
+        SelfAssertArgumentNotNull(id, "ApiKeyId is required.");
+        SelfAssertArgumentNotNull(organizationId, "OrganizationId is required.");
+        SelfAssertArgumentNotEmpty(name, "API key name is required.");
+        SelfAssertArgumentLength(name, 1, 100, "API key name must be 100 characters or less.");
+        SelfAssertArgumentNotEmpty(keyHash, "Key hash is required.");
+        SelfAssertArgumentLength(keyHash, 64, 64, "Key hash must be exactly 64 characters (SHA-256 hex).");
+        SelfAssertArgumentNotEmpty(keyPrefix, "Key prefix is required.");
+        SelfAssertArgumentLength(keyPrefix, 1, 12, "Key prefix must be 12 characters or less.");
+
+        var permissionList = permissions?.ToList() ?? new List<string>();
+        SelfAssertArgumentTrue(permissionList.Count > 0, "At least one permission is required.");
+
+        Id = id;
+        OrganizationId = organizationId;
+        Name = name;
+        KeyHash = keyHash;
+        KeyPrefix = keyPrefix;
+        EnvironmentId = environmentId;
+        ExpiresAt = expiresAt;
+        IsRevoked = false;
+        CreatedAt = SystemClock.UtcNow;
+
+        _permissions.AddRange(permissionList);
+
+        AddDomainEvent(new ApiKeyCreated(Id, Name));
+    }
+
+    /// <summary>
+    /// Creates a new API key.
+    /// </summary>
+    public static ApiKey Create(
+        ApiKeyId id,
+        OrganizationId organizationId,
+        string name,
+        string keyHash,
+        string keyPrefix,
+        IEnumerable<string> permissions,
+        Guid? environmentId = null,
+        DateTime? expiresAt = null)
+    {
+        return new ApiKey(id, organizationId, name, keyHash, keyPrefix, permissions, environmentId, expiresAt);
+    }
+
+    /// <summary>
+    /// Revokes this API key, permanently disabling it.
+    /// </summary>
+    public void Revoke(string? reason = null)
+    {
+        SelfAssertArgumentTrue(!IsRevoked, "API key is already revoked.");
+
+        IsRevoked = true;
+        RevokedAt = SystemClock.UtcNow;
+        RevokedReason = reason;
+
+        AddDomainEvent(new ApiKeyRevoked(Id, Name, reason));
+    }
+
+    /// <summary>
+    /// Records a usage timestamp for this API key.
+    /// </summary>
+    public void RecordUsage()
+    {
+        LastUsedAt = SystemClock.UtcNow;
+    }
+
+    /// <summary>
+    /// Checks if this API key has expired.
+    /// </summary>
+    public bool IsExpired()
+    {
+        return ExpiresAt.HasValue && ExpiresAt.Value <= SystemClock.UtcNow;
+    }
+
+    /// <summary>
+    /// Checks if this API key is valid (not revoked and not expired).
+    /// </summary>
+    public bool IsValid()
+    {
+        return !IsRevoked && !IsExpired();
+    }
+
+    /// <summary>
+    /// Checks if this API key has the specified permission.
+    /// Supports wildcards: "*.*" matches all, "Resource.*" matches all actions on a resource.
+    /// </summary>
+    public bool HasPermission(string permissionString)
+    {
+        if (string.IsNullOrEmpty(permissionString))
+            return false;
+
+        var required = permissionString.Split('.');
+        if (required.Length != 2)
+            return false;
+
+        var requiredResource = required[0];
+        var requiredAction = required[1];
+
+        return _permissions.Any(p =>
+        {
+            var parts = p.Split('.');
+            if (parts.Length != 2) return false;
+
+            var resource = parts[0];
+            var action = parts[1];
+
+            if (resource == "*") return true;
+            if (resource != requiredResource) return false;
+            if (action == "*") return true;
+            return action == requiredAction;
+        });
+    }
+
+    public override string ToString() =>
+        $"ApiKey [id={Id}, name={Name}, prefix={KeyPrefix}, revoked={IsRevoked}]";
+}

--- a/src/ReadyStackGo.Domain/IdentityAccess/ApiKeys/ApiKeyEvents.cs
+++ b/src/ReadyStackGo.Domain/IdentityAccess/ApiKeys/ApiKeyEvents.cs
@@ -1,0 +1,35 @@
+namespace ReadyStackGo.Domain.IdentityAccess.ApiKeys;
+
+using ReadyStackGo.Domain.SharedKernel;
+
+/// <summary>
+/// Event raised when a new API key is created.
+/// </summary>
+public sealed class ApiKeyCreated : DomainEvent
+{
+    public ApiKeyId ApiKeyId { get; }
+    public string Name { get; }
+
+    public ApiKeyCreated(ApiKeyId apiKeyId, string name)
+    {
+        ApiKeyId = apiKeyId;
+        Name = name;
+    }
+}
+
+/// <summary>
+/// Event raised when an API key is revoked.
+/// </summary>
+public sealed class ApiKeyRevoked : DomainEvent
+{
+    public ApiKeyId ApiKeyId { get; }
+    public string Name { get; }
+    public string? Reason { get; }
+
+    public ApiKeyRevoked(ApiKeyId apiKeyId, string name, string? reason)
+    {
+        ApiKeyId = apiKeyId;
+        Name = name;
+        Reason = reason;
+    }
+}

--- a/src/ReadyStackGo.Domain/IdentityAccess/ApiKeys/ApiKeyId.cs
+++ b/src/ReadyStackGo.Domain/IdentityAccess/ApiKeys/ApiKeyId.cs
@@ -1,0 +1,33 @@
+namespace ReadyStackGo.Domain.IdentityAccess.ApiKeys;
+
+using ReadyStackGo.Domain.SharedKernel;
+
+/// <summary>
+/// Value object identifying an API Key.
+/// </summary>
+public sealed class ApiKeyId : ValueObject
+{
+    public Guid Value { get; }
+
+    public ApiKeyId()
+    {
+        Value = Guid.NewGuid();
+    }
+
+    public ApiKeyId(Guid value)
+    {
+        SelfAssertArgumentTrue(value != Guid.Empty, "ApiKeyId cannot be empty.");
+        Value = value;
+    }
+
+    public static ApiKeyId Create() => new();
+    public static ApiKeyId NewId() => new();
+    public static ApiKeyId FromGuid(Guid value) => new(value);
+
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return Value;
+    }
+
+    public override string ToString() => Value.ToString();
+}

--- a/src/ReadyStackGo.Domain/IdentityAccess/ApiKeys/IApiKeyRepository.cs
+++ b/src/ReadyStackGo.Domain/IdentityAccess/ApiKeys/IApiKeyRepository.cs
@@ -1,0 +1,44 @@
+namespace ReadyStackGo.Domain.IdentityAccess.ApiKeys;
+
+using ReadyStackGo.Domain.IdentityAccess.Organizations;
+
+/// <summary>
+/// Repository interface for ApiKey aggregate.
+/// </summary>
+public interface IApiKeyRepository
+{
+    /// <summary>
+    /// Gets an API key by its ID.
+    /// </summary>
+    ApiKey? GetById(ApiKeyId id);
+
+    /// <summary>
+    /// Gets an API key by its SHA-256 hash. Used for authentication lookup.
+    /// </summary>
+    ApiKey? GetByKeyHash(string keyHash);
+
+    /// <summary>
+    /// Gets all API keys for an organization.
+    /// </summary>
+    IEnumerable<ApiKey> GetByOrganization(OrganizationId organizationId);
+
+    /// <summary>
+    /// Adds a new API key.
+    /// </summary>
+    void Add(ApiKey apiKey);
+
+    /// <summary>
+    /// Updates an existing API key.
+    /// </summary>
+    void Update(ApiKey apiKey);
+
+    /// <summary>
+    /// Removes an API key.
+    /// </summary>
+    void Remove(ApiKey apiKey);
+
+    /// <summary>
+    /// Saves all pending changes.
+    /// </summary>
+    void SaveChanges();
+}

--- a/src/ReadyStackGo.Domain/IdentityAccess/Roles/Permission.cs
+++ b/src/ReadyStackGo.Domain/IdentityAccess/Roles/Permission.cs
@@ -87,6 +87,20 @@ public sealed class Permission : ValueObject
         public static Permission Read => new("Dashboard", "Read");
     }
 
+    public static class ApiKeys
+    {
+        public static Permission Create => new("ApiKeys", "Create");
+        public static Permission Read => new("ApiKeys", "Read");
+        public static Permission Delete => new("ApiKeys", "Delete");
+    }
+
+    public static class Hooks
+    {
+        public static Permission Redeploy => new("Hooks", "Redeploy");
+        public static Permission Upgrade => new("Hooks", "Upgrade");
+        public static Permission SyncSources => new("Hooks", "SyncSources");
+    }
+
     protected override IEnumerable<object?> GetEqualityComponents()
     {
         yield return Resource;

--- a/src/ReadyStackGo.Domain/IdentityAccess/Roles/Role.cs
+++ b/src/ReadyStackGo.Domain/IdentityAccess/Roles/Role.cs
@@ -79,6 +79,9 @@ public class Role : AggregateRoot<RoleId>
             Permission.Registries.Delete,
             Permission.Stacks.Read,
             Permission.Dashboard.Read,
+            Permission.ApiKeys.Create,
+            Permission.ApiKeys.Read,
+            Permission.ApiKeys.Delete,
         });
 
     public static Role Operator => new(

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Configurations/ApiKeyConfiguration.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Configurations/ApiKeyConfiguration.cs
@@ -1,0 +1,78 @@
+namespace ReadyStackGo.Infrastructure.DataAccess.Configurations;
+
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using ReadyStackGo.Domain.IdentityAccess.ApiKeys;
+using ReadyStackGo.Domain.IdentityAccess.Organizations;
+
+/// <summary>
+/// EF Core configuration for ApiKey aggregate.
+/// </summary>
+public class ApiKeyConfiguration : IEntityTypeConfiguration<ApiKey>
+{
+    public void Configure(EntityTypeBuilder<ApiKey> builder)
+    {
+        builder.ToTable("ApiKeys");
+
+        builder.HasKey(a => a.Id);
+
+        builder.Property(a => a.Id)
+            .HasConversion(
+                id => id.Value,
+                value => new ApiKeyId(value))
+            .IsRequired();
+
+        builder.Property(a => a.OrganizationId)
+            .HasConversion(
+                id => id.Value,
+                value => new OrganizationId(value))
+            .IsRequired();
+
+        builder.Property(a => a.Name)
+            .HasMaxLength(100)
+            .IsRequired();
+
+        builder.Property(a => a.KeyHash)
+            .HasMaxLength(64)
+            .IsRequired();
+
+        builder.Property(a => a.KeyPrefix)
+            .HasMaxLength(12)
+            .IsRequired();
+
+        builder.Property(a => a.EnvironmentId);
+
+        builder.Property(a => a.CreatedAt)
+            .IsRequired();
+
+        builder.Property(a => a.LastUsedAt);
+        builder.Property(a => a.ExpiresAt);
+        builder.Property(a => a.IsRevoked)
+            .IsRequired();
+        builder.Property(a => a.RevokedAt);
+
+        builder.Property(a => a.RevokedReason)
+            .HasMaxLength(500);
+
+        // Store Permissions as JSON array in a single column
+        builder.Property<List<string>>("_permissions")
+            .HasField("_permissions")
+            .UsePropertyAccessMode(PropertyAccessMode.Field)
+            .HasConversion(
+                permissions => JsonSerializer.Serialize(permissions ?? new List<string>(), (JsonSerializerOptions?)null),
+                json => string.IsNullOrEmpty(json)
+                    ? new List<string>()
+                    : JsonSerializer.Deserialize<List<string>>(json, (JsonSerializerOptions?)null) ?? new List<string>())
+            .HasColumnName("Permissions")
+            .HasMaxLength(4000);
+
+        // Ignore the read-only property
+        builder.Ignore(a => a.Permissions);
+
+        // Indexes
+        builder.HasIndex(a => a.KeyHash).IsUnique();
+        builder.HasIndex(a => a.OrganizationId);
+        builder.HasIndex(a => new { a.OrganizationId, a.Name }).IsUnique();
+    }
+}

--- a/src/ReadyStackGo.Infrastructure.DataAccess/DependencyInjection.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/DependencyInjection.cs
@@ -5,6 +5,7 @@ using ReadyStackGo.Domain.Deployment.Deployments;
 using ReadyStackGo.Domain.Deployment.Environments;
 using ReadyStackGo.Domain.Deployment.Health;
 using ReadyStackGo.Domain.Deployment.Registries;
+using ReadyStackGo.Domain.IdentityAccess.ApiKeys;
 using ReadyStackGo.Domain.IdentityAccess.Organizations;
 using ReadyStackGo.Domain.IdentityAccess.Roles;
 using ReadyStackGo.Domain.IdentityAccess.Users;
@@ -39,6 +40,7 @@ public static class DependencyInjection
         services.AddScoped<IHealthSnapshotRepository, HealthSnapshotRepository>();
         services.AddScoped<IRegistryRepository, RegistryRepository>();
         services.AddScoped<IStackSourceRepository, StackSourceRepository>();
+        services.AddScoped<IApiKeyRepository, ApiKeyRepository>();
 
         return services;
     }

--- a/src/ReadyStackGo.Infrastructure.DataAccess/ReadyStackGoDbContext.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/ReadyStackGoDbContext.cs
@@ -1,6 +1,7 @@
 namespace ReadyStackGo.Infrastructure.DataAccess;
 
 using Microsoft.EntityFrameworkCore;
+using ReadyStackGo.Domain.IdentityAccess.ApiKeys;
 using ReadyStackGo.Domain.IdentityAccess.Organizations;
 using ReadyStackGo.Domain.IdentityAccess.Roles;
 using ReadyStackGo.Domain.IdentityAccess.Users;
@@ -29,6 +30,7 @@ public class ReadyStackGoDbContext : DbContext
     public DbSet<HealthSnapshot> HealthSnapshots => Set<HealthSnapshot>();
     public DbSet<Registry> Registries => Set<Registry>();
     public DbSet<StackSource> StackSources => Set<StackSource>();
+    public DbSet<ApiKey> ApiKeys => Set<ApiKey>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Repositories/ApiKeyRepository.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Repositories/ApiKeyRepository.cs
@@ -1,0 +1,57 @@
+namespace ReadyStackGo.Infrastructure.DataAccess.Repositories;
+
+using ReadyStackGo.Domain.IdentityAccess.ApiKeys;
+using ReadyStackGo.Domain.IdentityAccess.Organizations;
+
+/// <summary>
+/// SQLite implementation of IApiKeyRepository.
+/// </summary>
+public class ApiKeyRepository : IApiKeyRepository
+{
+    private readonly ReadyStackGoDbContext _context;
+
+    public ApiKeyRepository(ReadyStackGoDbContext context)
+    {
+        _context = context;
+    }
+
+    public ApiKey? GetById(ApiKeyId id)
+    {
+        return _context.ApiKeys
+            .FirstOrDefault(a => a.Id == id);
+    }
+
+    public ApiKey? GetByKeyHash(string keyHash)
+    {
+        return _context.ApiKeys
+            .FirstOrDefault(a => a.KeyHash == keyHash);
+    }
+
+    public IEnumerable<ApiKey> GetByOrganization(OrganizationId organizationId)
+    {
+        return _context.ApiKeys
+            .Where(a => a.OrganizationId == organizationId)
+            .OrderBy(a => a.Name)
+            .ToList();
+    }
+
+    public void Add(ApiKey apiKey)
+    {
+        _context.ApiKeys.Add(apiKey);
+    }
+
+    public void Update(ApiKey apiKey)
+    {
+        _context.ApiKeys.Update(apiKey);
+    }
+
+    public void Remove(ApiKey apiKey)
+    {
+        _context.ApiKeys.Remove(apiKey);
+    }
+
+    public void SaveChanges()
+    {
+        _context.SaveChanges();
+    }
+}

--- a/tests/ReadyStackGo.IntegrationTests/DataAccess/ApiKeyRepositoryIntegrationTests.cs
+++ b/tests/ReadyStackGo.IntegrationTests/DataAccess/ApiKeyRepositoryIntegrationTests.cs
@@ -1,0 +1,420 @@
+namespace ReadyStackGo.IntegrationTests.DataAccess;
+
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using ReadyStackGo.Domain.IdentityAccess.ApiKeys;
+using ReadyStackGo.Domain.IdentityAccess.Organizations;
+using ReadyStackGo.Infrastructure.DataAccess.Repositories;
+using ReadyStackGo.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Integration tests for ApiKeyRepository with real SQLite database.
+/// Tests verify that the entity configuration works correctly with SQLite,
+/// especially the JSON column for Permissions.
+/// </summary>
+public class ApiKeyRepositoryIntegrationTests : IDisposable
+{
+    private readonly SqliteTestFixture _fixture;
+    private readonly ApiKeyRepository _repository;
+    private readonly OrganizationId _testOrgId;
+
+    private const string ValidKeyHash = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+    private const string ValidKeyPrefix = "rsgo_a1b2c3d";
+
+    public ApiKeyRepositoryIntegrationTests()
+    {
+        _fixture = new SqliteTestFixture();
+        _repository = new ApiKeyRepository(_fixture.Context);
+        _testOrgId = new OrganizationId(Guid.NewGuid());
+    }
+
+    public void Dispose() => _fixture.Dispose();
+
+    private ApiKey CreateTestApiKey(
+        string name = "CI Pipeline",
+        string? keyHash = null,
+        string keyPrefix = ValidKeyPrefix,
+        IEnumerable<string>? permissions = null,
+        Guid? environmentId = null,
+        DateTime? expiresAt = null)
+    {
+        return ApiKey.Create(
+            ApiKeyId.Create(),
+            _testOrgId,
+            name,
+            keyHash ?? GenerateUniqueHash(),
+            keyPrefix,
+            permissions ?? new[] { "Hooks.Redeploy" },
+            environmentId,
+            expiresAt);
+    }
+
+    private static string GenerateUniqueHash()
+    {
+        return Guid.NewGuid().ToString("N") + Guid.NewGuid().ToString("N");
+    }
+
+    #region Add Tests
+
+    [Fact]
+    public void Add_ShouldPersistApiKey_WithAllProperties()
+    {
+        // Arrange
+        var apiKeyId = ApiKeyId.Create();
+        var envId = Guid.NewGuid();
+        var expiresAt = DateTime.UtcNow.AddDays(30);
+        var permissions = new[] { "Hooks.Redeploy", "Hooks.Upgrade", "Hooks.SyncSources" };
+        var apiKey = ApiKey.Create(
+            apiKeyId, _testOrgId, "Full Key", ValidKeyHash, ValidKeyPrefix,
+            permissions, envId, expiresAt);
+
+        // Act
+        _repository.Add(apiKey);
+        _fixture.Context.SaveChanges();
+
+        // Assert - use fresh context to verify persistence
+        using var verifyContext = _fixture.CreateNewContext();
+        var persisted = verifyContext.ApiKeys.Find(apiKeyId);
+
+        persisted.Should().NotBeNull();
+        persisted!.Name.Should().Be("Full Key");
+        persisted.KeyHash.Should().Be(ValidKeyHash);
+        persisted.KeyPrefix.Should().Be(ValidKeyPrefix);
+        persisted.OrganizationId.Should().Be(_testOrgId);
+        persisted.EnvironmentId.Should().Be(envId);
+        persisted.ExpiresAt.Should().BeCloseTo(expiresAt, TimeSpan.FromSeconds(1));
+        persisted.IsRevoked.Should().BeFalse();
+        persisted.Permissions.Should().HaveCount(3);
+        persisted.Permissions.Should().Contain("Hooks.Redeploy");
+        persisted.Permissions.Should().Contain("Hooks.Upgrade");
+        persisted.Permissions.Should().Contain("Hooks.SyncSources");
+    }
+
+    [Fact]
+    public void Add_ShouldPersistApiKey_WithNullableFieldsNull()
+    {
+        // Arrange
+        var apiKey = CreateTestApiKey();
+
+        // Act
+        _repository.Add(apiKey);
+        _fixture.Context.SaveChanges();
+
+        // Assert
+        using var verifyContext = _fixture.CreateNewContext();
+        var persisted = verifyContext.ApiKeys.Find(apiKey.Id);
+
+        persisted.Should().NotBeNull();
+        persisted!.EnvironmentId.Should().BeNull();
+        persisted.ExpiresAt.Should().BeNull();
+        persisted.LastUsedAt.Should().BeNull();
+        persisted.RevokedAt.Should().BeNull();
+        persisted.RevokedReason.Should().BeNull();
+    }
+
+    [Fact]
+    public void Add_ShouldPersistPermissionsAsJson()
+    {
+        // Arrange
+        var permissions = new[] { "Hooks.Redeploy", "Hooks.Upgrade" };
+        var apiKey = CreateTestApiKey(permissions: permissions);
+
+        // Act
+        _repository.Add(apiKey);
+        _fixture.Context.SaveChanges();
+
+        // Assert - verify with fresh context that JSON deserialization works
+        using var verifyContext = _fixture.CreateNewContext();
+        var persisted = verifyContext.ApiKeys.Find(apiKey.Id);
+
+        persisted!.Permissions.Should().HaveCount(2);
+        persisted.Permissions.Should().Contain("Hooks.Redeploy");
+        persisted.Permissions.Should().Contain("Hooks.Upgrade");
+    }
+
+    #endregion
+
+    #region GetById Tests
+
+    [Fact]
+    public void GetById_ExistingKey_ReturnsApiKey()
+    {
+        // Arrange
+        var apiKey = CreateTestApiKey();
+        _repository.Add(apiKey);
+        _fixture.Context.SaveChanges();
+
+        // Act
+        var result = _repository.GetById(apiKey.Id);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(apiKey.Id);
+        result.Name.Should().Be(apiKey.Name);
+    }
+
+    [Fact]
+    public void GetById_NonExistingKey_ReturnsNull()
+    {
+        // Act
+        var result = _repository.GetById(ApiKeyId.Create());
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region GetByKeyHash Tests
+
+    [Fact]
+    public void GetByKeyHash_ExistingHash_ReturnsApiKey()
+    {
+        // Arrange
+        var uniqueHash = GenerateUniqueHash();
+        var apiKey = CreateTestApiKey(keyHash: uniqueHash);
+        _repository.Add(apiKey);
+        _fixture.Context.SaveChanges();
+
+        // Act
+        var result = _repository.GetByKeyHash(uniqueHash);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.KeyHash.Should().Be(uniqueHash);
+        result.Id.Should().Be(apiKey.Id);
+    }
+
+    [Fact]
+    public void GetByKeyHash_NonExistingHash_ReturnsNull()
+    {
+        // Act
+        var result = _repository.GetByKeyHash("0000000000000000000000000000000000000000000000000000000000000000");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    #endregion
+
+    #region GetByOrganization Tests
+
+    [Fact]
+    public void GetByOrganization_ReturnsKeysForOrganization()
+    {
+        // Arrange
+        var key1 = CreateTestApiKey(name: "Key Alpha");
+        var key2 = CreateTestApiKey(name: "Key Beta");
+        _repository.Add(key1);
+        _repository.Add(key2);
+        _fixture.Context.SaveChanges();
+
+        // Act
+        var result = _repository.GetByOrganization(_testOrgId).ToList();
+
+        // Assert
+        result.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void GetByOrganization_ReturnsOrderedByName()
+    {
+        // Arrange
+        var keyC = CreateTestApiKey(name: "Charlie");
+        var keyA = CreateTestApiKey(name: "Alpha");
+        var keyB = CreateTestApiKey(name: "Bravo");
+        _repository.Add(keyC);
+        _repository.Add(keyA);
+        _repository.Add(keyB);
+        _fixture.Context.SaveChanges();
+
+        // Act
+        var result = _repository.GetByOrganization(_testOrgId).ToList();
+
+        // Assert
+        result.Should().HaveCount(3);
+        result[0].Name.Should().Be("Alpha");
+        result[1].Name.Should().Be("Bravo");
+        result[2].Name.Should().Be("Charlie");
+    }
+
+    [Fact]
+    public void GetByOrganization_IsolatesBetweenOrganizations()
+    {
+        // Arrange
+        var otherOrgId = new OrganizationId(Guid.NewGuid());
+        var key1 = CreateTestApiKey(name: "Org1 Key");
+        var key2 = ApiKey.Create(
+            ApiKeyId.Create(), otherOrgId, "Org2 Key", GenerateUniqueHash(),
+            ValidKeyPrefix, new[] { "Hooks.Redeploy" });
+        _repository.Add(key1);
+        _repository.Add(key2);
+        _fixture.Context.SaveChanges();
+
+        // Act
+        var result = _repository.GetByOrganization(_testOrgId).ToList();
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].Name.Should().Be("Org1 Key");
+    }
+
+    [Fact]
+    public void GetByOrganization_EmptyOrganization_ReturnsEmptyList()
+    {
+        // Act
+        var result = _repository.GetByOrganization(new OrganizationId(Guid.NewGuid())).ToList();
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region Update Tests
+
+    [Fact]
+    public void Update_RecordUsage_PersistsLastUsedAt()
+    {
+        // Arrange
+        var apiKey = CreateTestApiKey();
+        _repository.Add(apiKey);
+        _fixture.Context.SaveChanges();
+
+        // Act
+        apiKey.RecordUsage();
+        _repository.Update(apiKey);
+        _fixture.Context.SaveChanges();
+
+        // Assert
+        using var verifyContext = _fixture.CreateNewContext();
+        var persisted = verifyContext.ApiKeys.Find(apiKey.Id);
+
+        persisted!.LastUsedAt.Should().NotBeNull();
+        persisted.LastUsedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public void Update_Revoke_PersistsRevocationFields()
+    {
+        // Arrange
+        var apiKey = CreateTestApiKey();
+        _repository.Add(apiKey);
+        _fixture.Context.SaveChanges();
+
+        // Act
+        apiKey.Revoke("Security audit");
+        _repository.Update(apiKey);
+        _fixture.Context.SaveChanges();
+
+        // Assert
+        using var verifyContext = _fixture.CreateNewContext();
+        var persisted = verifyContext.ApiKeys.Find(apiKey.Id);
+
+        persisted!.IsRevoked.Should().BeTrue();
+        persisted.RevokedAt.Should().NotBeNull();
+        persisted.RevokedReason.Should().Be("Security audit");
+    }
+
+    #endregion
+
+    #region Remove Tests
+
+    [Fact]
+    public void Remove_DeletesApiKey()
+    {
+        // Arrange
+        var apiKey = CreateTestApiKey();
+        _repository.Add(apiKey);
+        _fixture.Context.SaveChanges();
+
+        // Act
+        _repository.Remove(apiKey);
+        _fixture.Context.SaveChanges();
+
+        // Assert
+        using var verifyContext = _fixture.CreateNewContext();
+        var persisted = verifyContext.ApiKeys.Find(apiKey.Id);
+        persisted.Should().BeNull();
+    }
+
+    [Fact]
+    public void Remove_DoesNotAffectOtherKeys()
+    {
+        // Arrange
+        var key1 = CreateTestApiKey(name: "Key to Delete");
+        var key2 = CreateTestApiKey(name: "Key to Keep");
+        _repository.Add(key1);
+        _repository.Add(key2);
+        _fixture.Context.SaveChanges();
+
+        // Act
+        _repository.Remove(key1);
+        _fixture.Context.SaveChanges();
+
+        // Assert
+        using var verifyContext = _fixture.CreateNewContext();
+        verifyContext.ApiKeys.Find(key1.Id).Should().BeNull();
+        verifyContext.ApiKeys.Find(key2.Id).Should().NotBeNull();
+    }
+
+    #endregion
+
+    #region Unique Constraint Tests
+
+    [Fact]
+    public void Add_DuplicateKeyHash_ThrowsException()
+    {
+        // Arrange
+        var sharedHash = GenerateUniqueHash();
+        var key1 = CreateTestApiKey(name: "Key 1", keyHash: sharedHash);
+        var key2 = CreateTestApiKey(name: "Key 2", keyHash: sharedHash);
+        _repository.Add(key1);
+        _fixture.Context.SaveChanges();
+
+        // Act
+        _repository.Add(key2);
+        var act = () => _fixture.Context.SaveChanges();
+
+        // Assert
+        act.Should().Throw<DbUpdateException>();
+    }
+
+    [Fact]
+    public void Add_DuplicateOrgAndName_ThrowsException()
+    {
+        // Arrange
+        var key1 = CreateTestApiKey(name: "Same Name");
+        var key2 = CreateTestApiKey(name: "Same Name");
+        _repository.Add(key1);
+        _fixture.Context.SaveChanges();
+
+        // Act
+        _repository.Add(key2);
+        var act = () => _fixture.Context.SaveChanges();
+
+        // Assert
+        act.Should().Throw<DbUpdateException>();
+    }
+
+    [Fact]
+    public void Add_SameNameDifferentOrg_Succeeds()
+    {
+        // Arrange
+        var otherOrgId = new OrganizationId(Guid.NewGuid());
+        var key1 = CreateTestApiKey(name: "Shared Name");
+        var key2 = ApiKey.Create(
+            ApiKeyId.Create(), otherOrgId, "Shared Name", GenerateUniqueHash(),
+            ValidKeyPrefix, new[] { "Hooks.Redeploy" });
+        _repository.Add(key1);
+        _repository.Add(key2);
+
+        // Act
+        var act = () => _fixture.Context.SaveChanges();
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    #endregion
+}

--- a/tests/ReadyStackGo.UnitTests/Domain/IdentityAccess/ApiKeyTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Domain/IdentityAccess/ApiKeyTests.cs
@@ -1,0 +1,488 @@
+using FluentAssertions;
+using ReadyStackGo.Domain.IdentityAccess.ApiKeys;
+using ReadyStackGo.Domain.IdentityAccess.Organizations;
+
+namespace ReadyStackGo.UnitTests.Domain.IdentityAccess;
+
+/// <summary>
+/// Unit tests for ApiKey aggregate root.
+/// </summary>
+public class ApiKeyTests
+{
+    private readonly OrganizationId _organizationId = new OrganizationId(Guid.NewGuid());
+    private const string ValidKeyHash = "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+    private const string ValidKeyPrefix = "rsgo_a1b2c3d";
+    private static readonly string[] DefaultPermissions = new[] { "Hooks.Redeploy" };
+
+    private ApiKey CreateApiKey(
+        string name = "CI/CD Pipeline",
+        string keyHash = ValidKeyHash,
+        string keyPrefix = ValidKeyPrefix,
+        IEnumerable<string>? permissions = null,
+        Guid? environmentId = null,
+        DateTime? expiresAt = null)
+    {
+        return ApiKey.Create(
+            ApiKeyId.Create(),
+            _organizationId,
+            name,
+            keyHash,
+            keyPrefix,
+            permissions ?? DefaultPermissions,
+            environmentId,
+            expiresAt);
+    }
+
+    #region Creation Tests
+
+    [Fact]
+    public void Create_WithValidData_CreatesApiKey()
+    {
+        // Arrange
+        var id = ApiKeyId.Create();
+        var permissions = new[] { "Hooks.Redeploy", "Hooks.Upgrade" };
+
+        // Act
+        var apiKey = ApiKey.Create(id, _organizationId, "CI Pipeline", ValidKeyHash, ValidKeyPrefix, permissions);
+
+        // Assert
+        apiKey.Id.Should().Be(id);
+        apiKey.OrganizationId.Should().Be(_organizationId);
+        apiKey.Name.Should().Be("CI Pipeline");
+        apiKey.KeyHash.Should().Be(ValidKeyHash);
+        apiKey.KeyPrefix.Should().Be(ValidKeyPrefix);
+        apiKey.Permissions.Should().HaveCount(2);
+        apiKey.Permissions.Should().Contain("Hooks.Redeploy");
+        apiKey.Permissions.Should().Contain("Hooks.Upgrade");
+        apiKey.EnvironmentId.Should().BeNull();
+        apiKey.ExpiresAt.Should().BeNull();
+        apiKey.IsRevoked.Should().BeFalse();
+        apiKey.RevokedAt.Should().BeNull();
+        apiKey.RevokedReason.Should().BeNull();
+        apiKey.LastUsedAt.Should().BeNull();
+        apiKey.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public void Create_WithAllOptionalFields_CreatesApiKey()
+    {
+        // Arrange
+        var envId = Guid.NewGuid();
+        var expiresAt = DateTime.UtcNow.AddDays(30);
+
+        // Act
+        var apiKey = CreateApiKey(environmentId: envId, expiresAt: expiresAt);
+
+        // Assert
+        apiKey.EnvironmentId.Should().Be(envId);
+        apiKey.ExpiresAt.Should().Be(expiresAt);
+    }
+
+    [Fact]
+    public void Create_WithEmptyName_ThrowsArgumentException()
+    {
+        // Act
+        var act = () => CreateApiKey(name: "");
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*name*required*");
+    }
+
+    [Fact]
+    public void Create_WithTooLongName_ThrowsArgumentException()
+    {
+        // Act
+        var act = () => CreateApiKey(name: new string('a', 101));
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*100 characters*");
+    }
+
+    [Fact]
+    public void Create_WithEmptyKeyHash_ThrowsArgumentException()
+    {
+        // Act
+        var act = () => CreateApiKey(keyHash: "");
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*hash*required*");
+    }
+
+    [Fact]
+    public void Create_WithInvalidKeyHashLength_ThrowsArgumentException()
+    {
+        // Act
+        var act = () => CreateApiKey(keyHash: "tooshort");
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*64 characters*");
+    }
+
+    [Fact]
+    public void Create_WithEmptyKeyPrefix_ThrowsArgumentException()
+    {
+        // Act
+        var act = () => CreateApiKey(keyPrefix: "");
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*prefix*required*");
+    }
+
+    [Fact]
+    public void Create_WithEmptyPermissions_ThrowsArgumentException()
+    {
+        // Act
+        var act = () => CreateApiKey(permissions: Array.Empty<string>());
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*permission*required*");
+    }
+
+    [Fact]
+    public void Create_WithNullPermissions_ThrowsArgumentException()
+    {
+        // Act
+        var act = () => ApiKey.Create(
+            ApiKeyId.Create(), _organizationId, "Test", ValidKeyHash, ValidKeyPrefix, null!);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*permission*required*");
+    }
+
+    #endregion
+
+    #region Domain Events
+
+    [Fact]
+    public void Create_RaisesApiKeyCreatedEvent()
+    {
+        // Act
+        var apiKey = CreateApiKey(name: "Pipeline Key");
+
+        // Assert
+        apiKey.DomainEvents.Should().ContainSingle();
+        var domainEvent = apiKey.DomainEvents.First();
+        domainEvent.Should().BeOfType<ApiKeyCreated>();
+        var created = (ApiKeyCreated)domainEvent;
+        created.ApiKeyId.Should().Be(apiKey.Id);
+        created.Name.Should().Be("Pipeline Key");
+    }
+
+    [Fact]
+    public void Revoke_RaisesApiKeyRevokedEvent()
+    {
+        // Arrange
+        var apiKey = CreateApiKey(name: "Test Key");
+        apiKey.ClearDomainEvents();
+
+        // Act
+        apiKey.Revoke("Compromised");
+
+        // Assert
+        apiKey.DomainEvents.Should().ContainSingle();
+        var domainEvent = apiKey.DomainEvents.First();
+        domainEvent.Should().BeOfType<ApiKeyRevoked>();
+        var revoked = (ApiKeyRevoked)domainEvent;
+        revoked.ApiKeyId.Should().Be(apiKey.Id);
+        revoked.Name.Should().Be("Test Key");
+        revoked.Reason.Should().Be("Compromised");
+    }
+
+    #endregion
+
+    #region Revoke Tests
+
+    [Fact]
+    public void Revoke_WithReason_RevokesApiKey()
+    {
+        // Arrange
+        var apiKey = CreateApiKey();
+
+        // Act
+        apiKey.Revoke("Key compromised");
+
+        // Assert
+        apiKey.IsRevoked.Should().BeTrue();
+        apiKey.RevokedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+        apiKey.RevokedReason.Should().Be("Key compromised");
+    }
+
+    [Fact]
+    public void Revoke_WithoutReason_RevokesApiKey()
+    {
+        // Arrange
+        var apiKey = CreateApiKey();
+
+        // Act
+        apiKey.Revoke();
+
+        // Assert
+        apiKey.IsRevoked.Should().BeTrue();
+        apiKey.RevokedAt.Should().NotBeNull();
+        apiKey.RevokedReason.Should().BeNull();
+    }
+
+    [Fact]
+    public void Revoke_AlreadyRevoked_ThrowsArgumentException()
+    {
+        // Arrange
+        var apiKey = CreateApiKey();
+        apiKey.Revoke("First revocation");
+
+        // Act
+        var act = () => apiKey.Revoke("Second revocation");
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*already revoked*");
+    }
+
+    #endregion
+
+    #region IsExpired Tests
+
+    [Fact]
+    public void IsExpired_NoExpiryDate_ReturnsFalse()
+    {
+        // Arrange
+        var apiKey = CreateApiKey(expiresAt: null);
+
+        // Act & Assert
+        apiKey.IsExpired().Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsExpired_FutureExpiryDate_ReturnsFalse()
+    {
+        // Arrange
+        var apiKey = CreateApiKey(expiresAt: DateTime.UtcNow.AddDays(30));
+
+        // Act & Assert
+        apiKey.IsExpired().Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsExpired_PastExpiryDate_ReturnsTrue()
+    {
+        // Arrange
+        var apiKey = CreateApiKey(expiresAt: DateTime.UtcNow.AddDays(-1));
+
+        // Act & Assert
+        apiKey.IsExpired().Should().BeTrue();
+    }
+
+    #endregion
+
+    #region IsValid Tests
+
+    [Fact]
+    public void IsValid_ActiveKey_ReturnsTrue()
+    {
+        // Arrange
+        var apiKey = CreateApiKey();
+
+        // Act & Assert
+        apiKey.IsValid().Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValid_RevokedKey_ReturnsFalse()
+    {
+        // Arrange
+        var apiKey = CreateApiKey();
+        apiKey.Revoke();
+
+        // Act & Assert
+        apiKey.IsValid().Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValid_ExpiredKey_ReturnsFalse()
+    {
+        // Arrange
+        var apiKey = CreateApiKey(expiresAt: DateTime.UtcNow.AddDays(-1));
+
+        // Act & Assert
+        apiKey.IsValid().Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValid_RevokedAndExpiredKey_ReturnsFalse()
+    {
+        // Arrange
+        var apiKey = CreateApiKey(expiresAt: DateTime.UtcNow.AddDays(-1));
+        apiKey.Revoke();
+
+        // Act & Assert
+        apiKey.IsValid().Should().BeFalse();
+    }
+
+    #endregion
+
+    #region HasPermission Tests
+
+    [Fact]
+    public void HasPermission_ExactMatch_ReturnsTrue()
+    {
+        // Arrange
+        var apiKey = CreateApiKey(permissions: new[] { "Hooks.Redeploy" });
+
+        // Act & Assert
+        apiKey.HasPermission("Hooks.Redeploy").Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasPermission_NoMatch_ReturnsFalse()
+    {
+        // Arrange
+        var apiKey = CreateApiKey(permissions: new[] { "Hooks.Redeploy" });
+
+        // Act & Assert
+        apiKey.HasPermission("Hooks.Upgrade").Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasPermission_WildcardAll_MatchesEverything()
+    {
+        // Arrange
+        var apiKey = CreateApiKey(permissions: new[] { "*.*" });
+
+        // Act & Assert
+        apiKey.HasPermission("Hooks.Redeploy").Should().BeTrue();
+        apiKey.HasPermission("ApiKeys.Create").Should().BeTrue();
+        apiKey.HasPermission("Anything.Whatever").Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasPermission_ResourceWildcard_MatchesAllActionsOnResource()
+    {
+        // Arrange
+        var apiKey = CreateApiKey(permissions: new[] { "Hooks.*" });
+
+        // Act & Assert
+        apiKey.HasPermission("Hooks.Redeploy").Should().BeTrue();
+        apiKey.HasPermission("Hooks.Upgrade").Should().BeTrue();
+        apiKey.HasPermission("Hooks.SyncSources").Should().BeTrue();
+        apiKey.HasPermission("ApiKeys.Create").Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasPermission_MultiplePermissions_MatchesAny()
+    {
+        // Arrange
+        var apiKey = CreateApiKey(permissions: new[] { "Hooks.Redeploy", "Hooks.Upgrade" });
+
+        // Act & Assert
+        apiKey.HasPermission("Hooks.Redeploy").Should().BeTrue();
+        apiKey.HasPermission("Hooks.Upgrade").Should().BeTrue();
+        apiKey.HasPermission("Hooks.SyncSources").Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasPermission_EmptyInput_ReturnsFalse()
+    {
+        // Arrange
+        var apiKey = CreateApiKey(permissions: new[] { "*.*" });
+
+        // Act & Assert
+        apiKey.HasPermission("").Should().BeFalse();
+        apiKey.HasPermission(null!).Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasPermission_InvalidFormat_ReturnsFalse()
+    {
+        // Arrange
+        var apiKey = CreateApiKey(permissions: new[] { "Hooks.Redeploy" });
+
+        // Act & Assert
+        apiKey.HasPermission("NoDotsHere").Should().BeFalse();
+        apiKey.HasPermission("Too.Many.Dots").Should().BeFalse();
+    }
+
+    #endregion
+
+    #region RecordUsage Tests
+
+    [Fact]
+    public void RecordUsage_UpdatesLastUsedAt()
+    {
+        // Arrange
+        var apiKey = CreateApiKey();
+        apiKey.LastUsedAt.Should().BeNull();
+
+        // Act
+        apiKey.RecordUsage();
+
+        // Assert
+        apiKey.LastUsedAt.Should().NotBeNull();
+        apiKey.LastUsedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public void RecordUsage_CalledMultipleTimes_UpdatesTimestamp()
+    {
+        // Arrange
+        var apiKey = CreateApiKey();
+        apiKey.RecordUsage();
+        var firstUsage = apiKey.LastUsedAt;
+
+        // Act
+        apiKey.RecordUsage();
+
+        // Assert
+        apiKey.LastUsedAt.Should().BeOnOrAfter(firstUsage!.Value);
+    }
+
+    #endregion
+
+    #region ApiKeyId Tests
+
+    [Fact]
+    public void ApiKeyId_Create_GeneratesNewGuid()
+    {
+        // Act
+        var id = ApiKeyId.Create();
+
+        // Assert
+        id.Value.Should().NotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public void ApiKeyId_FromGuid_PreservesValue()
+    {
+        // Arrange
+        var guid = Guid.NewGuid();
+
+        // Act
+        var id = ApiKeyId.FromGuid(guid);
+
+        // Assert
+        id.Value.Should().Be(guid);
+    }
+
+    [Fact]
+    public void ApiKeyId_EmptyGuid_ThrowsArgumentException()
+    {
+        // Act
+        var act = () => new ApiKeyId(Guid.Empty);
+
+        // Assert
+        act.Should().Throw<ArgumentException>().WithMessage("*cannot be empty*");
+    }
+
+    [Fact]
+    public void ApiKeyId_EqualityByValue()
+    {
+        // Arrange
+        var guid = Guid.NewGuid();
+
+        // Act
+        var id1 = ApiKeyId.FromGuid(guid);
+        var id2 = ApiKeyId.FromGuid(guid);
+
+        // Assert
+        id1.Should().Be(id2);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Introduce `ApiKey` aggregate root in IdentityAccess bounded context for CI/CD pipeline authentication
- SHA-256 hashed key storage with `rsgo_` prefix format, optional environment scoping
- Permission-based access control with wildcard support (`*.*`, `Hooks.*`)
- EF Core configuration with JSON permissions column and unique indexes on KeyHash and (OrgId, Name)
- New permissions: `ApiKeys.Create/Read/Delete`, `Hooks.Redeploy/Upgrade/SyncSources`
- OrganizationOwner role updated with ApiKeys permissions

## Test plan
- [x] 34 unit tests (Create validation, Revoke, IsExpired, IsValid, HasPermission with wildcards, RecordUsage, domain events, ApiKeyId)
- [x] 18 integration tests (CRUD persistence, JSON permissions, GetByKeyHash lookup, org isolation, unique constraints)
- [x] `dotnet build` with 0 errors and 0 warnings
- [x] All 1425 existing unit tests still pass
- [x] All 316/317 existing integration tests still pass (1 pre-existing failure unrelated)