### PR TITLE
Add Upgrade Webhook for CI/CD pipeline integration

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/Hooks/UpgradeEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Hooks/UpgradeEndpoint.cs
@@ -1,0 +1,50 @@
+using FastEndpoints;
+using MediatR;
+using ReadyStackGo.Api.Authorization;
+using ReadyStackGo.Application.UseCases.Hooks.UpgradeViaHook;
+using ReadyStackGo.Infrastructure.Security.Authentication;
+
+namespace ReadyStackGo.Api.Endpoints.Hooks;
+
+[RequirePermission("Hooks", "Upgrade")]
+public class UpgradeEndpoint : Endpoint<UpgradeViaHookRequest, UpgradeViaHookResponse>
+{
+    private readonly IMediator _mediator;
+
+    public UpgradeEndpoint(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Post("/api/hooks/upgrade");
+        PreProcessor<RbacPreProcessor<UpgradeViaHookRequest>>();
+    }
+
+    public override async Task HandleAsync(UpgradeViaHookRequest req, CancellationToken ct)
+    {
+        // Resolve EnvironmentId: from request body, or fallback to API Key's env_id claim
+        var environmentId = req.EnvironmentId;
+
+        if (string.IsNullOrEmpty(environmentId))
+        {
+            environmentId = HttpContext.User.FindFirst(RbacClaimTypes.EnvironmentId)?.Value;
+        }
+
+        if (string.IsNullOrEmpty(environmentId))
+        {
+            ThrowError("EnvironmentId is required. Provide it in the request body or use an environment-scoped API key.");
+        }
+
+        var response = await _mediator.Send(
+            new UpgradeViaHookCommand(req.StackName, req.TargetVersion, environmentId!, req.Variables), ct);
+
+        if (!response.Success)
+        {
+            HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+        }
+
+        Response = response;
+    }
+}

--- a/src/ReadyStackGo.Application/UseCases/Hooks/UpgradeViaHook/UpgradeViaHookCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Hooks/UpgradeViaHook/UpgradeViaHookCommand.cs
@@ -1,0 +1,151 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Application.UseCases.Deployments.UpgradeStack;
+using ReadyStackGo.Domain.Deployment.Deployments;
+using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.StackManagement.Stacks;
+
+namespace ReadyStackGo.Application.UseCases.Hooks.UpgradeViaHook;
+
+public record UpgradeViaHookRequest
+{
+    public required string StackName { get; init; }
+    public required string TargetVersion { get; init; }
+    public string? EnvironmentId { get; init; }
+    public Dictionary<string, string>? Variables { get; init; }
+}
+
+public record UpgradeViaHookResponse
+{
+    public bool Success { get; init; }
+    public string? Message { get; init; }
+    public string? DeploymentId { get; init; }
+    public string? PreviousVersion { get; init; }
+    public string? NewVersion { get; init; }
+
+    public static UpgradeViaHookResponse Failed(string message) =>
+        new() { Success = false, Message = message };
+}
+
+public record UpgradeViaHookCommand(
+    string StackName,
+    string TargetVersion,
+    string EnvironmentId,
+    Dictionary<string, string>? Variables = null
+) : IRequest<UpgradeViaHookResponse>;
+
+public class UpgradeViaHookHandler : IRequestHandler<UpgradeViaHookCommand, UpgradeViaHookResponse>
+{
+    private readonly IDeploymentRepository _deploymentRepository;
+    private readonly IProductSourceService _productSourceService;
+    private readonly IMediator _mediator;
+    private readonly ILogger<UpgradeViaHookHandler> _logger;
+
+    public UpgradeViaHookHandler(
+        IDeploymentRepository deploymentRepository,
+        IProductSourceService productSourceService,
+        IMediator mediator,
+        ILogger<UpgradeViaHookHandler> logger)
+    {
+        _deploymentRepository = deploymentRepository;
+        _productSourceService = productSourceService;
+        _mediator = mediator;
+        _logger = logger;
+    }
+
+    public async Task<UpgradeViaHookResponse> Handle(UpgradeViaHookCommand request, CancellationToken cancellationToken)
+    {
+        // 1. Parse environment ID
+        if (!Guid.TryParse(request.EnvironmentId, out var envGuid))
+        {
+            return UpgradeViaHookResponse.Failed("Invalid environment ID format.");
+        }
+
+        var environmentId = new EnvironmentId(envGuid);
+
+        // 2. Find deployment by stack name + environment
+        var deployment = _deploymentRepository.GetByStackName(environmentId, request.StackName);
+        if (deployment == null)
+        {
+            return UpgradeViaHookResponse.Failed(
+                $"No deployment found for stack '{request.StackName}' in environment '{request.EnvironmentId}'.");
+        }
+
+        // 3. Validate: only running stacks can be upgraded
+        if (!deployment.CanUpgrade())
+        {
+            return UpgradeViaHookResponse.Failed(
+                $"Only running deployments can be upgraded. Current status: {deployment.Status}");
+        }
+
+        // 4. Parse the stack ID to get the product lookup key
+        if (!StackId.TryParse(deployment.StackId, out var parsedStackId) || parsedStackId == null)
+        {
+            return UpgradeViaHookResponse.Failed(
+                "Deployment was not created from catalog. Upgrade via webhook not supported.");
+        }
+
+        // 5. Look up the product to get its GroupId
+        var productLookupKey = $"{parsedStackId.SourceId}:{parsedStackId.ProductId.Value}";
+        var product = await _productSourceService.GetProductAsync(productLookupKey, cancellationToken);
+        if (product == null)
+        {
+            return UpgradeViaHookResponse.Failed(
+                $"Product '{productLookupKey}' no longer available in catalog.");
+        }
+
+        // 6. Find the target version in the product group
+        var versions = (await _productSourceService.GetProductVersionsAsync(
+            product.GroupId, cancellationToken)).ToList();
+
+        var targetProduct = versions.FirstOrDefault(v =>
+            string.Equals(v.ProductVersion, request.TargetVersion, StringComparison.OrdinalIgnoreCase));
+
+        if (targetProduct == null)
+        {
+            var available = string.Join(", ", versions
+                .Where(v => v.ProductVersion != null)
+                .Select(v => v.ProductVersion));
+            return UpgradeViaHookResponse.Failed(
+                $"Version '{request.TargetVersion}' not found in catalog. Available versions: {available}");
+        }
+
+        // 7. Get the target stack ID
+        var targetStackId = targetProduct.DefaultStack.Id.Value;
+
+        _logger.LogInformation(
+            "Starting upgrade of stack '{StackName}' from {CurrentVersion} to {TargetVersion} via webhook",
+            request.StackName, deployment.StackVersion, request.TargetVersion);
+
+        // 8. Delegate to UpgradeStackCommand
+        var upgradeResult = await _mediator.Send(new UpgradeStackCommand(
+            request.EnvironmentId,
+            deployment.Id.Value.ToString(),
+            targetStackId,
+            request.Variables,
+            null), cancellationToken);
+
+        if (!upgradeResult.Success)
+        {
+            _logger.LogWarning(
+                "Upgrade of stack '{StackName}' to {TargetVersion} failed: {Message}",
+                request.StackName, request.TargetVersion, upgradeResult.Message);
+
+            return UpgradeViaHookResponse.Failed(upgradeResult.Message ?? "Upgrade failed.");
+        }
+
+        _logger.LogInformation(
+            "Successfully upgraded stack '{StackName}' from {PreviousVersion} to {NewVersion}",
+            request.StackName, upgradeResult.PreviousVersion, upgradeResult.NewVersion);
+
+        return new UpgradeViaHookResponse
+        {
+            Success = true,
+            Message = $"Successfully upgraded '{request.StackName}' from {upgradeResult.PreviousVersion} to {upgradeResult.NewVersion}.",
+            DeploymentId = upgradeResult.DeploymentId,
+            PreviousVersion = upgradeResult.PreviousVersion,
+            NewVersion = upgradeResult.NewVersion
+        };
+    }
+}

--- a/tests/ReadyStackGo.IntegrationTests/UpgradeEndpointIntegrationTests.cs
+++ b/tests/ReadyStackGo.IntegrationTests/UpgradeEndpointIntegrationTests.cs
@@ -1,0 +1,135 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using ReadyStackGo.IntegrationTests.Infrastructure;
+using Xunit;
+
+namespace ReadyStackGo.IntegrationTests;
+
+/// <summary>
+/// Integration tests for the Upgrade Webhook Endpoint.
+/// Tests authentication, authorization, and request validation.
+/// </summary>
+public class UpgradeEndpointIntegrationTests : AuthenticatedTestBase
+{
+    #region Authentication
+
+    [Fact]
+    public async Task POST_Upgrade_WithoutAuth_ReturnsUnauthorized()
+    {
+        using var unauthenticatedClient = CreateUnauthenticatedClient();
+
+        var request = new { stackName = "my-stack", targetVersion = "2.0.0", environmentId = EnvironmentId };
+        var response = await unauthenticatedClient.PostAsJsonAsync("/api/hooks/upgrade", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task POST_Upgrade_WithJwtAuth_IsAllowed()
+    {
+        var request = new { stackName = "nonexistent-stack", targetVersion = "2.0.0", environmentId = EnvironmentId };
+        var response = await Client.PostAsJsonAsync("/api/hooks/upgrade", request);
+
+        // Should reach the handler (not 401/403), but fail because no deployment exists
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    #endregion
+
+    #region Validation
+
+    [Fact]
+    public async Task POST_Upgrade_NonexistentStack_ReturnsBadRequest()
+    {
+        var request = new { stackName = "stack-that-does-not-exist", targetVersion = "2.0.0", environmentId = EnvironmentId };
+        var response = await Client.PostAsJsonAsync("/api/hooks/upgrade", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("No deployment found");
+    }
+
+    [Fact]
+    public async Task POST_Upgrade_InvalidEnvironmentId_ReturnsBadRequest()
+    {
+        var request = new { stackName = "my-stack", targetVersion = "2.0.0", environmentId = "not-a-guid" };
+        var response = await Client.PostAsJsonAsync("/api/hooks/upgrade", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Invalid environment ID");
+    }
+
+    [Fact]
+    public async Task POST_Upgrade_WithoutEnvironmentId_ReturnsError()
+    {
+        var request = new { stackName = "my-stack", targetVersion = "2.0.0" };
+        var response = await Client.PostAsJsonAsync("/api/hooks/upgrade", request);
+
+        // Should fail because no environmentId and no env_id claim in JWT
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.BadRequest, HttpStatusCode.InternalServerError);
+    }
+
+    #endregion
+
+    #region API Key Authentication
+
+    [Fact]
+    public async Task POST_Upgrade_WithApiKey_IsAllowed()
+    {
+        var createKeyRequest = new
+        {
+            name = "Upgrade Test Key",
+            permissions = new[] { "Hooks.Upgrade" }
+        };
+        var createResponse = await Client.PostAsJsonAsync("/api/api-keys", createKeyRequest);
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var keyResult = await createResponse.Content.ReadFromJsonAsync<CreateApiKeyResponse>();
+        var apiKey = keyResult!.ApiKey!.FullKey;
+
+        using var apiKeyClient = CreateUnauthenticatedClient();
+        apiKeyClient.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
+
+        var request = new { stackName = "test-stack", targetVersion = "2.0.0", environmentId = EnvironmentId };
+        var response = await apiKeyClient.PostAsJsonAsync("/api/hooks/upgrade", request);
+
+        // Should reach handler (not 401/403), fail because no deployment exists
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("No deployment found");
+    }
+
+    [Fact]
+    public async Task POST_Upgrade_WithApiKeyWithoutUpgradePermission_ReturnsForbidden()
+    {
+        var createKeyRequest = new
+        {
+            name = "Redeploy Only Key",
+            permissions = new[] { "Hooks.Redeploy" }
+        };
+        var createResponse = await Client.PostAsJsonAsync("/api/api-keys", createKeyRequest);
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var keyResult = await createResponse.Content.ReadFromJsonAsync<CreateApiKeyResponse>();
+        var apiKey = keyResult!.ApiKey!.FullKey;
+
+        using var apiKeyClient = CreateUnauthenticatedClient();
+        apiKeyClient.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
+
+        var request = new { stackName = "test-stack", targetVersion = "2.0.0", environmentId = EnvironmentId };
+        var response = await apiKeyClient.PostAsJsonAsync("/api/hooks/upgrade", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    #endregion
+
+    #region DTOs
+
+    private record CreateApiKeyResponse(bool Success, string? Message, ApiKeyCreatedDto? ApiKey = null);
+    private record ApiKeyCreatedDto(string Id, string Name, string KeyPrefix, string FullKey);
+
+    #endregion
+}

--- a/tests/ReadyStackGo.UnitTests/Application/Hooks/UpgradeViaHookHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Hooks/UpgradeViaHookHandlerTests.cs
@@ -1,0 +1,356 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Application.UseCases.Deployments.UpgradeStack;
+using ReadyStackGo.Application.UseCases.Hooks.UpgradeViaHook;
+using ReadyStackGo.Domain.Deployment;
+using ReadyStackGo.Domain.Deployment.Deployments;
+using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.StackManagement.Stacks;
+
+namespace ReadyStackGo.UnitTests.Application.Hooks;
+
+public class UpgradeViaHookHandlerTests
+{
+    private readonly Mock<IDeploymentRepository> _deploymentRepoMock;
+    private readonly Mock<IProductSourceService> _productSourceMock;
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<ILogger<UpgradeViaHookHandler>> _loggerMock;
+    private readonly UpgradeViaHookHandler _handler;
+
+    private static readonly string TestEnvironmentId = Guid.NewGuid().ToString();
+    private static readonly string TestStackId = "source1:myproduct:my-stack";
+    private const string TestStackName = "my-stack";
+    private const string TestGroupId = "source1:myproduct";
+
+    public UpgradeViaHookHandlerTests()
+    {
+        _deploymentRepoMock = new Mock<IDeploymentRepository>();
+        _productSourceMock = new Mock<IProductSourceService>();
+        _mediatorMock = new Mock<IMediator>();
+        _loggerMock = new Mock<ILogger<UpgradeViaHookHandler>>();
+        _handler = new UpgradeViaHookHandler(
+            _deploymentRepoMock.Object,
+            _productSourceMock.Object,
+            _mediatorMock.Object,
+            _loggerMock.Object);
+    }
+
+    private static Deployment CreateRunningDeployment(
+        string? stackId = null,
+        string? version = null)
+    {
+        var envId = new EnvironmentId(Guid.Parse(TestEnvironmentId));
+        var deployment = Deployment.StartInstallation(
+            DeploymentId.Create(),
+            envId,
+            stackId ?? TestStackId,
+            TestStackName,
+            $"rsgo-{TestStackName}",
+            UserId.Create());
+        deployment.MarkAsRunning();
+        if (version != null)
+        {
+            deployment.SetStackVersion(version);
+        }
+        return deployment;
+    }
+
+    private static ProductDefinition CreateProduct(string version, string? groupId = null)
+    {
+        var stack = new StackDefinition(
+            "source1", "my-stack", new ProductId("myproduct"),
+            productVersion: version);
+
+        return new ProductDefinition(
+            "source1", "myproduct", "My Product",
+            stacks: new List<StackDefinition> { stack },
+            productVersion: version,
+            productId: groupId);
+    }
+
+    #region Successful Upgrade
+
+    [Fact]
+    public async Task Handle_RunningDeployment_ValidVersion_DelegatesToUpgradeCommand()
+    {
+        var deployment = CreateRunningDeployment(version: "1.0.0");
+        SetupDeploymentLookup(deployment);
+        SetupProductLookup("1.0.0", "2.0.0");
+        SetupSuccessfulUpgrade("1.0.0", "2.0.0");
+
+        var result = await _handler.Handle(
+            new UpgradeViaHookCommand(TestStackName, "2.0.0", TestEnvironmentId),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.PreviousVersion.Should().Be("1.0.0");
+        result.NewVersion.Should().Be("2.0.0");
+    }
+
+    [Fact]
+    public async Task Handle_PassesCorrectParametersToUpgradeCommand()
+    {
+        var deployment = CreateRunningDeployment(version: "1.0.0");
+        SetupDeploymentLookup(deployment);
+        SetupProductLookup("1.0.0", "2.0.0");
+        SetupSuccessfulUpgrade("1.0.0", "2.0.0");
+
+        await _handler.Handle(
+            new UpgradeViaHookCommand(TestStackName, "2.0.0", TestEnvironmentId),
+            CancellationToken.None);
+
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<UpgradeStackCommand>(cmd =>
+                cmd.EnvironmentId == TestEnvironmentId &&
+                cmd.DeploymentId == deployment.Id.Value.ToString() &&
+                cmd.NewStackId == "source1:myproduct:2.0.0:my-stack" &&
+                cmd.SessionId == null),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithVariables_PassesVariablesToUpgradeCommand()
+    {
+        var deployment = CreateRunningDeployment(version: "1.0.0");
+        SetupDeploymentLookup(deployment);
+        SetupProductLookup("1.0.0", "2.0.0");
+        SetupSuccessfulUpgrade("1.0.0", "2.0.0");
+
+        var variables = new Dictionary<string, string> { ["NEW_VAR"] = "value" };
+
+        await _handler.Handle(
+            new UpgradeViaHookCommand(TestStackName, "2.0.0", TestEnvironmentId, variables),
+            CancellationToken.None);
+
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<UpgradeStackCommand>(cmd =>
+                cmd.Variables != null &&
+                cmd.Variables["NEW_VAR"] == "value"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsDeploymentIdFromUpgradeResult()
+    {
+        var deployment = CreateRunningDeployment(version: "1.0.0");
+        SetupDeploymentLookup(deployment);
+        SetupProductLookup("1.0.0", "2.0.0");
+
+        var expectedId = Guid.NewGuid().ToString();
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<UpgradeStackCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UpgradeStackResponse
+            {
+                Success = true,
+                DeploymentId = expectedId,
+                PreviousVersion = "1.0.0",
+                NewVersion = "2.0.0"
+            });
+
+        var result = await _handler.Handle(
+            new UpgradeViaHookCommand(TestStackName, "2.0.0", TestEnvironmentId),
+            CancellationToken.None);
+
+        result.DeploymentId.Should().Be(expectedId);
+    }
+
+    #endregion
+
+    #region Deployment Not Found
+
+    [Fact]
+    public async Task Handle_UnknownStackName_ReturnsNotFound()
+    {
+        _deploymentRepoMock
+            .Setup(r => r.GetByStackName(It.IsAny<EnvironmentId>(), It.IsAny<string>()))
+            .Returns((Deployment?)null);
+
+        var result = await _handler.Handle(
+            new UpgradeViaHookCommand("nonexistent", "2.0.0", TestEnvironmentId),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("No deployment found");
+    }
+
+    #endregion
+
+    #region Invalid Status
+
+    [Fact]
+    public async Task Handle_FailedDeployment_ReturnsError()
+    {
+        var envId = new EnvironmentId(Guid.Parse(TestEnvironmentId));
+        var deployment = Deployment.StartInstallation(
+            DeploymentId.Create(), envId, TestStackId, TestStackName, $"rsgo-{TestStackName}", UserId.Create());
+        deployment.MarkAsFailed("Something broke");
+        SetupDeploymentLookup(deployment);
+
+        var result = await _handler.Handle(
+            new UpgradeViaHookCommand(TestStackName, "2.0.0", TestEnvironmentId),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Only running deployments");
+    }
+
+    #endregion
+
+    #region Version Not Found
+
+    [Fact]
+    public async Task Handle_TargetVersionNotInCatalog_ReturnsError()
+    {
+        var deployment = CreateRunningDeployment(version: "1.0.0");
+        SetupDeploymentLookup(deployment);
+        SetupProductLookup("1.0.0");
+
+        var result = await _handler.Handle(
+            new UpgradeViaHookCommand(TestStackName, "9.9.9", TestEnvironmentId),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Version '9.9.9' not found in catalog");
+        result.Message.Should().Contain("Available versions");
+    }
+
+    [Fact]
+    public async Task Handle_TargetVersionNotFound_ListsAvailableVersions()
+    {
+        var deployment = CreateRunningDeployment(version: "1.0.0");
+        SetupDeploymentLookup(deployment);
+        SetupProductLookup("1.0.0", "2.0.0", "3.0.0");
+
+        var result = await _handler.Handle(
+            new UpgradeViaHookCommand(TestStackName, "5.0.0", TestEnvironmentId),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("1.0.0");
+        result.Message.Should().Contain("2.0.0");
+        result.Message.Should().Contain("3.0.0");
+    }
+
+    #endregion
+
+    #region Product Not Found
+
+    [Fact]
+    public async Task Handle_ProductNotInCatalog_ReturnsError()
+    {
+        var deployment = CreateRunningDeployment(version: "1.0.0");
+        SetupDeploymentLookup(deployment);
+        _productSourceMock
+            .Setup(s => s.GetProductAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ProductDefinition?)null);
+
+        var result = await _handler.Handle(
+            new UpgradeViaHookCommand(TestStackName, "2.0.0", TestEnvironmentId),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("no longer available in catalog");
+    }
+
+    #endregion
+
+    #region Invalid Input
+
+    [Fact]
+    public async Task Handle_InvalidEnvironmentId_ReturnsError()
+    {
+        var result = await _handler.Handle(
+            new UpgradeViaHookCommand(TestStackName, "2.0.0", "not-a-guid"),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Invalid environment ID");
+    }
+
+    #endregion
+
+    #region Non-Catalog Deployment
+
+    [Fact]
+    public async Task Handle_NonCatalogDeployment_ReturnsError()
+    {
+        // A deployment with a non-parseable StackId (e.g., manual YAML deploy)
+        var deployment = CreateRunningDeployment(stackId: "invalid-stack-id");
+        SetupDeploymentLookup(deployment);
+
+        var result = await _handler.Handle(
+            new UpgradeViaHookCommand(TestStackName, "2.0.0", TestEnvironmentId),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("not created from catalog");
+    }
+
+    #endregion
+
+    #region Upgrade Failure Propagation
+
+    [Fact]
+    public async Task Handle_UpgradeCommandFails_PropagatesError()
+    {
+        var deployment = CreateRunningDeployment(version: "1.0.0");
+        SetupDeploymentLookup(deployment);
+        SetupProductLookup("1.0.0", "2.0.0");
+
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<UpgradeStackCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(UpgradeStackResponse.Failed("Downgrade not supported"));
+
+        var result = await _handler.Handle(
+            new UpgradeViaHookCommand(TestStackName, "2.0.0", TestEnvironmentId),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Downgrade not supported");
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private void SetupDeploymentLookup(Deployment deployment)
+    {
+        _deploymentRepoMock
+            .Setup(r => r.GetByStackName(
+                It.Is<EnvironmentId>(e => e.Value == Guid.Parse(TestEnvironmentId)),
+                It.Is<string>(s => s == deployment.StackName)))
+            .Returns(deployment);
+    }
+
+    private void SetupProductLookup(params string[] versions)
+    {
+        var products = versions.Select(v => CreateProduct(v)).ToList();
+        var product = products.First();
+
+        _productSourceMock
+            .Setup(s => s.GetProductAsync(TestGroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(product);
+
+        _productSourceMock
+            .Setup(s => s.GetProductVersionsAsync(product.GroupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(products);
+    }
+
+    private void SetupSuccessfulUpgrade(string previousVersion, string newVersion)
+    {
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<UpgradeStackCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UpgradeStackResponse
+            {
+                Success = true,
+                DeploymentId = Guid.NewGuid().ToString(),
+                PreviousVersion = previousVersion,
+                NewVersion = newVersion
+            });
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- New `POST /api/hooks/upgrade` endpoint for triggering stack upgrades from CI/CD pipelines
- `UpgradeViaHookHandler` resolves stack by name, looks up target version in catalog via product GroupId, then delegates to `UpgradeStackCommand`
- Supports optional variable overrides for the new version
- EnvironmentId resolves from request body or API Key `env_id` claim
- Requires `Hooks.Upgrade` permission (API Key or JWT auth)

## Test plan
- [x] 12 unit tests: success, parameter passing, variables, deployment not found, failed status, version not in catalog (lists available), product not in catalog, non-catalog deployment, invalid env ID, upgrade failure propagation
- [x] 7 integration tests: JWT auth, API Key auth, missing permission → 403, unauthenticated → 401, invalid env ID, nonexistent stack, missing env ID
- [x] 1493 unit tests passing