### PR TITLE
Add API Key management CRUD endpoints and Settings UI

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/ApiKeys/CreateApiKeyEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/ApiKeys/CreateApiKeyEndpoint.cs
@@ -1,0 +1,37 @@
+using FastEndpoints;
+using MediatR;
+using ReadyStackGo.Api.Authorization;
+using ReadyStackGo.Application.UseCases.ApiKeys;
+using ReadyStackGo.Application.UseCases.ApiKeys.CreateApiKey;
+
+namespace ReadyStackGo.Api.Endpoints.ApiKeys;
+
+[RequirePermission("ApiKeys", "Create")]
+public class CreateApiKeyEndpoint : Endpoint<CreateApiKeyRequest, CreateApiKeyResponse>
+{
+    private readonly IMediator _mediator;
+
+    public CreateApiKeyEndpoint(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Post("/api/api-keys");
+        PreProcessor<RbacPreProcessor<CreateApiKeyRequest>>();
+    }
+
+    public override async Task HandleAsync(CreateApiKeyRequest req, CancellationToken ct)
+    {
+        var response = await _mediator.Send(new CreateApiKeyCommand(req), ct);
+
+        if (!response.Success)
+        {
+            ThrowError(response.Message ?? "Failed to create API key");
+        }
+
+        HttpContext.Response.StatusCode = StatusCodes.Status201Created;
+        Response = response;
+    }
+}

--- a/src/ReadyStackGo.Api/Endpoints/ApiKeys/ListApiKeysEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/ApiKeys/ListApiKeysEndpoint.cs
@@ -1,0 +1,29 @@
+using FastEndpoints;
+using MediatR;
+using ReadyStackGo.Api.Authorization;
+using ReadyStackGo.Application.UseCases.ApiKeys;
+using ReadyStackGo.Application.UseCases.ApiKeys.ListApiKeys;
+
+namespace ReadyStackGo.Api.Endpoints.ApiKeys;
+
+[RequirePermission("ApiKeys", "Read")]
+public class ListApiKeysEndpoint : Endpoint<EmptyRequest, ListApiKeysResponse>
+{
+    private readonly IMediator _mediator;
+
+    public ListApiKeysEndpoint(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Get("/api/api-keys");
+        PreProcessor<RbacPreProcessor<EmptyRequest>>();
+    }
+
+    public override async Task HandleAsync(EmptyRequest req, CancellationToken ct)
+    {
+        Response = await _mediator.Send(new ListApiKeysQuery(), ct);
+    }
+}

--- a/src/ReadyStackGo.Api/Endpoints/ApiKeys/RevokeApiKeyEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/ApiKeys/RevokeApiKeyEndpoint.cs
@@ -1,0 +1,45 @@
+using FastEndpoints;
+using MediatR;
+using ReadyStackGo.Api.Authorization;
+using ReadyStackGo.Application.UseCases.ApiKeys;
+using ReadyStackGo.Application.UseCases.ApiKeys.RevokeApiKey;
+
+namespace ReadyStackGo.Api.Endpoints.ApiKeys;
+
+public class RevokeApiKeyEndpointRequest
+{
+    public string ApiKeyId { get; set; } = string.Empty;
+    public string? Reason { get; set; }
+}
+
+[RequirePermission("ApiKeys", "Delete")]
+public class RevokeApiKeyEndpoint : Endpoint<RevokeApiKeyEndpointRequest, RevokeApiKeyResponse>
+{
+    private readonly IMediator _mediator;
+
+    public RevokeApiKeyEndpoint(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Delete("/api/api-keys/{apiKeyId}");
+        PreProcessor<RbacPreProcessor<RevokeApiKeyEndpointRequest>>();
+    }
+
+    public override async Task HandleAsync(RevokeApiKeyEndpointRequest req, CancellationToken ct)
+    {
+        var response = await _mediator.Send(new RevokeApiKeyCommand(req.ApiKeyId, req.Reason), ct);
+
+        if (!response.Success)
+        {
+            var statusCode = response.Message?.Contains("not found") == true
+                ? StatusCodes.Status404NotFound
+                : StatusCodes.Status400BadRequest;
+            ThrowError(response.Message ?? "Failed to revoke API key", statusCode);
+        }
+
+        Response = response;
+    }
+}

--- a/src/ReadyStackGo.Application/UseCases/ApiKeys/ApiKeyDtos.cs
+++ b/src/ReadyStackGo.Application/UseCases/ApiKeys/ApiKeyDtos.cs
@@ -1,0 +1,66 @@
+namespace ReadyStackGo.Application.UseCases.ApiKeys;
+
+/// <summary>
+/// DTO for returning API key data (without the full key).
+/// </summary>
+public record ApiKeyDto(
+    string Id,
+    string Name,
+    string KeyPrefix,
+    string OrganizationId,
+    string? EnvironmentId,
+    IReadOnlyList<string> Permissions,
+    DateTime CreatedAt,
+    DateTime? LastUsedAt,
+    DateTime? ExpiresAt,
+    bool IsRevoked);
+
+/// <summary>
+/// DTO returned only once after API key creation (includes the full key).
+/// </summary>
+public record ApiKeyCreatedDto(
+    string Id,
+    string Name,
+    string KeyPrefix,
+    string FullKey);
+
+/// <summary>
+/// Request to create a new API key.
+/// </summary>
+public record CreateApiKeyRequest
+{
+    public string Name { get; init; } = null!;
+    public string? EnvironmentId { get; init; }
+    public List<string> Permissions { get; init; } = new();
+    public DateTime? ExpiresAt { get; init; }
+}
+
+/// <summary>
+/// Response for API key creation.
+/// </summary>
+public record CreateApiKeyResponse(
+    bool Success,
+    string? Message = null,
+    ApiKeyCreatedDto? ApiKey = null);
+
+/// <summary>
+/// Response for listing API keys.
+/// </summary>
+public record ListApiKeysResponse(
+    IReadOnlyList<ApiKeyDto> ApiKeys);
+
+/// <summary>
+/// Request to revoke an API key.
+/// </summary>
+public record RevokeApiKeyRequest
+{
+    public string ApiKeyId { get; init; } = string.Empty;
+    public string? Reason { get; init; }
+}
+
+/// <summary>
+/// Response for revoking an API key.
+/// </summary>
+public record RevokeApiKeyResponse(
+    bool Success,
+    string? Message = null);

--- a/src/ReadyStackGo.Application/UseCases/ApiKeys/CreateApiKey/CreateApiKeyCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/ApiKeys/CreateApiKey/CreateApiKeyCommand.cs
@@ -1,0 +1,123 @@
+using System.Security.Cryptography;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using ReadyStackGo.Domain.IdentityAccess.ApiKeys;
+using ReadyStackGo.Domain.IdentityAccess.Organizations;
+
+namespace ReadyStackGo.Application.UseCases.ApiKeys.CreateApiKey;
+
+public record CreateApiKeyCommand(CreateApiKeyRequest Request) : IRequest<CreateApiKeyResponse>;
+
+public class CreateApiKeyHandler : IRequestHandler<CreateApiKeyCommand, CreateApiKeyResponse>
+{
+    private readonly IApiKeyRepository _apiKeyRepository;
+    private readonly IOrganizationRepository _organizationRepository;
+    private readonly ILogger<CreateApiKeyHandler> _logger;
+
+    private const string KeyPrefix = "rsgo_";
+    private const int RandomPartLength = 32;
+    private const string AlphanumericChars = "abcdefghijklmnopqrstuvwxyz0123456789";
+
+    public CreateApiKeyHandler(
+        IApiKeyRepository apiKeyRepository,
+        IOrganizationRepository organizationRepository,
+        ILogger<CreateApiKeyHandler> logger)
+    {
+        _apiKeyRepository = apiKeyRepository;
+        _organizationRepository = organizationRepository;
+        _logger = logger;
+    }
+
+    public Task<CreateApiKeyResponse> Handle(CreateApiKeyCommand command, CancellationToken cancellationToken)
+    {
+        var organization = _organizationRepository.GetAll().FirstOrDefault();
+        if (organization == null)
+        {
+            return Task.FromResult(new CreateApiKeyResponse(false, "Organization not set."));
+        }
+
+        var request = command.Request;
+
+        if (string.IsNullOrWhiteSpace(request.Name))
+        {
+            return Task.FromResult(new CreateApiKeyResponse(false, "API key name is required."));
+        }
+
+        if (request.Permissions.Count == 0)
+        {
+            return Task.FromResult(new CreateApiKeyResponse(false, "At least one permission is required."));
+        }
+
+        // Check for duplicate name within organization
+        var existingKeys = _apiKeyRepository.GetByOrganization(organization.Id);
+        if (existingKeys.Any(k => k.Name == request.Name && !k.IsRevoked))
+        {
+            return Task.FromResult(new CreateApiKeyResponse(false, $"An active API key with name '{request.Name}' already exists."));
+        }
+
+        Guid? environmentId = null;
+        if (!string.IsNullOrEmpty(request.EnvironmentId))
+        {
+            if (!Guid.TryParse(request.EnvironmentId, out var envGuid))
+            {
+                return Task.FromResult(new CreateApiKeyResponse(false, "Invalid environment ID format."));
+            }
+            environmentId = envGuid;
+        }
+
+        try
+        {
+            // Generate the raw key: rsgo_ + 32 random alphanumeric characters
+            var rawKey = GenerateRawKey();
+            var keyHash = ComputeSha256Hash(rawKey);
+            var displayPrefix = rawKey[..12];
+
+            var apiKeyId = ApiKeyId.Create();
+            var apiKey = ApiKey.Create(
+                apiKeyId,
+                organization.Id,
+                request.Name,
+                keyHash,
+                displayPrefix,
+                request.Permissions,
+                environmentId,
+                request.ExpiresAt);
+
+            _apiKeyRepository.Add(apiKey);
+            _apiKeyRepository.SaveChanges();
+
+            _logger.LogInformation("Created API key '{Name}' (prefix: {Prefix}) for organization {OrgId}",
+                request.Name, displayPrefix, organization.Id.Value);
+
+            var dto = new ApiKeyCreatedDto(
+                Id: apiKey.Id.Value.ToString(),
+                Name: apiKey.Name,
+                KeyPrefix: apiKey.KeyPrefix,
+                FullKey: rawKey);
+
+            return Task.FromResult(new CreateApiKeyResponse(true, "API key created successfully.", dto));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to create API key '{Name}'", request.Name);
+            return Task.FromResult(new CreateApiKeyResponse(false, $"Failed to create API key: {ex.Message}"));
+        }
+    }
+
+    internal static string GenerateRawKey()
+    {
+        var randomPart = new char[RandomPartLength];
+        for (var i = 0; i < RandomPartLength; i++)
+        {
+            randomPart[i] = AlphanumericChars[RandomNumberGenerator.GetInt32(AlphanumericChars.Length)];
+        }
+        return KeyPrefix + new string(randomPart);
+    }
+
+    internal static string ComputeSha256Hash(string rawKey)
+    {
+        var bytes = global::System.Security.Cryptography.SHA256.HashData(
+            global::System.Text.Encoding.UTF8.GetBytes(rawKey));
+        return Convert.ToHexStringLower(bytes);
+    }
+}

--- a/src/ReadyStackGo.Application/UseCases/ApiKeys/ListApiKeys/ListApiKeysQuery.cs
+++ b/src/ReadyStackGo.Application/UseCases/ApiKeys/ListApiKeys/ListApiKeysQuery.cs
@@ -1,0 +1,47 @@
+using MediatR;
+using ReadyStackGo.Domain.IdentityAccess.ApiKeys;
+using ReadyStackGo.Domain.IdentityAccess.Organizations;
+
+namespace ReadyStackGo.Application.UseCases.ApiKeys.ListApiKeys;
+
+public record ListApiKeysQuery() : IRequest<ListApiKeysResponse>;
+
+public class ListApiKeysHandler : IRequestHandler<ListApiKeysQuery, ListApiKeysResponse>
+{
+    private readonly IApiKeyRepository _apiKeyRepository;
+    private readonly IOrganizationRepository _organizationRepository;
+
+    public ListApiKeysHandler(
+        IApiKeyRepository apiKeyRepository,
+        IOrganizationRepository organizationRepository)
+    {
+        _apiKeyRepository = apiKeyRepository;
+        _organizationRepository = organizationRepository;
+    }
+
+    public Task<ListApiKeysResponse> Handle(ListApiKeysQuery request, CancellationToken cancellationToken)
+    {
+        var organization = _organizationRepository.GetAll().FirstOrDefault();
+        if (organization == null)
+        {
+            return Task.FromResult(new ListApiKeysResponse(Array.Empty<ApiKeyDto>()));
+        }
+
+        var apiKeys = _apiKeyRepository.GetByOrganization(organization.Id);
+
+        var dtos = apiKeys.Select(k => new ApiKeyDto(
+            Id: k.Id.Value.ToString(),
+            Name: k.Name,
+            KeyPrefix: k.KeyPrefix,
+            OrganizationId: k.OrganizationId.Value.ToString(),
+            EnvironmentId: k.EnvironmentId?.ToString(),
+            Permissions: k.Permissions,
+            CreatedAt: k.CreatedAt,
+            LastUsedAt: k.LastUsedAt,
+            ExpiresAt: k.ExpiresAt,
+            IsRevoked: k.IsRevoked
+        )).ToList();
+
+        return Task.FromResult(new ListApiKeysResponse(dtos));
+    }
+}

--- a/src/ReadyStackGo.Application/UseCases/ApiKeys/RevokeApiKey/RevokeApiKeyCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/ApiKeys/RevokeApiKey/RevokeApiKeyCommand.cs
@@ -1,0 +1,56 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using ReadyStackGo.Domain.IdentityAccess.ApiKeys;
+
+namespace ReadyStackGo.Application.UseCases.ApiKeys.RevokeApiKey;
+
+public record RevokeApiKeyCommand(string ApiKeyId, string? Reason) : IRequest<RevokeApiKeyResponse>;
+
+public class RevokeApiKeyHandler : IRequestHandler<RevokeApiKeyCommand, RevokeApiKeyResponse>
+{
+    private readonly IApiKeyRepository _apiKeyRepository;
+    private readonly ILogger<RevokeApiKeyHandler> _logger;
+
+    public RevokeApiKeyHandler(
+        IApiKeyRepository apiKeyRepository,
+        ILogger<RevokeApiKeyHandler> logger)
+    {
+        _apiKeyRepository = apiKeyRepository;
+        _logger = logger;
+    }
+
+    public Task<RevokeApiKeyResponse> Handle(RevokeApiKeyCommand command, CancellationToken cancellationToken)
+    {
+        if (!Guid.TryParse(command.ApiKeyId, out var apiKeyGuid))
+        {
+            return Task.FromResult(new RevokeApiKeyResponse(false, "Invalid API key ID format."));
+        }
+
+        var apiKey = _apiKeyRepository.GetById(new ApiKeyId(apiKeyGuid));
+        if (apiKey == null)
+        {
+            return Task.FromResult(new RevokeApiKeyResponse(false, "API key not found."));
+        }
+
+        if (apiKey.IsRevoked)
+        {
+            return Task.FromResult(new RevokeApiKeyResponse(false, "API key is already revoked."));
+        }
+
+        try
+        {
+            apiKey.Revoke(command.Reason);
+            _apiKeyRepository.Update(apiKey);
+            _apiKeyRepository.SaveChanges();
+
+            _logger.LogInformation("Revoked API key '{Name}' ({Id})", apiKey.Name, command.ApiKeyId);
+
+            return Task.FromResult(new RevokeApiKeyResponse(true, $"API key '{apiKey.Name}' revoked successfully."));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to revoke API key {Id}", command.ApiKeyId);
+            return Task.FromResult(new RevokeApiKeyResponse(false, $"Failed to revoke API key: {ex.Message}"));
+        }
+    }
+}

--- a/src/ReadyStackGo.WebUi/src/App.tsx
+++ b/src/ReadyStackGo.WebUi/src/App.tsx
@@ -28,6 +28,7 @@ import {
   ConfigureLetsEncrypt,
   UploadCertificate,
   ResetToSelfSigned,
+  CiCdList,
 } from "./pages/Settings";
 import SetupEnvironment from "./pages/Environments/SetupEnvironment";
 import Login from "./pages/Auth/Login";
@@ -177,6 +178,7 @@ export default function App() {
                 <Route path="/settings/tls/letsencrypt" element={<ConfigureLetsEncrypt />} />
                 <Route path="/settings/tls/upload" element={<UploadCertificate />} />
                 <Route path="/settings/tls/selfsigned" element={<ResetToSelfSigned />} />
+                <Route path="/settings/cicd" element={<CiCdList />} />
               </Route>
               {/* 404 catch-all route */}
               <Route path="*" element={<NotFound />} />

--- a/src/ReadyStackGo.WebUi/src/api/apiKeys.ts
+++ b/src/ReadyStackGo.WebUi/src/api/apiKeys.ts
@@ -1,0 +1,55 @@
+import { apiGet, apiPost, apiDelete } from './client';
+
+export interface ApiKeyDto {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  organizationId: string;
+  environmentId: string | null;
+  permissions: string[];
+  createdAt: string;
+  lastUsedAt: string | null;
+  expiresAt: string | null;
+  isRevoked: boolean;
+}
+
+export interface ApiKeyCreatedDto {
+  id: string;
+  name: string;
+  keyPrefix: string;
+  fullKey: string;
+}
+
+export interface CreateApiKeyRequest {
+  name: string;
+  environmentId?: string;
+  permissions: string[];
+  expiresAt?: string;
+}
+
+export interface CreateApiKeyResponse {
+  success: boolean;
+  message?: string;
+  apiKey?: ApiKeyCreatedDto;
+}
+
+export interface ListApiKeysResponse {
+  apiKeys: ApiKeyDto[];
+}
+
+export interface RevokeApiKeyResponse {
+  success: boolean;
+  message?: string;
+}
+
+export async function getApiKeys(): Promise<ListApiKeysResponse> {
+  return apiGet<ListApiKeysResponse>('/api/api-keys');
+}
+
+export async function createApiKey(request: CreateApiKeyRequest): Promise<CreateApiKeyResponse> {
+  return apiPost<CreateApiKeyResponse>('/api/api-keys', request);
+}
+
+export async function revokeApiKey(id: string, reason?: string): Promise<RevokeApiKeyResponse> {
+  return apiDelete<RevokeApiKeyResponse>(`/api/api-keys/${id}`, reason ? { reason } : undefined);
+}

--- a/src/ReadyStackGo.WebUi/src/pages/Settings/CiCd/CiCdList.tsx
+++ b/src/ReadyStackGo.WebUi/src/pages/Settings/CiCd/CiCdList.tsx
@@ -1,0 +1,448 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  getApiKeys,
+  createApiKey,
+  revokeApiKey,
+  type ApiKeyDto,
+  type CreateApiKeyRequest,
+} from "../../../api/apiKeys";
+
+const AVAILABLE_PERMISSIONS = [
+  { value: "Hooks.Redeploy", label: "Redeploy", description: "Trigger redeployment of running stacks" },
+  { value: "Hooks.Upgrade", label: "Upgrade", description: "Upgrade stacks to a new version" },
+  { value: "Hooks.SyncSources", label: "Sync Sources", description: "Synchronize stack catalog sources" },
+];
+
+export default function CiCdList() {
+  const [apiKeys, setApiKeys] = useState<ApiKeyDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [showCreateModal, setShowCreateModal] = useState(false);
+  const [showRevokeModal, setShowRevokeModal] = useState<string | null>(null);
+  const [revokeReason, setRevokeReason] = useState("");
+  const [createdKey, setCreatedKey] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [actionLoading, setActionLoading] = useState(false);
+
+  // Create form state
+  const [newKeyName, setNewKeyName] = useState("");
+  const [newKeyPermissions, setNewKeyPermissions] = useState<string[]>(["Hooks.Redeploy"]);
+  const [newKeyExpiry, setNewKeyExpiry] = useState("");
+
+  const loadApiKeys = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await getApiKeys();
+      setApiKeys(response.apiKeys);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load API keys");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadApiKeys();
+  }, []);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newKeyName.trim()) return;
+
+    try {
+      setActionLoading(true);
+      setError(null);
+      const request: CreateApiKeyRequest = {
+        name: newKeyName.trim(),
+        permissions: newKeyPermissions,
+      };
+      if (newKeyExpiry) {
+        request.expiresAt = new Date(newKeyExpiry).toISOString();
+      }
+
+      const response = await createApiKey(request);
+      if (response.success && response.apiKey) {
+        setCreatedKey(response.apiKey.fullKey);
+        setShowCreateModal(false);
+        setNewKeyName("");
+        setNewKeyPermissions(["Hooks.Redeploy"]);
+        setNewKeyExpiry("");
+        await loadApiKeys();
+      } else {
+        setError(response.message || "Failed to create API key");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create API key");
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleRevoke = async () => {
+    if (!showRevokeModal) return;
+
+    try {
+      setActionLoading(true);
+      setError(null);
+      const response = await revokeApiKey(showRevokeModal, revokeReason || undefined);
+      if (response.success) {
+        setShowRevokeModal(null);
+        setRevokeReason("");
+        await loadApiKeys();
+      } else {
+        setError(response.message || "Failed to revoke API key");
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to revoke API key");
+    } finally {
+      setActionLoading(false);
+    }
+  };
+
+  const handleCopyKey = async () => {
+    if (!createdKey) return;
+    try {
+      await navigator.clipboard.writeText(createdKey);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback for non-secure contexts
+      const textArea = document.createElement("textarea");
+      textArea.value = createdKey;
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textArea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
+
+  const togglePermission = (perm: string) => {
+    setNewKeyPermissions((prev) =>
+      prev.includes(perm) ? prev.filter((p) => p !== perm) : [...prev, perm]
+    );
+  };
+
+  const formatDate = (dateStr: string | null) => {
+    if (!dateStr) return "-";
+    return new Date(dateStr).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  };
+
+  const getStatusBadge = (key: ApiKeyDto) => {
+    if (key.isRevoked) {
+      return (
+        <span className="inline-flex items-center rounded-full bg-red-100 px-2.5 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900/30 dark:text-red-400">
+          Revoked
+        </span>
+      );
+    }
+    if (key.expiresAt && new Date(key.expiresAt) < new Date()) {
+      return (
+        <span className="inline-flex items-center rounded-full bg-yellow-100 px-2.5 py-0.5 text-xs font-medium text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400">
+          Expired
+        </span>
+      );
+    }
+    return (
+      <span className="inline-flex items-center rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900/30 dark:text-green-400">
+        Active
+      </span>
+    );
+  };
+
+  const revokeTarget = apiKeys.find((k) => k.id === showRevokeModal);
+
+  return (
+    <div className="mx-auto max-w-screen-2xl p-4 md:p-6 2xl:p-10">
+      {/* Breadcrumb */}
+      <nav className="mb-6 flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+        <Link to="/settings" className="hover:text-brand-600 dark:hover:text-brand-400">
+          Settings
+        </Link>
+        <span>/</span>
+        <span className="text-gray-900 dark:text-white">CI/CD Integration</span>
+      </nav>
+
+      {/* Header */}
+      <div className="mb-8 flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-bold text-black dark:text-white">CI/CD Integration</h2>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Manage API keys for CI/CD pipeline integration
+          </p>
+        </div>
+        <button
+          onClick={() => setShowCreateModal(true)}
+          className="inline-flex items-center gap-2 rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-medium text-white shadow-sm hover:bg-brand-600 transition-colors"
+        >
+          <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+          </svg>
+          Create API Key
+        </button>
+      </div>
+
+      {/* Error alert */}
+      {error && (
+        <div className="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-800 dark:bg-red-900/20 dark:text-red-400">
+          {error}
+          <button onClick={() => setError(null)} className="ml-2 font-medium underline">
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {/* Created key banner */}
+      {createdKey && (
+        <div className="mb-6 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-900/20">
+          <div className="flex items-start gap-3">
+            <svg className="mt-0.5 h-5 w-5 text-green-600 dark:text-green-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+            </svg>
+            <div className="flex-1">
+              <p className="font-semibold text-green-800 dark:text-green-300">
+                API key created! Copy it now — it won't be shown again.
+              </p>
+              <div className="mt-2 flex items-center gap-2">
+                <code className="rounded bg-green-100 px-3 py-1.5 font-mono text-sm text-green-900 dark:bg-green-900/40 dark:text-green-200 select-all">
+                  {createdKey}
+                </code>
+                <button
+                  onClick={handleCopyKey}
+                  className="inline-flex items-center gap-1.5 rounded-md bg-green-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-green-700 transition-colors"
+                >
+                  {copied ? (
+                    <>
+                      <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+                      </svg>
+                      Copied!
+                    </>
+                  ) : (
+                    <>
+                      <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                      </svg>
+                      Copy
+                    </>
+                  )}
+                </button>
+              </div>
+            </div>
+            <button
+              onClick={() => setCreatedKey(null)}
+              className="text-green-600 hover:text-green-800 dark:text-green-400 dark:hover:text-green-200"
+            >
+              <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Loading state */}
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-brand-500 border-t-transparent" />
+        </div>
+      ) : apiKeys.length === 0 ? (
+        /* Empty state */
+        <div className="rounded-2xl border border-gray-200 bg-white p-12 text-center dark:border-gray-800 dark:bg-white/[0.03]">
+          <svg className="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
+          </svg>
+          <h3 className="mt-4 text-lg font-semibold text-gray-900 dark:text-white">No API keys yet</h3>
+          <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+            Create an API key to enable CI/CD pipeline integration with webhooks.
+          </p>
+          <button
+            onClick={() => setShowCreateModal(true)}
+            className="mt-6 inline-flex items-center gap-2 rounded-lg bg-brand-500 px-4 py-2.5 text-sm font-medium text-white hover:bg-brand-600 transition-colors"
+          >
+            Create your first API key
+          </button>
+        </div>
+      ) : (
+        /* API Keys table */
+        <div className="overflow-hidden rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03]">
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-800">
+            <thead className="bg-gray-50 dark:bg-gray-800/50">
+              <tr>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Name</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Key Prefix</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Permissions</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Created</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Last Used</th>
+                <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Status</th>
+                <th className="px-6 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 dark:divide-gray-800">
+              {apiKeys.map((key) => (
+                <tr key={key.id} className={key.isRevoked ? "opacity-60" : ""}>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900 dark:text-white">
+                    {key.name}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4">
+                    <code className="rounded bg-gray-100 px-2 py-1 font-mono text-xs text-gray-700 dark:bg-gray-800 dark:text-gray-300">
+                      {key.keyPrefix}...
+                    </code>
+                  </td>
+                  <td className="px-6 py-4">
+                    <div className="flex flex-wrap gap-1">
+                      {key.permissions.map((perm) => (
+                        <span
+                          key={perm}
+                          className="inline-flex items-center rounded-md bg-blue-50 px-2 py-0.5 text-xs font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-300"
+                        >
+                          {perm.split(".")[1]}
+                        </span>
+                      ))}
+                    </div>
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
+                    {formatDate(key.createdAt)}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500 dark:text-gray-400">
+                    {formatDate(key.lastUsedAt)}
+                  </td>
+                  <td className="whitespace-nowrap px-6 py-4">{getStatusBadge(key)}</td>
+                  <td className="whitespace-nowrap px-6 py-4 text-right">
+                    {!key.isRevoked && (
+                      <button
+                        onClick={() => setShowRevokeModal(key.id)}
+                        className="text-sm font-medium text-red-600 hover:text-red-800 dark:text-red-400 dark:hover:text-red-300"
+                      >
+                        Revoke
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Create Modal */}
+      {showCreateModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl dark:bg-gray-900">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Create API Key</h3>
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              The API key will be shown only once after creation.
+            </p>
+            <form onSubmit={handleCreate} className="mt-4 space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">Name</label>
+                <input
+                  type="text"
+                  value={newKeyName}
+                  onChange={(e) => setNewKeyName(e.target.value)}
+                  placeholder="e.g., GitHub Actions Deploy"
+                  className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+                  required
+                  autoFocus
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">Permissions</label>
+                <div className="mt-2 space-y-2">
+                  {AVAILABLE_PERMISSIONS.map((perm) => (
+                    <label key={perm.value} className="flex items-start gap-3 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={newKeyPermissions.includes(perm.value)}
+                        onChange={() => togglePermission(perm.value)}
+                        className="mt-0.5 h-4 w-4 rounded border-gray-300 text-brand-600 focus:ring-brand-500"
+                      />
+                      <div>
+                        <span className="text-sm font-medium text-gray-900 dark:text-white">{perm.label}</span>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">{perm.description}</p>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Expiry (optional)
+                </label>
+                <input
+                  type="datetime-local"
+                  value={newKeyExpiry}
+                  onChange={(e) => setNewKeyExpiry(e.target.value)}
+                  className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+                />
+              </div>
+              <div className="flex justify-end gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={() => setShowCreateModal(false)}
+                  className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={actionLoading || newKeyPermissions.length === 0}
+                  className="rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white hover:bg-brand-600 disabled:opacity-50 transition-colors"
+                >
+                  {actionLoading ? "Creating..." : "Create"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {/* Revoke confirmation modal */}
+      {showRevokeModal && revokeTarget && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl dark:bg-gray-900">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">Revoke API Key</h3>
+            <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+              Are you sure you want to revoke <strong className="text-gray-900 dark:text-white">{revokeTarget.name}</strong>?
+              This action cannot be undone. Any pipelines using this key will stop working.
+            </p>
+            <div className="mt-4">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">Reason (optional)</label>
+              <input
+                type="text"
+                value={revokeReason}
+                onChange={(e) => setRevokeReason(e.target.value)}
+                placeholder="e.g., Key compromised"
+                className="mt-1 block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
+              />
+            </div>
+            <div className="mt-6 flex justify-end gap-3">
+              <button
+                onClick={() => { setShowRevokeModal(null); setRevokeReason(""); }}
+                className="rounded-lg border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleRevoke}
+                disabled={actionLoading}
+                className="rounded-lg bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 disabled:opacity-50 transition-colors"
+              >
+                {actionLoading ? "Revoking..." : "Revoke Key"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ReadyStackGo.WebUi/src/pages/Settings/CiCd/index.ts
+++ b/src/ReadyStackGo.WebUi/src/pages/Settings/CiCd/index.ts
@@ -1,0 +1,1 @@
+export { default as CiCdList } from "./CiCdList";

--- a/src/ReadyStackGo.WebUi/src/pages/Settings/SettingsIndex.tsx
+++ b/src/ReadyStackGo.WebUi/src/pages/Settings/SettingsIndex.tsx
@@ -46,6 +46,18 @@ const settingsSections: SettingsSection[] = [
       </svg>
     ),
   },
+  {
+    id: "cicd",
+    title: "CI/CD Integration",
+    description: "Manage API keys for automated deployments from CI/CD pipelines",
+    href: "/settings/cicd",
+    color: "bg-orange-100 text-orange-600 dark:bg-orange-900/30 dark:text-orange-400",
+    icon: (
+      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z" />
+      </svg>
+    ),
+  },
 ];
 
 export default function SettingsIndex() {

--- a/src/ReadyStackGo.WebUi/src/pages/Settings/index.ts
+++ b/src/ReadyStackGo.WebUi/src/pages/Settings/index.ts
@@ -2,3 +2,4 @@ export { default as SettingsIndex } from "./SettingsIndex";
 export * from "./StackSources";
 export * from "./Registries";
 export * from "./Tls";
+export * from "./CiCd";

--- a/tests/ReadyStackGo.IntegrationTests/ApiKeyEndpointsIntegrationTests.cs
+++ b/tests/ReadyStackGo.IntegrationTests/ApiKeyEndpointsIntegrationTests.cs
@@ -1,0 +1,243 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using ReadyStackGo.IntegrationTests.Infrastructure;
+using Xunit;
+
+namespace ReadyStackGo.IntegrationTests;
+
+/// <summary>
+/// Integration tests for API Key Management Endpoints.
+/// Tests CRUD operations for CI/CD API key management (v0.19 feature).
+/// </summary>
+public class ApiKeyEndpointsIntegrationTests : AuthenticatedTestBase
+{
+    #region List API Keys
+
+    [Fact]
+    public async Task GET_ListApiKeys_ReturnsSuccess()
+    {
+        var response = await Client.GetAsync("/api/api-keys");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<ListApiKeysResponse>();
+        result.Should().NotBeNull();
+        result!.ApiKeys.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GET_ListApiKeys_WithoutAuth_ReturnsUnauthorized()
+    {
+        using var unauthenticatedClient = CreateUnauthenticatedClient();
+
+        var response = await unauthenticatedClient.GetAsync("/api/api-keys");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task GET_ListApiKeys_ReturnsEmptyList_WhenNoKeysExist()
+    {
+        var response = await Client.GetAsync("/api/api-keys");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<ListApiKeysResponse>();
+        result!.ApiKeys.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region Create API Key
+
+    [Fact]
+    public async Task POST_CreateApiKey_WithValidData_ReturnsCreated()
+    {
+        var request = new
+        {
+            name = "Test CI/CD Key",
+            permissions = new[] { "Hooks.Redeploy", "Hooks.Upgrade" }
+        };
+
+        var response = await Client.PostAsJsonAsync("/api/api-keys", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var result = await response.Content.ReadFromJsonAsync<CreateApiKeyResponse>();
+        result.Should().NotBeNull();
+        result!.Success.Should().BeTrue();
+        result.ApiKey.Should().NotBeNull();
+        result.ApiKey!.Name.Should().Be("Test CI/CD Key");
+        result.ApiKey.FullKey.Should().StartWith("rsgo_");
+        result.ApiKey.FullKey.Should().HaveLength(37);
+        result.ApiKey.KeyPrefix.Should().HaveLength(12);
+    }
+
+    [Fact]
+    public async Task POST_CreateApiKey_WithoutAuth_ReturnsUnauthorized()
+    {
+        using var unauthenticatedClient = CreateUnauthenticatedClient();
+        var request = new
+        {
+            name = "Unauthorized Key",
+            permissions = new[] { "Hooks.Redeploy" }
+        };
+
+        var response = await unauthenticatedClient.PostAsJsonAsync("/api/api-keys", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task POST_CreateApiKey_CreatedKeyAppearsInList()
+    {
+        // Create
+        var request = new
+        {
+            name = "Listed Key",
+            permissions = new[] { "Hooks.Redeploy" }
+        };
+        var createResponse = await Client.PostAsJsonAsync("/api/api-keys", request);
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // List
+        var listResponse = await Client.GetAsync("/api/api-keys");
+        var result = await listResponse.Content.ReadFromJsonAsync<ListApiKeysResponse>();
+        result!.ApiKeys.Should().Contain(k => k.Name == "Listed Key");
+    }
+
+    [Fact]
+    public async Task POST_CreateApiKey_WithEmptyName_ReturnsBadRequest()
+    {
+        var request = new
+        {
+            name = "",
+            permissions = new[] { "Hooks.Redeploy" }
+        };
+
+        var response = await Client.PostAsJsonAsync("/api/api-keys", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task POST_CreateApiKey_WithNoPermissions_ReturnsBadRequest()
+    {
+        var request = new
+        {
+            name = "No Perms Key",
+            permissions = Array.Empty<string>()
+        };
+
+        var response = await Client.PostAsJsonAsync("/api/api-keys", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task POST_CreateApiKey_DuplicateName_ReturnsBadRequest()
+    {
+        var request = new
+        {
+            name = "Duplicate Name Test",
+            permissions = new[] { "Hooks.Redeploy" }
+        };
+
+        var first = await Client.PostAsJsonAsync("/api/api-keys", request);
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var second = await Client.PostAsJsonAsync("/api/api-keys", request);
+        second.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    #endregion
+
+    #region Revoke API Key
+
+    [Fact]
+    public async Task DELETE_RevokeApiKey_ExistingKey_ReturnsSuccess()
+    {
+        // Create key first
+        var createRequest = new
+        {
+            name = "Key To Revoke",
+            permissions = new[] { "Hooks.Redeploy" }
+        };
+        var createResponse = await Client.PostAsJsonAsync("/api/api-keys", createRequest);
+        var created = await createResponse.Content.ReadFromJsonAsync<CreateApiKeyResponse>();
+        var keyId = created!.ApiKey!.Id;
+
+        // Revoke
+        var response = await Client.DeleteAsync($"/api/api-keys/{keyId}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var result = await response.Content.ReadFromJsonAsync<RevokeApiKeyResponse>();
+        result!.Success.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DELETE_RevokeApiKey_AppearAsRevokedInList()
+    {
+        // Create key first
+        var createRequest = new
+        {
+            name = "Key To Check Revoked",
+            permissions = new[] { "Hooks.Redeploy" }
+        };
+        var createResponse = await Client.PostAsJsonAsync("/api/api-keys", createRequest);
+        var created = await createResponse.Content.ReadFromJsonAsync<CreateApiKeyResponse>();
+        var keyId = created!.ApiKey!.Id;
+
+        // Revoke
+        await Client.DeleteAsync($"/api/api-keys/{keyId}");
+
+        // List
+        var listResponse = await Client.GetAsync("/api/api-keys");
+        var result = await listResponse.Content.ReadFromJsonAsync<ListApiKeysResponse>();
+        var revokedKey = result!.ApiKeys.FirstOrDefault(k => k.Id == keyId);
+        revokedKey.Should().NotBeNull();
+        revokedKey!.IsRevoked.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DELETE_RevokeApiKey_NonExistentId_ReturnsNotFound()
+    {
+        var response = await Client.DeleteAsync($"/api/api-keys/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DELETE_RevokeApiKey_WithoutAuth_ReturnsUnauthorized()
+    {
+        using var unauthenticatedClient = CreateUnauthenticatedClient();
+
+        var response = await unauthenticatedClient.DeleteAsync($"/api/api-keys/{Guid.NewGuid()}");
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    #endregion
+
+    #region Response DTOs
+
+    private record ListApiKeysResponse(ApiKeyDto[] ApiKeys);
+
+    private record CreateApiKeyResponse(bool Success, string? Message, ApiKeyCreatedDto? ApiKey);
+
+    private record ApiKeyCreatedDto(string Id, string Name, string KeyPrefix, string FullKey);
+
+    private record ApiKeyDto(
+        string Id,
+        string Name,
+        string KeyPrefix,
+        string OrganizationId,
+        string? EnvironmentId,
+        string[] Permissions,
+        string CreatedAt,
+        string? LastUsedAt,
+        string? ExpiresAt,
+        bool IsRevoked);
+
+    private record RevokeApiKeyResponse(bool Success, string? Message);
+
+    #endregion
+}

--- a/tests/ReadyStackGo.UnitTests/Application/ApiKeys/CreateApiKeyHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/ApiKeys/CreateApiKeyHandlerTests.cs
@@ -1,0 +1,278 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ReadyStackGo.Application.UseCases.ApiKeys;
+using ReadyStackGo.Application.UseCases.ApiKeys.CreateApiKey;
+using ReadyStackGo.Domain.IdentityAccess.ApiKeys;
+using ReadyStackGo.Domain.IdentityAccess.Organizations;
+
+namespace ReadyStackGo.UnitTests.Application.ApiKeys;
+
+public class CreateApiKeyHandlerTests
+{
+    private readonly Mock<IApiKeyRepository> _apiKeyRepositoryMock;
+    private readonly Mock<IOrganizationRepository> _organizationRepositoryMock;
+    private readonly Mock<ILogger<CreateApiKeyHandler>> _loggerMock;
+    private readonly CreateApiKeyHandler _handler;
+    private readonly Organization _testOrganization;
+
+    public CreateApiKeyHandlerTests()
+    {
+        _apiKeyRepositoryMock = new Mock<IApiKeyRepository>();
+        _organizationRepositoryMock = new Mock<IOrganizationRepository>();
+        _loggerMock = new Mock<ILogger<CreateApiKeyHandler>>();
+        _handler = new CreateApiKeyHandler(
+            _apiKeyRepositoryMock.Object,
+            _organizationRepositoryMock.Object,
+            _loggerMock.Object);
+
+        _testOrganization = Organization.Provision(OrganizationId.Create(), "Test Org", "Test Organization");
+        _organizationRepositoryMock.Setup(r => r.GetAll())
+            .Returns(new List<Organization> { _testOrganization });
+        _apiKeyRepositoryMock.Setup(r => r.GetByOrganization(It.IsAny<OrganizationId>()))
+            .Returns(new List<ApiKey>());
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsSuccessWithFullKey()
+    {
+        var request = new CreateApiKeyRequest
+        {
+            Name = "Test Key",
+            Permissions = new List<string> { "Hooks.Redeploy" }
+        };
+
+        var result = await _handler.Handle(new CreateApiKeyCommand(request), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ApiKey.Should().NotBeNull();
+        result.ApiKey!.Name.Should().Be("Test Key");
+        result.ApiKey.FullKey.Should().StartWith("rsgo_");
+        result.ApiKey.FullKey.Should().HaveLength(37); // rsgo_ (5) + 32 random chars
+        result.ApiKey.KeyPrefix.Should().HaveLength(12);
+        _apiKeyRepositoryMock.Verify(r => r.Add(It.IsAny<ApiKey>()), Times.Once);
+        _apiKeyRepositoryMock.Verify(r => r.SaveChanges(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyName_ReturnsFailure()
+    {
+        var request = new CreateApiKeyRequest
+        {
+            Name = "",
+            Permissions = new List<string> { "Hooks.Redeploy" }
+        };
+
+        var result = await _handler.Handle(new CreateApiKeyCommand(request), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("name is required");
+        _apiKeyRepositoryMock.Verify(r => r.Add(It.IsAny<ApiKey>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhitespaceName_ReturnsFailure()
+    {
+        var request = new CreateApiKeyRequest
+        {
+            Name = "   ",
+            Permissions = new List<string> { "Hooks.Redeploy" }
+        };
+
+        var result = await _handler.Handle(new CreateApiKeyCommand(request), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("name is required");
+    }
+
+    [Fact]
+    public async Task Handle_NoPermissions_ReturnsFailure()
+    {
+        var request = new CreateApiKeyRequest
+        {
+            Name = "Test Key",
+            Permissions = new List<string>()
+        };
+
+        var result = await _handler.Handle(new CreateApiKeyCommand(request), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("permission is required");
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateActiveName_ReturnsFailure()
+    {
+        var existingKey = ApiKey.Create(
+            ApiKeyId.Create(),
+            _testOrganization.Id,
+            "Existing Key",
+            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+            "rsgo_existin",
+            new List<string> { "Hooks.Redeploy" });
+
+        _apiKeyRepositoryMock.Setup(r => r.GetByOrganization(_testOrganization.Id))
+            .Returns(new List<ApiKey> { existingKey });
+
+        var request = new CreateApiKeyRequest
+        {
+            Name = "Existing Key",
+            Permissions = new List<string> { "Hooks.Redeploy" }
+        };
+
+        var result = await _handler.Handle(new CreateApiKeyCommand(request), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("already exists");
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateRevokedName_AllowsCreation()
+    {
+        var revokedKey = ApiKey.Create(
+            ApiKeyId.Create(),
+            _testOrganization.Id,
+            "Revoked Key",
+            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+            "rsgo_revoked",
+            new List<string> { "Hooks.Redeploy" });
+        revokedKey.Revoke("No longer needed");
+
+        _apiKeyRepositoryMock.Setup(r => r.GetByOrganization(_testOrganization.Id))
+            .Returns(new List<ApiKey> { revokedKey });
+
+        var request = new CreateApiKeyRequest
+        {
+            Name = "Revoked Key",
+            Permissions = new List<string> { "Hooks.Redeploy" }
+        };
+
+        var result = await _handler.Handle(new CreateApiKeyCommand(request), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_NoOrganization_ReturnsFailure()
+    {
+        _organizationRepositoryMock.Setup(r => r.GetAll())
+            .Returns(new List<Organization>());
+
+        var request = new CreateApiKeyRequest
+        {
+            Name = "Test Key",
+            Permissions = new List<string> { "Hooks.Redeploy" }
+        };
+
+        var result = await _handler.Handle(new CreateApiKeyCommand(request), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Organization not set");
+    }
+
+    [Fact]
+    public async Task Handle_InvalidEnvironmentId_ReturnsFailure()
+    {
+        var request = new CreateApiKeyRequest
+        {
+            Name = "Test Key",
+            Permissions = new List<string> { "Hooks.Redeploy" },
+            EnvironmentId = "not-a-guid"
+        };
+
+        var result = await _handler.Handle(new CreateApiKeyCommand(request), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Invalid environment ID");
+    }
+
+    [Fact]
+    public async Task Handle_ValidEnvironmentId_CreatesKeyWithScope()
+    {
+        var envId = Guid.NewGuid();
+        var request = new CreateApiKeyRequest
+        {
+            Name = "Scoped Key",
+            Permissions = new List<string> { "Hooks.Redeploy" },
+            EnvironmentId = envId.ToString()
+        };
+
+        var result = await _handler.Handle(new CreateApiKeyCommand(request), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _apiKeyRepositoryMock.Verify(r => r.Add(It.Is<ApiKey>(k => k.EnvironmentId == envId)), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithExpiry_CreatesKeyWithExpiration()
+    {
+        var expiresAt = DateTime.UtcNow.AddDays(30);
+        var request = new CreateApiKeyRequest
+        {
+            Name = "Expiring Key",
+            Permissions = new List<string> { "Hooks.Redeploy" },
+            ExpiresAt = expiresAt
+        };
+
+        var result = await _handler.Handle(new CreateApiKeyCommand(request), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _apiKeyRepositoryMock.Verify(r => r.Add(It.Is<ApiKey>(k => k.ExpiresAt == expiresAt)), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_GeneratedKey_HasCorrectFormat()
+    {
+        var request = new CreateApiKeyRequest
+        {
+            Name = "Format Test Key",
+            Permissions = new List<string> { "Hooks.Redeploy" }
+        };
+
+        var result = await _handler.Handle(new CreateApiKeyCommand(request), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ApiKey!.FullKey.Should().StartWith("rsgo_");
+        result.ApiKey.FullKey.Should().HaveLength(37); // rsgo_ (5) + 32 random
+        result.ApiKey.FullKey[5..].Should().MatchRegex("^[a-z0-9]{32}$");
+    }
+
+    [Fact]
+    public async Task Handle_GeneratedKeys_AreUnique()
+    {
+        var request1 = new CreateApiKeyRequest
+        {
+            Name = "Unique Key 1",
+            Permissions = new List<string> { "Hooks.Redeploy" }
+        };
+        var request2 = new CreateApiKeyRequest
+        {
+            Name = "Unique Key 2",
+            Permissions = new List<string> { "Hooks.Redeploy" }
+        };
+
+        var result1 = await _handler.Handle(new CreateApiKeyCommand(request1), CancellationToken.None);
+        var result2 = await _handler.Handle(new CreateApiKeyCommand(request2), CancellationToken.None);
+
+        result1.ApiKey!.FullKey.Should().NotBe(result2.ApiKey!.FullKey);
+    }
+
+    [Fact]
+    public async Task Handle_MultiplePermissions_CreatesKeyWithAllPermissions()
+    {
+        var request = new CreateApiKeyRequest
+        {
+            Name = "Multi Perm Key",
+            Permissions = new List<string> { "Hooks.Redeploy", "Hooks.Upgrade", "Hooks.SyncSources" }
+        };
+
+        var result = await _handler.Handle(new CreateApiKeyCommand(request), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _apiKeyRepositoryMock.Verify(r => r.Add(It.Is<ApiKey>(k =>
+            k.Permissions.Count == 3 &&
+            k.Permissions.Contains("Hooks.Redeploy") &&
+            k.Permissions.Contains("Hooks.Upgrade") &&
+            k.Permissions.Contains("Hooks.SyncSources"))), Times.Once);
+    }
+}

--- a/tests/ReadyStackGo.UnitTests/Application/ApiKeys/RevokeApiKeyHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/ApiKeys/RevokeApiKeyHandlerTests.cs
@@ -1,0 +1,106 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ReadyStackGo.Application.UseCases.ApiKeys.RevokeApiKey;
+using ReadyStackGo.Domain.IdentityAccess.ApiKeys;
+using ReadyStackGo.Domain.IdentityAccess.Organizations;
+
+namespace ReadyStackGo.UnitTests.Application.ApiKeys;
+
+public class RevokeApiKeyHandlerTests
+{
+    private readonly Mock<IApiKeyRepository> _apiKeyRepositoryMock;
+    private readonly Mock<ILogger<RevokeApiKeyHandler>> _loggerMock;
+    private readonly RevokeApiKeyHandler _handler;
+
+    public RevokeApiKeyHandlerTests()
+    {
+        _apiKeyRepositoryMock = new Mock<IApiKeyRepository>();
+        _loggerMock = new Mock<ILogger<RevokeApiKeyHandler>>();
+        _handler = new RevokeApiKeyHandler(
+            _apiKeyRepositoryMock.Object,
+            _loggerMock.Object);
+    }
+
+    private static ApiKey CreateTestApiKey(string name = "Test Key")
+    {
+        return ApiKey.Create(
+            ApiKeyId.Create(),
+            OrganizationId.Create(),
+            name,
+            "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+            "rsgo_testkey",
+            new List<string> { "Hooks.Redeploy" });
+    }
+
+    [Fact]
+    public async Task Handle_ValidKey_RevokesSuccessfully()
+    {
+        var apiKey = CreateTestApiKey();
+        _apiKeyRepositoryMock.Setup(r => r.GetById(apiKey.Id)).Returns(apiKey);
+
+        var result = await _handler.Handle(
+            new RevokeApiKeyCommand(apiKey.Id.Value.ToString(), "No longer needed"),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Message.Should().Contain("revoked successfully");
+        apiKey.IsRevoked.Should().BeTrue();
+        _apiKeyRepositoryMock.Verify(r => r.Update(apiKey), Times.Once);
+        _apiKeyRepositoryMock.Verify(r => r.SaveChanges(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_InvalidIdFormat_ReturnsFailure()
+    {
+        var result = await _handler.Handle(
+            new RevokeApiKeyCommand("not-a-guid", null),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Invalid API key ID");
+    }
+
+    [Fact]
+    public async Task Handle_KeyNotFound_ReturnsFailure()
+    {
+        var id = Guid.NewGuid();
+        _apiKeyRepositoryMock.Setup(r => r.GetById(It.IsAny<ApiKeyId>())).Returns((ApiKey?)null);
+
+        var result = await _handler.Handle(
+            new RevokeApiKeyCommand(id.ToString(), null),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task Handle_AlreadyRevoked_ReturnsFailure()
+    {
+        var apiKey = CreateTestApiKey();
+        apiKey.Revoke("First revocation");
+        _apiKeyRepositoryMock.Setup(r => r.GetById(apiKey.Id)).Returns(apiKey);
+
+        var result = await _handler.Handle(
+            new RevokeApiKeyCommand(apiKey.Id.Value.ToString(), "Second attempt"),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("already revoked");
+    }
+
+    [Fact]
+    public async Task Handle_WithoutReason_RevokesSuccessfully()
+    {
+        var apiKey = CreateTestApiKey();
+        _apiKeyRepositoryMock.Setup(r => r.GetById(apiKey.Id)).Returns(apiKey);
+
+        var result = await _handler.Handle(
+            new RevokeApiKeyCommand(apiKey.Id.Value.ToString(), null),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        apiKey.IsRevoked.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary

- Adds Application Layer with CreateApiKey (key generation, SHA-256 hashing, uniqueness validation), ListApiKeys (org-scoped), and RevokeApiKey (permanent disable) handlers
- Adds FastEndpoints for POST/GET/DELETE `/api/api-keys` with RBAC permissions (ApiKeys.Create/Read/Delete)
- Adds Settings UI page at `/settings/cicd` with table view, create modal (permission checkboxes, optional expiry), one-time key display with copy-to-clipboard, and revoke confirmation dialog

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] Unit tests: 1467 passing (18 new: 13 CreateApiKeyHandler + 5 RevokeApiKeyHandler)
- [x] Integration tests: 329/330 passing (13 new endpoint tests, 1 pre-existing failure unrelated)
- [x] Existing tests all pass (no regressions from new endpoints)