### PR TITLE
Add API Key authentication handler with multi-scheme auth

### DIFF
--- a/src/ReadyStackGo.Infrastructure.Security/Authentication/ApiKeyAuthenticationHandler.cs
+++ b/src/ReadyStackGo.Infrastructure.Security/Authentication/ApiKeyAuthenticationHandler.cs
@@ -1,0 +1,119 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using ReadyStackGo.Domain.IdentityAccess.ApiKeys;
+using ReadyStackGo.Domain.IdentityAccess.Roles;
+
+namespace ReadyStackGo.Infrastructure.Security.Authentication;
+
+/// <summary>
+/// Authentication handler that validates API keys via X-Api-Key header.
+/// Looks up the key hash in the database and builds a ClaimsPrincipal
+/// compatible with the existing RBAC system.
+/// </summary>
+public class ApiKeyAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public const string SchemeName = "ApiKey";
+    public const string HeaderName = "X-Api-Key";
+    private const string KeyPrefix = "rsgo_";
+
+    private readonly IServiceProvider _serviceProvider;
+
+    public ApiKeyAuthenticationHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        IServiceProvider serviceProvider)
+        : base(options, logger, encoder)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue(HeaderName, out var headerValue))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        var rawKey = headerValue.ToString();
+        if (string.IsNullOrEmpty(rawKey))
+        {
+            return Task.FromResult(AuthenticateResult.NoResult());
+        }
+
+        if (!rawKey.StartsWith(KeyPrefix, StringComparison.Ordinal))
+        {
+            return Task.FromResult(AuthenticateResult.Fail("Invalid API key format."));
+        }
+
+        // Use a scope to resolve scoped services (repository)
+        using var scope = _serviceProvider.CreateScope();
+        var repository = scope.ServiceProvider.GetRequiredService<IApiKeyRepository>();
+
+        var keyHash = ApiKeyHasher.ComputeSha256Hash(rawKey);
+        var apiKey = repository.GetByKeyHash(keyHash);
+
+        if (apiKey == null)
+        {
+            return Task.FromResult(AuthenticateResult.Fail("Invalid API key."));
+        }
+
+        if (apiKey.IsRevoked)
+        {
+            return Task.FromResult(AuthenticateResult.Fail("API key has been revoked."));
+        }
+
+        if (apiKey.IsExpired())
+        {
+            return Task.FromResult(AuthenticateResult.Fail("API key has expired."));
+        }
+
+        // Record usage
+        apiKey.RecordUsage();
+        repository.Update(apiKey);
+        repository.SaveChanges();
+
+        // Build claims
+        var claims = new List<Claim>
+        {
+            new(RbacClaimTypes.ApiKeyId, apiKey.Id.Value.ToString()),
+            new(RbacClaimTypes.ApiKeyName, apiKey.Name),
+            new(RbacClaimTypes.UserId, $"apikey:{apiKey.Id.Value}")
+        };
+
+        // Add Operator-level role assignment at Organization scope
+        var roleAssignments = new List<RoleAssignmentClaim>
+        {
+            new()
+            {
+                Role = RoleId.Operator.Value,
+                Scope = ScopeType.Organization.ToString(),
+                ScopeId = apiKey.OrganizationId.Value.ToString()
+            }
+        };
+        claims.Add(new Claim(RbacClaimTypes.RoleAssignments, JsonSerializer.Serialize(roleAssignments)));
+
+        // Add direct API key permissions
+        foreach (var permission in apiKey.Permissions)
+        {
+            claims.Add(new Claim(RbacClaimTypes.ApiPermission, permission));
+        }
+
+        // Add environment scope if set
+        if (apiKey.EnvironmentId.HasValue)
+        {
+            claims.Add(new Claim(RbacClaimTypes.EnvironmentId, apiKey.EnvironmentId.Value.ToString()));
+        }
+
+        var identity = new ClaimsIdentity(claims, SchemeName);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, SchemeName);
+
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/src/ReadyStackGo.Infrastructure.Security/Authentication/ApiKeyHasher.cs
+++ b/src/ReadyStackGo.Infrastructure.Security/Authentication/ApiKeyHasher.cs
@@ -1,0 +1,19 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace ReadyStackGo.Infrastructure.Security.Authentication;
+
+/// <summary>
+/// Utility for computing SHA-256 hashes of API keys.
+/// </summary>
+public static class ApiKeyHasher
+{
+    /// <summary>
+    /// Computes a SHA-256 hash of the raw API key, returned as lowercase hex (64 chars).
+    /// </summary>
+    public static string ComputeSha256Hash(string rawKey)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(rawKey));
+        return Convert.ToHexStringLower(bytes);
+    }
+}

--- a/src/ReadyStackGo.Infrastructure.Security/Authentication/RbacService.cs
+++ b/src/ReadyStackGo.Infrastructure.Security/Authentication/RbacService.cs
@@ -65,6 +65,15 @@ public class RbacService : IRbacService
             }
         }
 
+        // Check direct API key permissions (fallback for API key authenticated requests)
+        var apiPermissions = user.FindAll(RbacClaimTypes.ApiPermission);
+        foreach (var claim in apiPermissions)
+        {
+            var parsed = Permission.Parse(claim.Value);
+            if (parsed.Includes(permission))
+                return true;
+        }
+
         return false;
     }
 

--- a/src/ReadyStackGo.Infrastructure.Security/Authentication/TokenService.cs
+++ b/src/ReadyStackGo.Infrastructure.Security/Authentication/TokenService.cs
@@ -26,6 +26,27 @@ public static class RbacClaimTypes
     /// Note: Program.cs sets MapInboundClaims=false to prevent ASP.NET Core from transforming this claim.
     /// </summary>
     public const string RoleAssignments = "roles";
+
+    /// <summary>
+    /// Claim type for API key ID.
+    /// </summary>
+    public const string ApiKeyId = "apikey_id";
+
+    /// <summary>
+    /// Claim type for API key name.
+    /// </summary>
+    public const string ApiKeyName = "apikey_name";
+
+    /// <summary>
+    /// Claim type for direct API key permissions.
+    /// Multiple claims with this type can exist (one per permission).
+    /// </summary>
+    public const string ApiPermission = "api_permission";
+
+    /// <summary>
+    /// Claim type for environment ID scope.
+    /// </summary>
+    public const string EnvironmentId = "env_id";
 }
 
 public class TokenService : ITokenService

--- a/src/ReadyStackGo.Infrastructure.Security/ReadyStackGo.Infrastructure.Security.csproj
+++ b/src/ReadyStackGo.Infrastructure.Security/ReadyStackGo.Infrastructure.Security.csproj
@@ -20,6 +20,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <InternalsVisibleTo Include="ReadyStackGo.UnitTests" />
   </ItemGroup>
 

--- a/tests/ReadyStackGo.UnitTests/Authentication/ApiKeyAuthenticationHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Authentication/ApiKeyAuthenticationHandlerTests.cs
@@ -1,0 +1,245 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using ReadyStackGo.Domain.IdentityAccess.ApiKeys;
+using ReadyStackGo.Domain.IdentityAccess.Organizations;
+using ReadyStackGo.Domain.IdentityAccess.Roles;
+using ReadyStackGo.Infrastructure.Security.Authentication;
+
+namespace ReadyStackGo.UnitTests.Authentication;
+
+public class ApiKeyAuthenticationHandlerTests
+{
+    private readonly Mock<IApiKeyRepository> _repositoryMock;
+    private readonly ApiKeyAuthenticationHandler _handler;
+    private readonly DefaultHttpContext _httpContext;
+
+    public ApiKeyAuthenticationHandlerTests()
+    {
+        _repositoryMock = new Mock<IApiKeyRepository>();
+
+        // Build a service provider that can resolve IApiKeyRepository via scope
+        var services = new ServiceCollection();
+        services.AddScoped(_ => _repositoryMock.Object);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var optionsMonitor = new Mock<IOptionsMonitor<AuthenticationSchemeOptions>>();
+        optionsMonitor.Setup(o => o.Get(It.IsAny<string>())).Returns(new AuthenticationSchemeOptions());
+
+        var loggerFactory = NullLoggerFactory.Instance;
+
+        _handler = new ApiKeyAuthenticationHandler(
+            optionsMonitor.Object,
+            loggerFactory,
+            UrlEncoder.Default,
+            serviceProvider);
+
+        _httpContext = new DefaultHttpContext();
+    }
+
+    private static ApiKey CreateTestApiKey(
+        string rawKey,
+        OrganizationId orgId,
+        List<string> permissions,
+        Guid? environmentId = null,
+        DateTime? expiresAt = null)
+    {
+        var keyHash = ApiKeyHasher.ComputeSha256Hash(rawKey);
+        return ApiKey.Create(
+            ApiKeyId.Create(),
+            orgId,
+            "Test Key",
+            keyHash,
+            rawKey[..12],
+            permissions,
+            environmentId,
+            expiresAt);
+    }
+
+    private async Task<AuthenticateResult> AuthenticateAsync()
+    {
+        var scheme = new AuthenticationScheme(
+            ApiKeyAuthenticationHandler.SchemeName,
+            null,
+            typeof(ApiKeyAuthenticationHandler));
+
+        await _handler.InitializeAsync(scheme, _httpContext);
+        return await _handler.AuthenticateAsync();
+    }
+
+    [Fact]
+    public async Task NoHeader_ReturnsNoResult()
+    {
+        var result = await AuthenticateAsync();
+
+        result.None.Should().BeTrue();
+        result.Succeeded.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task EmptyHeader_ReturnsNoResult()
+    {
+        _httpContext.Request.Headers[ApiKeyAuthenticationHandler.HeaderName] = "";
+
+        var result = await AuthenticateAsync();
+
+        result.None.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task InvalidPrefix_ReturnsFail()
+    {
+        _httpContext.Request.Headers[ApiKeyAuthenticationHandler.HeaderName] = "invalid_key_format";
+
+        var result = await AuthenticateAsync();
+
+        result.Succeeded.Should().BeFalse();
+        result.Failure!.Message.Should().Contain("Invalid API key format");
+    }
+
+    [Fact]
+    public async Task UnknownKey_ReturnsFail()
+    {
+        _httpContext.Request.Headers[ApiKeyAuthenticationHandler.HeaderName] = "rsgo_unknown_key_value";
+        _repositoryMock.Setup(r => r.GetByKeyHash(It.IsAny<string>())).Returns((ApiKey?)null);
+
+        var result = await AuthenticateAsync();
+
+        result.Succeeded.Should().BeFalse();
+        result.Failure!.Message.Should().Contain("Invalid API key");
+    }
+
+    [Fact]
+    public async Task RevokedKey_ReturnsFail()
+    {
+        var rawKey = "rsgo_testrevokedkey1234";
+        var orgId = OrganizationId.Create();
+        var apiKey = CreateTestApiKey(rawKey, orgId, new List<string> { "Hooks.Redeploy" });
+        apiKey.Revoke("Compromised");
+
+        var keyHash = ApiKeyHasher.ComputeSha256Hash(rawKey);
+        _httpContext.Request.Headers[ApiKeyAuthenticationHandler.HeaderName] = rawKey;
+        _repositoryMock.Setup(r => r.GetByKeyHash(keyHash)).Returns(apiKey);
+
+        var result = await AuthenticateAsync();
+
+        result.Succeeded.Should().BeFalse();
+        result.Failure!.Message.Should().Contain("revoked");
+    }
+
+    [Fact]
+    public async Task ExpiredKey_ReturnsFail()
+    {
+        var rawKey = "rsgo_testexpiredkey123";
+        var orgId = OrganizationId.Create();
+        var expiresAt = DateTime.UtcNow.AddDays(-1);
+        var apiKey = CreateTestApiKey(rawKey, orgId, new List<string> { "Hooks.Redeploy" }, expiresAt: expiresAt);
+
+        var keyHash = ApiKeyHasher.ComputeSha256Hash(rawKey);
+        _httpContext.Request.Headers[ApiKeyAuthenticationHandler.HeaderName] = rawKey;
+        _repositoryMock.Setup(r => r.GetByKeyHash(keyHash)).Returns(apiKey);
+
+        var result = await AuthenticateAsync();
+
+        result.Succeeded.Should().BeFalse();
+        result.Failure!.Message.Should().Contain("expired");
+    }
+
+    [Fact]
+    public async Task ValidKey_ReturnsSuccessWithCorrectClaims()
+    {
+        var rawKey = "rsgo_testvalidkey1234";
+        var orgId = OrganizationId.Create();
+        var permissions = new List<string> { "Hooks.Redeploy", "Hooks.Upgrade" };
+        var apiKey = CreateTestApiKey(rawKey, orgId, permissions);
+
+        var keyHash = ApiKeyHasher.ComputeSha256Hash(rawKey);
+        _httpContext.Request.Headers[ApiKeyAuthenticationHandler.HeaderName] = rawKey;
+        _repositoryMock.Setup(r => r.GetByKeyHash(keyHash)).Returns(apiKey);
+
+        var result = await AuthenticateAsync();
+
+        result.Succeeded.Should().BeTrue();
+
+        var principal = result.Principal!;
+        principal.FindFirst(RbacClaimTypes.ApiKeyId)!.Value.Should().Be(apiKey.Id.Value.ToString());
+        principal.FindFirst(RbacClaimTypes.ApiKeyName)!.Value.Should().Be("Test Key");
+        principal.FindFirst(RbacClaimTypes.UserId)!.Value.Should().Be($"apikey:{apiKey.Id.Value}");
+
+        // Check role assignments
+        var rolesClaim = principal.FindFirst(RbacClaimTypes.RoleAssignments)!.Value;
+        var roleAssignments = JsonSerializer.Deserialize<List<RoleAssignmentClaim>>(rolesClaim)!;
+        roleAssignments.Should().HaveCount(1);
+        roleAssignments[0].Role.Should().Be(RoleId.Operator.Value);
+        roleAssignments[0].Scope.Should().Be(ScopeType.Organization.ToString());
+        roleAssignments[0].ScopeId.Should().Be(orgId.Value.ToString());
+
+        // Check API permissions
+        var apiPermissionClaims = principal.FindAll(RbacClaimTypes.ApiPermission).Select(c => c.Value).ToList();
+        apiPermissionClaims.Should().Contain("Hooks.Redeploy");
+        apiPermissionClaims.Should().Contain("Hooks.Upgrade");
+    }
+
+    [Fact]
+    public async Task ValidKeyWithEnvironmentId_IncludesEnvIdClaim()
+    {
+        var rawKey = "rsgo_testenvkeyvalue1";
+        var orgId = OrganizationId.Create();
+        var envId = Guid.NewGuid();
+        var apiKey = CreateTestApiKey(rawKey, orgId, new List<string> { "Hooks.Redeploy" }, environmentId: envId);
+
+        var keyHash = ApiKeyHasher.ComputeSha256Hash(rawKey);
+        _httpContext.Request.Headers[ApiKeyAuthenticationHandler.HeaderName] = rawKey;
+        _repositoryMock.Setup(r => r.GetByKeyHash(keyHash)).Returns(apiKey);
+
+        var result = await AuthenticateAsync();
+
+        result.Succeeded.Should().BeTrue();
+        result.Principal!.FindFirst(RbacClaimTypes.EnvironmentId)!.Value.Should().Be(envId.ToString());
+    }
+
+    [Fact]
+    public async Task ValidKey_RecordsUsage()
+    {
+        var rawKey = "rsgo_testusagetrack12";
+        var orgId = OrganizationId.Create();
+        var apiKey = CreateTestApiKey(rawKey, orgId, new List<string> { "Hooks.Redeploy" });
+
+        apiKey.LastUsedAt.Should().BeNull();
+
+        var keyHash = ApiKeyHasher.ComputeSha256Hash(rawKey);
+        _httpContext.Request.Headers[ApiKeyAuthenticationHandler.HeaderName] = rawKey;
+        _repositoryMock.Setup(r => r.GetByKeyHash(keyHash)).Returns(apiKey);
+
+        await AuthenticateAsync();
+
+        apiKey.LastUsedAt.Should().NotBeNull();
+        _repositoryMock.Verify(r => r.Update(apiKey), Times.Once);
+        _repositoryMock.Verify(r => r.SaveChanges(), Times.Once);
+    }
+
+    [Fact]
+    public async Task ValidKeyWithNoEnvironmentId_DoesNotIncludeEnvIdClaim()
+    {
+        var rawKey = "rsgo_testnoenvkey123";
+        var orgId = OrganizationId.Create();
+        var apiKey = CreateTestApiKey(rawKey, orgId, new List<string> { "Hooks.Redeploy" });
+
+        var keyHash = ApiKeyHasher.ComputeSha256Hash(rawKey);
+        _httpContext.Request.Headers[ApiKeyAuthenticationHandler.HeaderName] = rawKey;
+        _repositoryMock.Setup(r => r.GetByKeyHash(keyHash)).Returns(apiKey);
+
+        var result = await AuthenticateAsync();
+
+        result.Succeeded.Should().BeTrue();
+        result.Principal!.FindFirst(RbacClaimTypes.EnvironmentId).Should().BeNull();
+    }
+}

--- a/tests/ReadyStackGo.UnitTests/Authentication/ApiKeyHasherTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Authentication/ApiKeyHasherTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using ReadyStackGo.Infrastructure.Security.Authentication;
+
+namespace ReadyStackGo.UnitTests.Authentication;
+
+public class ApiKeyHasherTests
+{
+    [Fact]
+    public void ComputeSha256Hash_SameInput_ReturnsSameHash()
+    {
+        var key = "rsgo_test1234567890";
+
+        var hash1 = ApiKeyHasher.ComputeSha256Hash(key);
+        var hash2 = ApiKeyHasher.ComputeSha256Hash(key);
+
+        hash1.Should().Be(hash2);
+    }
+
+    [Fact]
+    public void ComputeSha256Hash_Returns64CharLowercaseHex()
+    {
+        var key = "rsgo_someapikey";
+
+        var hash = ApiKeyHasher.ComputeSha256Hash(key);
+
+        hash.Should().HaveLength(64);
+        hash.Should().MatchRegex("^[0-9a-f]{64}$");
+    }
+
+    [Fact]
+    public void ComputeSha256Hash_DifferentInputs_ReturnDifferentHashes()
+    {
+        var hash1 = ApiKeyHasher.ComputeSha256Hash("rsgo_key_one");
+        var hash2 = ApiKeyHasher.ComputeSha256Hash("rsgo_key_two");
+
+        hash1.Should().NotBe(hash2);
+    }
+
+    [Fact]
+    public void ComputeSha256Hash_EmptyString_ReturnsValidHash()
+    {
+        var hash = ApiKeyHasher.ComputeSha256Hash("");
+
+        hash.Should().HaveLength(64);
+        hash.Should().MatchRegex("^[0-9a-f]{64}$");
+    }
+}

--- a/tests/ReadyStackGo.UnitTests/Authentication/RbacServiceApiKeyTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Authentication/RbacServiceApiKeyTests.cs
@@ -1,0 +1,177 @@
+using System.Security.Claims;
+using System.Text.Json;
+using FluentAssertions;
+using ReadyStackGo.Domain.IdentityAccess.Roles;
+using ReadyStackGo.Infrastructure.Security.Authentication;
+
+namespace ReadyStackGo.UnitTests.Authentication;
+
+public class RbacServiceApiKeyTests
+{
+    private readonly RbacService _rbacService;
+
+    public RbacServiceApiKeyTests()
+    {
+        _rbacService = new RbacService();
+    }
+
+    private ClaimsPrincipal CreateApiKeyUser(string orgId, params string[] permissions)
+    {
+        var claims = new List<Claim>
+        {
+            new(RbacClaimTypes.UserId, $"apikey:{Guid.NewGuid()}"),
+            new(RbacClaimTypes.ApiKeyId, Guid.NewGuid().ToString()),
+            new(RbacClaimTypes.ApiKeyName, "Test API Key")
+        };
+
+        // Add Operator role at org scope (like the auth handler does)
+        var roleAssignments = new List<RoleAssignmentClaim>
+        {
+            new()
+            {
+                Role = RoleId.Operator.Value,
+                Scope = ScopeType.Organization.ToString(),
+                ScopeId = orgId
+            }
+        };
+        claims.Add(new Claim(RbacClaimTypes.RoleAssignments, JsonSerializer.Serialize(roleAssignments)));
+
+        // Add API permissions
+        foreach (var permission in permissions)
+        {
+            claims.Add(new Claim(RbacClaimTypes.ApiPermission, permission));
+        }
+
+        var identity = new ClaimsIdentity(claims, "ApiKey");
+        return new ClaimsPrincipal(identity);
+    }
+
+    private ClaimsPrincipal CreateApiKeyUserWithoutRole(params string[] permissions)
+    {
+        var claims = new List<Claim>
+        {
+            new(RbacClaimTypes.UserId, $"apikey:{Guid.NewGuid()}"),
+            new(RbacClaimTypes.ApiKeyId, Guid.NewGuid().ToString()),
+            new(RbacClaimTypes.ApiKeyName, "Test API Key"),
+            new(RbacClaimTypes.RoleAssignments, "[]")
+        };
+
+        foreach (var permission in permissions)
+        {
+            claims.Add(new Claim(RbacClaimTypes.ApiPermission, permission));
+        }
+
+        var identity = new ClaimsIdentity(claims, "ApiKey");
+        return new ClaimsPrincipal(identity);
+    }
+
+    [Fact]
+    public void HasPermission_WithExactApiPermission_ReturnsTrue()
+    {
+        var user = CreateApiKeyUserWithoutRole("Hooks.Redeploy");
+
+        var result = _rbacService.HasPermission(user, Permission.Hooks.Redeploy);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasPermission_WithWildcardAll_ReturnsTrue()
+    {
+        var user = CreateApiKeyUserWithoutRole("*.*");
+
+        var result = _rbacService.HasPermission(user, Permission.Hooks.Redeploy);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasPermission_WithResourceWildcard_ReturnsTrue()
+    {
+        var user = CreateApiKeyUserWithoutRole("Hooks.*");
+
+        var result = _rbacService.HasPermission(user, Permission.Hooks.Redeploy);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasPermission_WithResourceWildcard_MatchesAllActionsInResource()
+    {
+        var user = CreateApiKeyUserWithoutRole("Hooks.*");
+
+        _rbacService.HasPermission(user, Permission.Hooks.Redeploy).Should().BeTrue();
+        _rbacService.HasPermission(user, Permission.Hooks.Upgrade).Should().BeTrue();
+        _rbacService.HasPermission(user, Permission.Hooks.SyncSources).Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasPermission_WithResourceWildcard_DoesNotMatchOtherResources()
+    {
+        var user = CreateApiKeyUserWithoutRole("Hooks.*");
+
+        _rbacService.HasPermission(user, Permission.Deployments.Create).Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasPermission_WithoutMatchingApiPermission_ReturnsFalse()
+    {
+        var user = CreateApiKeyUserWithoutRole("Hooks.Redeploy");
+
+        var result = _rbacService.HasPermission(user, Permission.Hooks.Upgrade);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasPermission_WithNoApiPermissions_ReturnsFalse()
+    {
+        var user = CreateApiKeyUserWithoutRole();
+
+        var result = _rbacService.HasPermission(user, Permission.Hooks.Redeploy);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasPermission_RoleBasedCheckTakesPrecedence()
+    {
+        // API key with Operator role at org scope + explicit Hooks.Redeploy permission
+        var orgId = Guid.NewGuid().ToString();
+        var user = CreateApiKeyUser(orgId, "Hooks.Redeploy");
+
+        // Operator role has Deployments.Create — check passes via role
+        _rbacService.HasPermission(user, Permission.Deployments.Create, orgId).Should().BeTrue();
+
+        // Hooks.Redeploy is NOT in Operator role but IS in api_permission — check passes via fallback
+        _rbacService.HasPermission(user, Permission.Hooks.Redeploy).Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasPermission_MultipleApiPermissions_AllWork()
+    {
+        var user = CreateApiKeyUserWithoutRole("Hooks.Redeploy", "Hooks.Upgrade", "Hooks.SyncSources");
+
+        _rbacService.HasPermission(user, Permission.Hooks.Redeploy).Should().BeTrue();
+        _rbacService.HasPermission(user, Permission.Hooks.Upgrade).Should().BeTrue();
+        _rbacService.HasPermission(user, Permission.Hooks.SyncSources).Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasPermission_ApiPermissionDoesNotBypassScopeForRoles()
+    {
+        // API key has Operator role at org1 scope
+        var orgId1 = Guid.NewGuid().ToString();
+        var orgId2 = Guid.NewGuid().ToString();
+        var user = CreateApiKeyUser(orgId1, "Hooks.Redeploy");
+
+        // Role-based check for org1 passes
+        _rbacService.HasPermission(user, Permission.Deployments.Create, orgId1).Should().BeTrue();
+
+        // Role-based check for org2 fails (scope mismatch)
+        _rbacService.HasPermission(user, Permission.Deployments.Create, orgId2).Should().BeFalse();
+
+        // API permission check is scope-independent (by design — webhook permissions don't need scope)
+        _rbacService.HasPermission(user, Permission.Hooks.Redeploy, orgId2).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ApiKeyAuthenticationHandler` that validates `X-Api-Key` headers via SHA-256 hash lookup, builds a ClaimsPrincipal with role assignments and direct `api_permission` claims, and records usage timestamps
- Configures ASP.NET Core multi-scheme authentication using a `PolicyScheme` that routes to API Key or JWT Bearer based on header presence
- Extends `RbacService.HasPermission` with a fallback that checks direct `api_permission` claims, enabling API keys to authorize hook endpoints without role-based wildcard grants

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] Unit tests: 1449 passing (24 new: 4 hasher, 9 handler, 11 RBAC API key)
- [x] Integration tests: 316/317 passing (1 pre-existing failure in StackSourceEndpoints, unrelated)
- [x] Existing JWT authentication tests all pass (multi-scheme is backwards-compatible)