### PR TITLE
Add Redeploy Webhook for CI/CD pipeline integration

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/Hooks/RedeployEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Hooks/RedeployEndpoint.cs
@@ -1,0 +1,50 @@
+using FastEndpoints;
+using MediatR;
+using ReadyStackGo.Api.Authorization;
+using ReadyStackGo.Application.UseCases.Hooks.RedeployStack;
+using ReadyStackGo.Infrastructure.Security.Authentication;
+
+namespace ReadyStackGo.Api.Endpoints.Hooks;
+
+[RequirePermission("Hooks", "Redeploy")]
+public class RedeployEndpoint : Endpoint<RedeployStackRequest, RedeployStackResponse>
+{
+    private readonly IMediator _mediator;
+
+    public RedeployEndpoint(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Post("/api/hooks/redeploy");
+        PreProcessor<RbacPreProcessor<RedeployStackRequest>>();
+    }
+
+    public override async Task HandleAsync(RedeployStackRequest req, CancellationToken ct)
+    {
+        // Resolve EnvironmentId: from request body, or fallback to API Key's env_id claim
+        var environmentId = req.EnvironmentId;
+
+        if (string.IsNullOrEmpty(environmentId))
+        {
+            environmentId = HttpContext.User.FindFirst(RbacClaimTypes.EnvironmentId)?.Value;
+        }
+
+        if (string.IsNullOrEmpty(environmentId))
+        {
+            ThrowError("EnvironmentId is required. Provide it in the request body or use an environment-scoped API key.");
+        }
+
+        var response = await _mediator.Send(
+            new RedeployStackCommand(req.StackName, environmentId!), ct);
+
+        if (!response.Success)
+        {
+            HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+        }
+
+        Response = response;
+    }
+}

--- a/src/ReadyStackGo.Application/UseCases/Hooks/RedeployStack/RedeployStackCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Hooks/RedeployStack/RedeployStackCommand.cs
@@ -1,0 +1,110 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using ReadyStackGo.Application.UseCases.Deployments.DeployStack;
+using ReadyStackGo.Domain.Deployment.Deployments;
+using ReadyStackGo.Domain.Deployment.Environments;
+
+namespace ReadyStackGo.Application.UseCases.Hooks.RedeployStack;
+
+public record RedeployStackRequest
+{
+    public required string StackName { get; init; }
+    public string? EnvironmentId { get; init; }
+}
+
+public record RedeployStackResponse
+{
+    public bool Success { get; init; }
+    public string? Message { get; init; }
+    public string? DeploymentId { get; init; }
+    public string? StackName { get; init; }
+    public string? StackVersion { get; init; }
+
+    public static RedeployStackResponse Failed(string message) =>
+        new() { Success = false, Message = message };
+}
+
+public record RedeployStackCommand(
+    string StackName,
+    string EnvironmentId
+) : IRequest<RedeployStackResponse>;
+
+public class RedeployStackHandler : IRequestHandler<RedeployStackCommand, RedeployStackResponse>
+{
+    private readonly IDeploymentRepository _deploymentRepository;
+    private readonly IMediator _mediator;
+    private readonly ILogger<RedeployStackHandler> _logger;
+
+    public RedeployStackHandler(
+        IDeploymentRepository deploymentRepository,
+        IMediator mediator,
+        ILogger<RedeployStackHandler> logger)
+    {
+        _deploymentRepository = deploymentRepository;
+        _mediator = mediator;
+        _logger = logger;
+    }
+
+    public async Task<RedeployStackResponse> Handle(RedeployStackCommand request, CancellationToken cancellationToken)
+    {
+        // 1. Parse environment ID
+        if (!Guid.TryParse(request.EnvironmentId, out var envGuid))
+        {
+            return RedeployStackResponse.Failed("Invalid environment ID format.");
+        }
+
+        var environmentId = new EnvironmentId(envGuid);
+
+        // 2. Find deployment by stack name + environment
+        var deployment = _deploymentRepository.GetByStackName(environmentId, request.StackName);
+        if (deployment == null)
+        {
+            return RedeployStackResponse.Failed(
+                $"No deployment found for stack '{request.StackName}' in environment '{request.EnvironmentId}'.");
+        }
+
+        // 3. Validate: only running stacks can be redeployed
+        if (deployment.Status != DeploymentStatus.Running)
+        {
+            return RedeployStackResponse.Failed(
+                $"Only running deployments can be redeployed. Current status: {deployment.Status}");
+        }
+
+        // 4. Extract redeployment data from existing deployment
+        var (stackId, stackVersion, variables) = deployment.GetRedeploymentData();
+
+        _logger.LogInformation(
+            "Starting redeploy of stack '{StackName}' (version {Version}) in environment {EnvironmentId}",
+            request.StackName, stackVersion, request.EnvironmentId);
+
+        // 5. Delegate to DeployStackCommand (same parameters, no SessionId for webhook)
+        var deployResult = await _mediator.Send(new DeployStackCommand(
+            request.EnvironmentId,
+            stackId,
+            deployment.StackName,
+            new Dictionary<string, string>(variables),
+            null), cancellationToken);
+
+        if (!deployResult.Success)
+        {
+            _logger.LogWarning(
+                "Redeploy of stack '{StackName}' failed: {Message}",
+                request.StackName, deployResult.Message);
+
+            return RedeployStackResponse.Failed(deployResult.Message ?? "Redeploy failed.");
+        }
+
+        _logger.LogInformation(
+            "Successfully redeployed stack '{StackName}' (version {Version})",
+            request.StackName, stackVersion);
+
+        return new RedeployStackResponse
+        {
+            Success = true,
+            Message = $"Successfully triggered redeploy of '{request.StackName}'.",
+            DeploymentId = deployResult.DeploymentId,
+            StackName = request.StackName,
+            StackVersion = stackVersion
+        };
+    }
+}

--- a/tests/ReadyStackGo.IntegrationTests/RedeployEndpointIntegrationTests.cs
+++ b/tests/ReadyStackGo.IntegrationTests/RedeployEndpointIntegrationTests.cs
@@ -1,0 +1,152 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using ReadyStackGo.IntegrationTests.Infrastructure;
+using Xunit;
+
+namespace ReadyStackGo.IntegrationTests;
+
+/// <summary>
+/// Integration tests for the Redeploy Webhook Endpoint.
+/// Tests authentication, authorization, and request validation.
+/// </summary>
+public class RedeployEndpointIntegrationTests : AuthenticatedTestBase
+{
+    #region Authentication
+
+    [Fact]
+    public async Task POST_Redeploy_WithoutAuth_ReturnsUnauthorized()
+    {
+        using var unauthenticatedClient = CreateUnauthenticatedClient();
+
+        var request = new { stackName = "my-stack", environmentId = Guid.NewGuid().ToString() };
+        var response = await unauthenticatedClient.PostAsJsonAsync("/api/hooks/redeploy", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task POST_Redeploy_WithJwtAuth_IsAllowed()
+    {
+        // JWT-authenticated admin has all permissions including Hooks.Redeploy
+        var request = new { stackName = "nonexistent-stack", environmentId = EnvironmentId };
+        var response = await Client.PostAsJsonAsync("/api/hooks/redeploy", request);
+
+        // Should reach the handler (not 401/403), but fail because no deployment exists
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    #endregion
+
+    #region Validation
+
+    [Fact]
+    public async Task POST_Redeploy_WithoutEnvironmentId_ReturnsError()
+    {
+        var request = new { stackName = "my-stack" };
+        var response = await Client.PostAsJsonAsync("/api/hooks/redeploy", request);
+
+        // Should fail because no environmentId and no env_id claim in JWT
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.BadRequest, HttpStatusCode.InternalServerError);
+    }
+
+    [Fact]
+    public async Task POST_Redeploy_NonexistentStack_ReturnsBadRequest()
+    {
+        var request = new { stackName = "stack-that-does-not-exist", environmentId = EnvironmentId };
+        var response = await Client.PostAsJsonAsync("/api/hooks/redeploy", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("No deployment found");
+    }
+
+    [Fact]
+    public async Task POST_Redeploy_InvalidEnvironmentId_ReturnsBadRequest()
+    {
+        var request = new { stackName = "my-stack", environmentId = "not-a-guid" };
+        var response = await Client.PostAsJsonAsync("/api/hooks/redeploy", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Invalid environment ID");
+    }
+
+    [Fact]
+    public async Task POST_Redeploy_WithValidEnvironmentId_NoDeployment_ReturnsBadRequest()
+    {
+        var request = new { stackName = "some-stack", environmentId = EnvironmentId };
+        var response = await Client.PostAsJsonAsync("/api/hooks/redeploy", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("No deployment found");
+        body.Should().Contain("some-stack");
+    }
+
+    #endregion
+
+    #region API Key Authentication
+
+    [Fact]
+    public async Task POST_Redeploy_WithApiKey_IsAllowed()
+    {
+        // Create an API key with Hooks.Redeploy permission
+        var createKeyRequest = new
+        {
+            name = "Redeploy Test Key",
+            permissions = new[] { "Hooks.Redeploy" }
+        };
+        var createResponse = await Client.PostAsJsonAsync("/api/api-keys", createKeyRequest);
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var keyResult = await createResponse.Content.ReadFromJsonAsync<CreateApiKeyResponse>();
+        var apiKey = keyResult!.ApiKey!.FullKey;
+
+        // Use the API key to call the redeploy endpoint
+        using var apiKeyClient = CreateUnauthenticatedClient();
+        apiKeyClient.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
+
+        var request = new { stackName = "test-stack", environmentId = EnvironmentId };
+        var response = await apiKeyClient.PostAsJsonAsync("/api/hooks/redeploy", request);
+
+        // Should reach handler (not 401/403), fail because no deployment exists
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("No deployment found");
+    }
+
+    [Fact]
+    public async Task POST_Redeploy_WithApiKeyWithoutRedeployPermission_ReturnsForbidden()
+    {
+        // Create an API key with only SyncSources permission (not Redeploy)
+        var createKeyRequest = new
+        {
+            name = "Sync Only Key",
+            permissions = new[] { "Hooks.SyncSources" }
+        };
+        var createResponse = await Client.PostAsJsonAsync("/api/api-keys", createKeyRequest);
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var keyResult = await createResponse.Content.ReadFromJsonAsync<CreateApiKeyResponse>();
+        var apiKey = keyResult!.ApiKey!.FullKey;
+
+        // Use the API key - should be forbidden since it lacks Hooks.Redeploy
+        using var apiKeyClient = CreateUnauthenticatedClient();
+        apiKeyClient.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
+
+        var request = new { stackName = "test-stack", environmentId = EnvironmentId };
+        var response = await apiKeyClient.PostAsJsonAsync("/api/hooks/redeploy", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    #endregion
+
+    #region DTOs
+
+    private record CreateApiKeyResponse(bool Success, string? Message, ApiKeyCreatedDto? ApiKey = null);
+    private record ApiKeyCreatedDto(string Id, string Name, string KeyPrefix, string FullKey);
+
+    #endregion
+}

--- a/tests/ReadyStackGo.UnitTests/Application/Hooks/RedeployStackHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Hooks/RedeployStackHandlerTests.cs
@@ -1,0 +1,370 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ReadyStackGo.Application.UseCases.Deployments.DeployStack;
+using ReadyStackGo.Application.UseCases.Hooks.RedeployStack;
+using ReadyStackGo.Domain.Deployment;
+using ReadyStackGo.Domain.Deployment.Deployments;
+using ReadyStackGo.Domain.Deployment.Environments;
+
+namespace ReadyStackGo.UnitTests.Application.Hooks;
+
+public class RedeployStackHandlerTests
+{
+    private readonly Mock<IDeploymentRepository> _deploymentRepoMock;
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<ILogger<RedeployStackHandler>> _loggerMock;
+    private readonly RedeployStackHandler _handler;
+
+    private static readonly string TestEnvironmentId = Guid.NewGuid().ToString();
+    private static readonly string TestStackId = "source1:product1:my-stack";
+    private const string TestStackName = "my-stack";
+
+    public RedeployStackHandlerTests()
+    {
+        _deploymentRepoMock = new Mock<IDeploymentRepository>();
+        _mediatorMock = new Mock<IMediator>();
+        _loggerMock = new Mock<ILogger<RedeployStackHandler>>();
+        _handler = new RedeployStackHandler(
+            _deploymentRepoMock.Object,
+            _mediatorMock.Object,
+            _loggerMock.Object);
+    }
+
+    private static Deployment CreateRunningDeployment(
+        string stackName = TestStackName,
+        string? stackId = null,
+        string? environmentId = null,
+        Dictionary<string, string>? variables = null)
+    {
+        var envId = new EnvironmentId(Guid.Parse(environmentId ?? TestEnvironmentId));
+        var deployment = Deployment.StartInstallation(
+            DeploymentId.Create(),
+            envId,
+            stackId ?? TestStackId,
+            stackName,
+            $"rsgo-{stackName}",
+            UserId.Create());
+
+        if (variables != null)
+        {
+            deployment.SetVariables(variables);
+        }
+
+        deployment.MarkAsRunning();
+        return deployment;
+    }
+
+    #region Successful Redeploy
+
+    [Fact]
+    public async Task Handle_RunningDeployment_ReturnsSuccess()
+    {
+        var deployment = CreateRunningDeployment();
+        SetupDeploymentLookup(deployment);
+        SetupSuccessfulDeploy();
+
+        var result = await _handler.Handle(
+            new RedeployStackCommand(TestStackName, TestEnvironmentId),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.StackName.Should().Be(TestStackName);
+        result.Message.Should().Contain("Successfully");
+    }
+
+    [Fact]
+    public async Task Handle_RunningDeployment_DelegatesToDeployStackCommand()
+    {
+        var variables = new Dictionary<string, string>
+        {
+            ["DB_HOST"] = "localhost",
+            ["DB_PORT"] = "5432"
+        };
+        var deployment = CreateRunningDeployment(variables: variables);
+        SetupDeploymentLookup(deployment);
+        SetupSuccessfulDeploy();
+
+        await _handler.Handle(
+            new RedeployStackCommand(TestStackName, TestEnvironmentId),
+            CancellationToken.None);
+
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<DeployStackCommand>(cmd =>
+                cmd.EnvironmentId == TestEnvironmentId &&
+                cmd.StackId == TestStackId &&
+                cmd.StackName == TestStackName &&
+                cmd.Variables["DB_HOST"] == "localhost" &&
+                cmd.Variables["DB_PORT"] == "5432" &&
+                cmd.SessionId == null),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_RunningDeployment_ReturnsDeploymentIdFromDeployResult()
+    {
+        var deployment = CreateRunningDeployment();
+        SetupDeploymentLookup(deployment);
+
+        var expectedDeploymentId = Guid.NewGuid().ToString();
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<DeployStackCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeployStackResponse
+            {
+                Success = true,
+                DeploymentId = expectedDeploymentId
+            });
+
+        var result = await _handler.Handle(
+            new RedeployStackCommand(TestStackName, TestEnvironmentId),
+            CancellationToken.None);
+
+        result.DeploymentId.Should().Be(expectedDeploymentId);
+    }
+
+    [Fact]
+    public async Task Handle_RunningDeployment_PreservesExistingVariables()
+    {
+        var variables = new Dictionary<string, string>
+        {
+            ["SECRET"] = "super-secret",
+            ["URL"] = "https://example.com"
+        };
+        var deployment = CreateRunningDeployment(variables: variables);
+        SetupDeploymentLookup(deployment);
+        SetupSuccessfulDeploy();
+
+        await _handler.Handle(
+            new RedeployStackCommand(TestStackName, TestEnvironmentId),
+            CancellationToken.None);
+
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<DeployStackCommand>(cmd =>
+                cmd.Variables.Count == 2 &&
+                cmd.Variables["SECRET"] == "super-secret" &&
+                cmd.Variables["URL"] == "https://example.com"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DeploymentWithVersion_ReturnsVersionInResponse()
+    {
+        var deployment = CreateRunningDeployment();
+        deployment.SetStackVersion("2.1.0");
+        SetupDeploymentLookup(deployment);
+        SetupSuccessfulDeploy();
+
+        var result = await _handler.Handle(
+            new RedeployStackCommand(TestStackName, TestEnvironmentId),
+            CancellationToken.None);
+
+        result.StackVersion.Should().Be("2.1.0");
+    }
+
+    #endregion
+
+    #region Deployment Not Found
+
+    [Fact]
+    public async Task Handle_UnknownStackName_ReturnsNotFound()
+    {
+        _deploymentRepoMock
+            .Setup(r => r.GetByStackName(It.IsAny<EnvironmentId>(), It.IsAny<string>()))
+            .Returns((Deployment?)null);
+
+        var result = await _handler.Handle(
+            new RedeployStackCommand("nonexistent-stack", TestEnvironmentId),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("No deployment found");
+        result.Message.Should().Contain("nonexistent-stack");
+    }
+
+    #endregion
+
+    #region Invalid Status
+
+    [Fact]
+    public async Task Handle_FailedDeployment_ReturnsError()
+    {
+        var deployment = CreateFailedDeployment();
+        SetupDeploymentLookup(deployment);
+
+        var result = await _handler.Handle(
+            new RedeployStackCommand(TestStackName, TestEnvironmentId),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Only running deployments");
+        result.Message.Should().Contain("Failed");
+    }
+
+    [Fact]
+    public async Task Handle_InstallingDeployment_ReturnsError()
+    {
+        var deployment = CreateInstallingDeployment();
+        SetupDeploymentLookup(deployment);
+
+        var result = await _handler.Handle(
+            new RedeployStackCommand(TestStackName, TestEnvironmentId),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Only running deployments");
+        result.Message.Should().Contain("Installing");
+    }
+
+    [Fact]
+    public async Task Handle_RemovedDeployment_ReturnsError()
+    {
+        var deployment = CreateRemovedDeployment();
+        SetupDeploymentLookup(deployment);
+
+        var result = await _handler.Handle(
+            new RedeployStackCommand(TestStackName, TestEnvironmentId),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Only running deployments");
+        result.Message.Should().Contain("Removed");
+    }
+
+    #endregion
+
+    #region Invalid Input
+
+    [Fact]
+    public async Task Handle_InvalidEnvironmentId_ReturnsError()
+    {
+        var result = await _handler.Handle(
+            new RedeployStackCommand(TestStackName, "not-a-guid"),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Invalid environment ID");
+    }
+
+    [Fact]
+    public async Task Handle_EmptyEnvironmentId_ReturnsError()
+    {
+        var result = await _handler.Handle(
+            new RedeployStackCommand(TestStackName, ""),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Invalid environment ID");
+    }
+
+    #endregion
+
+    #region Deploy Failure Propagation
+
+    [Fact]
+    public async Task Handle_DeployCommandFails_PropagatesError()
+    {
+        var deployment = CreateRunningDeployment();
+        SetupDeploymentLookup(deployment);
+
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<DeployStackCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DeployStackResponse.Failed("Image pull failed"));
+
+        var result = await _handler.Handle(
+            new RedeployStackCommand(TestStackName, TestEnvironmentId),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Image pull failed");
+    }
+
+    [Fact]
+    public async Task Handle_DeployCommandFails_DoesNotReturnDeploymentId()
+    {
+        var deployment = CreateRunningDeployment();
+        SetupDeploymentLookup(deployment);
+
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<DeployStackCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DeployStackResponse.Failed("Connection refused"));
+
+        var result = await _handler.Handle(
+            new RedeployStackCommand(TestStackName, TestEnvironmentId),
+            CancellationToken.None);
+
+        result.DeploymentId.Should().BeNull();
+    }
+
+    #endregion
+
+    #region No SessionId for Webhook
+
+    [Fact]
+    public async Task Handle_AlwaysSendsNullSessionId()
+    {
+        var deployment = CreateRunningDeployment();
+        SetupDeploymentLookup(deployment);
+        SetupSuccessfulDeploy();
+
+        await _handler.Handle(
+            new RedeployStackCommand(TestStackName, TestEnvironmentId),
+            CancellationToken.None);
+
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<DeployStackCommand>(cmd => cmd.SessionId == null),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private void SetupDeploymentLookup(Deployment deployment)
+    {
+        _deploymentRepoMock
+            .Setup(r => r.GetByStackName(
+                It.Is<EnvironmentId>(e => e.Value == Guid.Parse(TestEnvironmentId)),
+                It.Is<string>(s => s == deployment.StackName)))
+            .Returns(deployment);
+    }
+
+    private void SetupSuccessfulDeploy()
+    {
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<DeployStackCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeployStackResponse
+            {
+                Success = true,
+                DeploymentId = Guid.NewGuid().ToString()
+            });
+    }
+
+    private static Deployment CreateFailedDeployment()
+    {
+        var envId = new EnvironmentId(Guid.Parse(TestEnvironmentId));
+        var deployment = Deployment.StartInstallation(
+            DeploymentId.Create(), envId, TestStackId, TestStackName, $"rsgo-{TestStackName}", UserId.Create());
+        deployment.MarkAsFailed("Something went wrong");
+        return deployment;
+    }
+
+    private static Deployment CreateInstallingDeployment()
+    {
+        var envId = new EnvironmentId(Guid.Parse(TestEnvironmentId));
+        return Deployment.StartInstallation(
+            DeploymentId.Create(), envId, TestStackId, TestStackName, $"rsgo-{TestStackName}", UserId.Create());
+    }
+
+    private static Deployment CreateRemovedDeployment()
+    {
+        var envId = new EnvironmentId(Guid.Parse(TestEnvironmentId));
+        var deployment = Deployment.StartInstallation(
+            DeploymentId.Create(), envId, TestStackId, TestStackName, $"rsgo-{TestStackName}", UserId.Create());
+        deployment.MarkAsRunning();
+        deployment.MarkAsRemoved();
+        return deployment;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- New `POST /api/hooks/redeploy` endpoint for triggering stack redeployment from CI/CD pipelines
- `RedeployStackHandler` finds existing deployment by stack name + environment, validates Running status, then delegates to `DeployStackCommand` with the same StackId, Variables, and version
- EnvironmentId resolves from request body or API Key `env_id` claim (fallback)
- Requires `Hooks.Redeploy` permission (API Key or JWT auth)

## Test plan
- [x] 14 unit tests: success, not found, all invalid statuses (Failed/Installing/Removed), invalid env ID, variable preservation, deploy failure propagation, null SessionId
- [x] 8 integration tests: JWT auth, API Key auth, missing permission → 403, unauthenticated → 401, invalid env ID, nonexistent stack
- [x] 1481 unit tests passing, 337/338 integration tests passing (1 pre-existing failure)