### PR TITLE
Add CI/CD integration documentation and public website docs

### DIFF
--- a/docs/CI-CD/.order
+++ b/docs/CI-CD/.order
@@ -1,2 +1,3 @@
 Pipeline-Integration
+Pipeline-Examples
 Workflows

--- a/docs/CI-CD/Pipeline-Examples.md
+++ b/docs/CI-CD/Pipeline-Examples.md
@@ -1,0 +1,170 @@
+# Pipeline-Beispiele
+
+Konkrete Beispiele für die Integration von ReadyStackGo in CI/CD Pipelines.
+
+## curl
+
+### Redeploy (frische Images)
+
+```bash
+curl -X POST https://rsgo.example.com/api/hooks/redeploy \
+  -H "X-Api-Key: rsgo_a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6" \
+  -H "Content-Type: application/json" \
+  -d '{"stackName": "ams-project", "environmentId": "abc123-..."}'
+```
+
+### Katalog synchronisieren + Upgrade
+
+```bash
+# 1. Katalog-Quellen synchronisieren
+curl -X POST https://rsgo.example.com/api/hooks/sync-sources \
+  -H "X-Api-Key: rsgo_..."
+
+# 2. Auf neue Version upgraden
+curl -X POST https://rsgo.example.com/api/hooks/upgrade \
+  -H "X-Api-Key: rsgo_..." \
+  -H "Content-Type: application/json" \
+  -d '{"stackName": "ams-project", "targetVersion": "6.5.0"}'
+```
+
+## GitHub Actions
+
+### Redeploy nach Docker Build
+
+```yaml
+name: Build & Deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: myregistry/myapp:latest
+
+      - name: Trigger Redeploy
+        run: |
+          curl -sf -X POST "${{ secrets.RSGO_URL }}/api/hooks/redeploy" \
+            -H "X-Api-Key: ${{ secrets.RSGO_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d '{"stackName": "${{ vars.STACK_NAME }}"}'
+```
+
+### Release mit Sync + Upgrade
+
+```yaml
+name: Release & Upgrade
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags: myregistry/myapp:${{ github.event.release.tag_name }}
+
+      - name: Sync Catalog Sources
+        run: |
+          curl -sf -X POST "${{ secrets.RSGO_URL }}/api/hooks/sync-sources" \
+            -H "X-Api-Key: ${{ secrets.RSGO_API_KEY }}"
+
+      - name: Trigger Upgrade
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"  # Remove 'v' prefix
+          curl -sf -X POST "${{ secrets.RSGO_URL }}/api/hooks/upgrade" \
+            -H "X-Api-Key: ${{ secrets.RSGO_API_KEY }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"stackName\": \"${{ vars.STACK_NAME }}\", \"targetVersion\": \"${VERSION}\"}"
+```
+
+**Benötigte Secrets:**
+| Secret | Beschreibung |
+|--------|-------------|
+| `RSGO_URL` | ReadyStackGo Server URL (z.B. `https://rsgo.example.com`) |
+| `RSGO_API_KEY` | API Key mit den benötigten Permissions |
+
+**Benötigte Variables:**
+| Variable | Beschreibung |
+|----------|-------------|
+| `STACK_NAME` | Name des zu deployenden Stacks |
+
+## Azure DevOps
+
+### Redeploy nach Build
+
+```yaml
+trigger:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+  - task: Docker@2
+    displayName: Build and push Docker image
+    inputs:
+      command: buildAndPush
+      repository: myregistry/myapp
+      tags: latest
+
+  - script: |
+      curl -sf -X POST "$(RSGO_URL)/api/hooks/redeploy" \
+        -H "X-Api-Key: $(RSGO_API_KEY)" \
+        -H "Content-Type: application/json" \
+        -d '{"stackName": "$(STACK_NAME)"}'
+    displayName: Trigger Redeploy on ReadyStackGo
+```
+
+### Release Pipeline: Sync + Upgrade
+
+```yaml
+trigger: none
+
+resources:
+  pipelines:
+    - pipeline: build
+      source: 'Build Pipeline'
+      trigger: true
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+  - script: |
+      curl -sf -X POST "$(RSGO_URL)/api/hooks/sync-sources" \
+        -H "X-Api-Key: $(RSGO_API_KEY)"
+    displayName: Sync Catalog Sources
+
+  - script: |
+      curl -sf -X POST "$(RSGO_URL)/api/hooks/upgrade" \
+        -H "X-Api-Key: $(RSGO_API_KEY)" \
+        -H "Content-Type: application/json" \
+        -d '{"stackName": "$(STACK_NAME)", "targetVersion": "$(Build.BuildNumber)"}'
+    displayName: Trigger Upgrade
+```
+
+**Pipeline-Variablen:**
+| Variable | Typ | Beschreibung |
+|----------|-----|-------------|
+| `RSGO_URL` | Secret | ReadyStackGo Server URL |
+| `RSGO_API_KEY` | Secret | API Key |
+| `STACK_NAME` | Normal | Name des Stacks |

--- a/docs/CI-CD/Pipeline-Integration.md
+++ b/docs/CI-CD/Pipeline-Integration.md
@@ -1,47 +1,153 @@
 # CI/CD Integration
 
-ReadyStackGo is designed to be integrated into a fully automated build and release process.
-
-> **Implementation Specification**: See [PLAN-cicd-integration](../Plans/PLAN-cicd-integration.md) for the detailed implementation plan (v0.19).
+ReadyStackGo lässt sich vollständig in automatisierte Build- und Release-Prozesse integrieren. Über **API Keys** und **Webhook-Endpoints** können CI/CD Pipelines Deployments auslösen, Upgrades durchführen und den Stack-Katalog synchronisieren.
 
 ## Use Cases
 
-- Automatic build of context containers
-- Automatic tagging (`x.y.z`, `-alpha`, `-beta`)
-- Manifest generation
-- Triggering deployments on a dev/QA server via **Webhook API**
-- **Redeploy**: Pull fresh images and restart existing stack (dev/test)
-- **Upgrade**: Upgrade to a new catalog version (formal releases)
-- **Catalog Sync**: Trigger re-sync of stack sources after manifest changes
+- **Dev/Test**: Nach jedem erfolgreichen Build automatisch den Stack redeployen (frische Images)
+- **Formale Releases**: Katalog synchronisieren und auf eine neue Version upgraden
+- **Katalog-Sync**: Nach Änderungen am Manifest im Git-Repository den Katalog aktualisieren
 
 ## Authentication
 
-Pipeline access uses **API Keys** instead of JWT tokens:
-- Create API keys in Settings → CI/CD
-- Pass via `X-Api-Key` HTTP header
-- Keys can be scoped to specific environments
-- Fine-grained permissions per key
+Pipeline-Zugriff erfolgt über **API Keys** statt JWT Tokens:
 
-## Webhook Endpoints
+1. API Key erstellen unter **Settings → CI/CD Integration**
+2. Key als `X-Api-Key` HTTP Header übergeben
+3. Keys können optional auf ein Environment beschränkt werden
+4. Fine-grained Permissions pro Key (Redeploy, Upgrade, Sync Sources)
 
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/hooks/redeploy` | POST | Redeploy existing stack (fresh image pull) |
-| `/api/hooks/upgrade` | POST | Upgrade to specific catalog version |
-| `/api/hooks/sync-sources` | POST | Trigger catalog source re-sync |
+### API Key erstellen
 
----
+1. Navigiere zu **Settings → CI/CD Integration**
+2. Klicke **Create API Key**
+3. Vergib einen beschreibenden Namen (z.B. "GitHub Actions Deploy")
+4. Wähle die benötigten Permissions:
+   - **Redeploy** – Stack mit frischen Images neu starten
+   - **Upgrade** – Stack auf neue Katalog-Version upgraden
+   - **Sync Sources** – Katalog-Quellen synchronisieren
+5. Optional: Ablaufdatum setzen
+6. **Kopiere den Key sofort** – er wird nur einmal angezeigt!
+
+### Environment-Scope
+
+Wird ein API Key mit einem Environment verknüpft, muss die `environmentId` nicht in jedem Request mitgesendet werden – sie wird automatisch aus dem API Key Claim `env_id` ermittelt.
+
+## Webhook-Endpoints
+
+Alle Endpoints befinden sich unter `/api/hooks/` und erfordern API Key Authentifizierung.
+
+### POST /api/hooks/redeploy
+
+Triggert ein Redeployment eines laufenden Stacks. Stoppt die bestehenden Container, pullt frische Images und startet neu – mit denselben Variablen und Einstellungen.
+
+**Request:**
+```json
+{
+  "stackName": "ams-project",
+  "environmentId": "optional-wenn-key-environment-gebunden"
+}
+```
+
+**Response (200):**
+```json
+{
+  "success": true,
+  "message": "Successfully triggered redeploy of 'ams-project'.",
+  "deploymentId": "d4f8b2...",
+  "stackName": "ams-project",
+  "stackVersion": "6.4.0"
+}
+```
+
+**Permission:** `Hooks.Redeploy`
+
+### POST /api/hooks/upgrade
+
+Triggert ein Upgrade auf eine bestimmte Katalog-Version. Führt die Version-Validierung durch (kein Downgrade), merged Variablen und delegiert an den bestehenden Upgrade-Flow.
+
+**Request:**
+```json
+{
+  "stackName": "ams-project",
+  "targetVersion": "6.5.0",
+  "environmentId": "optional",
+  "variables": {
+    "NEW_SETTING": "value"
+  }
+}
+```
+
+**Response (200):**
+```json
+{
+  "success": true,
+  "message": "Successfully upgraded 'ams-project' from 6.4.0 to 6.5.0.",
+  "deploymentId": "d4f8b2...",
+  "previousVersion": "6.4.0",
+  "newVersion": "6.5.0"
+}
+```
+
+**Permission:** `Hooks.Upgrade`
+
+### POST /api/hooks/sync-sources
+
+Synchronisiert alle Stack-Katalog-Quellen (lokale Verzeichnisse und Git Repositories). Nützlich nach einem Git Push mit aktualisierten Manifests.
+
+**Request:** Leerer Body oder `{}`
+
+**Response (200):**
+```json
+{
+  "success": true,
+  "stacksLoaded": 12,
+  "sourcesSynced": 3,
+  "message": "Synced 3 source(s), loaded 12 stack(s)."
+}
+```
+
+**Permission:** `Hooks.SyncSources`
+
+## Typische Pipeline-Flows
+
+### Dev/Test: Redeploy nach Build
 
 ```mermaid
 flowchart LR
     A[Code Push] --> B[CI Build]
-    B --> C[Docker Images]
+    B --> C[Docker Image bauen]
     C --> D[Push to Registry]
-    D --> E{Deploy Mode}
-    E -->|Dev/Test| F[POST /api/hooks/redeploy]
-    E -->|Release| G[Update Manifest in Git]
-    G --> H[POST /api/hooks/sync-sources]
-    H --> I[POST /api/hooks/upgrade]
-    F --> J[ReadyStackGo pulls & restarts]
-    I --> J
+    D --> E["POST /api/hooks/redeploy"]
+    E --> F[ReadyStackGo pullt & startet neu]
 ```
+
+### Formales Release: Sync + Upgrade
+
+```mermaid
+flowchart LR
+    A[Release Tag] --> B[CI Build]
+    B --> C[Docker Image + Manifest Update]
+    C --> D[Push to Registry + Git]
+    D --> E["POST /api/hooks/sync-sources"]
+    E --> F["POST /api/hooks/upgrade"]
+    F --> G[ReadyStackGo upgraded Stack]
+```
+
+## Fehlerbehandlung
+
+| HTTP Status | Bedeutung |
+|-------------|-----------|
+| 200 | Erfolg |
+| 400 | Ungültige Anfrage (Stack nicht gefunden, ungültige Version, etc.) |
+| 401 | Nicht authentifiziert (fehlender oder ungültiger API Key) |
+| 403 | Nicht autorisiert (API Key hat nicht die benötigte Permission) |
+| 500 | Server-Fehler bei der Katalog-Synchronisation |
+
+## Sicherheit
+
+- API Keys werden als SHA-256 Hash in der Datenbank gespeichert
+- Keys haben das Format `rsgo_` + 32 alphanumerische Zeichen (~190 Bit Entropie)
+- Keys können jederzeit widerrufen werden (Settings → CI/CD → Revoke)
+- Webhook-Endpoints sind nur über API Keys erreichbar, nicht über JWT
+- Optional: Environment-Scope beschränkt den Key auf ein bestimmtes Environment

--- a/docs/Plans/PLAN-cicd-integration.md
+++ b/docs/Plans/PLAN-cicd-integration.md
@@ -157,10 +157,11 @@ Reihenfolge basierend auf Abhängigkeiten:
   - Branch: `feature/cicd-sync-webhook`
   - Abhängig von: Feature 3
 
-- [ ] **Dokumentation & Website**
-  - `docs/CI-CD/Pipeline-Integration.md` aktualisieren: API Key Erstellung, Redeploy/Upgrade/Sync Workflows
+- [x] **Dokumentation & Website**
+  - `docs/CI-CD/Pipeline-Integration.md` aktualisiert: API Key Erstellung, Redeploy/Upgrade/Sync Workflows
   - `docs/CI-CD/Pipeline-Examples.md` neu: GitHub Actions + Azure DevOps + curl Beispiele
-  - Roadmap v0.19 als Released markieren
+  - Public Website Docs (DE/EN): `ci-cd-integration.md`
+  - Roadmap v0.19 als Released markiert
 
 - [ ] **Phase abschließen** – Alle Tests grün, PR gegen main
 

--- a/docs/Reference/Roadmap.md
+++ b/docs/Reference/Roadmap.md
@@ -136,14 +136,16 @@ Rough outlook on planned versions and features.
   - Real-time Init Container Log Streaming via SignalR
   - Init Containers Excluded from Health Monitoring
   - Automatic Init Container Cleanup After Successful Init Phase
-
-### v0.19 – CI/CD Integration
-- API Key Authentication for Pipeline Access
-- Deploy Webhook (`POST /api/hooks/deploy`) for Automated Deployments
-- Upgrade Webhook (`POST /api/hooks/upgrade`) for Automated Upgrades
-- Webhook Secret Token Validation (HMAC-SHA256)
-- API Key Management UI in Settings
-- Pipeline Examples (Azure DevOps, GitHub Actions)
+- **v0.19** – CI/CD Integration (2026-02-11)
+  - API Key Domain Model with SHA-256 Hashed Key Storage
+  - API Key Authentication Handler with Multi-Scheme Auth (PolicyScheme)
+  - API Key Management CRUD Endpoints and Settings UI
+  - Redeploy Webhook (`POST /api/hooks/redeploy`) for Fresh Image Deployments
+  - Upgrade Webhook (`POST /api/hooks/upgrade`) with Catalog Version Resolution
+  - Catalog Sync Webhook (`POST /api/hooks/sync-sources`)
+  - Fine-grained Permission System per API Key (Redeploy, Upgrade, SyncSources)
+  - Optional Environment-Scope for API Keys
+  - Pipeline Examples for curl, GitHub Actions, and Azure DevOps
 
 ### v0.20 – Docker Volumes Management
 - Docker Volumes View (List All Volumes per Environment)

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/ci-cd-integration.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/ci-cd-integration.md
@@ -1,0 +1,180 @@
+---
+title: CI/CD Integration
+description: Automatisierte Deployments über API Keys und Webhooks in CI/CD Pipelines
+---
+
+ReadyStackGo lässt sich in automatisierte Build- und Release-Prozesse integrieren. Über **API Keys** und **Webhook-Endpoints** können CI/CD Pipelines Deployments auslösen, Upgrades durchführen und den Stack-Katalog synchronisieren.
+
+## Übersicht
+
+| Use Case | Webhook | Beschreibung |
+|----------|---------|--------------|
+| **Dev/Test** | `/api/hooks/redeploy` | Nach jedem Build automatisch den Stack redeployen (frische Images) |
+| **Release** | `/api/hooks/upgrade` | Auf eine neue Katalog-Version upgraden |
+| **Katalog-Sync** | `/api/hooks/sync-sources` | Nach Manifest-Änderungen den Katalog aktualisieren |
+
+---
+
+## API Key erstellen
+
+Pipeline-Zugriff erfolgt über **API Keys** statt JWT Tokens.
+
+1. Navigiere zu **Settings → CI/CD Integration**
+2. Klicke **Create API Key**
+3. Vergib einen beschreibenden Namen (z.B. "GitHub Actions Deploy")
+4. Wähle die benötigten Permissions:
+   - **Redeploy** – Stack mit frischen Images neu starten
+   - **Upgrade** – Stack auf neue Katalog-Version upgraden
+   - **Sync Sources** – Katalog-Quellen synchronisieren
+5. Optional: Ablaufdatum und Environment-Scope setzen
+6. **Kopiere den Key sofort** – er wird nur einmal angezeigt!
+
+### Environment-Scope
+
+Wird ein API Key mit einem bestimmten Environment verknüpft, muss die `environmentId` nicht in jedem Request mitgesendet werden – sie wird automatisch aus dem Key ermittelt.
+
+---
+
+## Webhook-Endpoints
+
+Alle Endpoints befinden sich unter `/api/hooks/` und erfordern API Key Authentifizierung via `X-Api-Key` Header.
+
+### Redeploy
+
+`POST /api/hooks/redeploy` – Triggert ein Redeployment eines laufenden Stacks mit frischen Images.
+
+**Request:**
+```json
+{
+  "stackName": "ams-project",
+  "environmentId": "optional-wenn-key-environment-gebunden"
+}
+```
+
+**Response (200):**
+```json
+{
+  "success": true,
+  "message": "Successfully triggered redeploy of 'ams-project'.",
+  "deploymentId": "d4f8b2...",
+  "stackName": "ams-project",
+  "stackVersion": "6.4.0"
+}
+```
+
+**Permission:** `Hooks.Redeploy`
+
+### Upgrade
+
+`POST /api/hooks/upgrade` – Upgradet einen Stack auf eine bestimmte Katalog-Version.
+
+**Request:**
+```json
+{
+  "stackName": "ams-project",
+  "targetVersion": "6.5.0",
+  "environmentId": "optional",
+  "variables": {
+    "NEW_SETTING": "value"
+  }
+}
+```
+
+**Response (200):**
+```json
+{
+  "success": true,
+  "message": "Successfully upgraded 'ams-project' from 6.4.0 to 6.5.0.",
+  "deploymentId": "d4f8b2...",
+  "previousVersion": "6.4.0",
+  "newVersion": "6.5.0"
+}
+```
+
+**Permission:** `Hooks.Upgrade`
+
+### Katalog synchronisieren
+
+`POST /api/hooks/sync-sources` – Synchronisiert alle Stack-Katalog-Quellen.
+
+**Request:** Kein Body erforderlich.
+
+**Response (200):**
+```json
+{
+  "success": true,
+  "stacksLoaded": 12,
+  "sourcesSynced": 3,
+  "message": "Synced 3 source(s), loaded 12 stack(s)."
+}
+```
+
+**Permission:** `Hooks.SyncSources`
+
+---
+
+## Fehlerbehandlung
+
+| HTTP Status | Bedeutung |
+|-------------|-----------|
+| 200 | Erfolg |
+| 400 | Ungültige Anfrage (Stack nicht gefunden, ungültige Version, etc.) |
+| 401 | Nicht authentifiziert (fehlender oder ungültiger API Key) |
+| 403 | Nicht autorisiert (API Key hat nicht die benötigte Permission) |
+| 500 | Server-Fehler |
+
+---
+
+## Pipeline-Beispiele
+
+### curl
+
+```bash
+# Redeploy (frische Images)
+curl -X POST https://rsgo.example.com/api/hooks/redeploy \
+  -H "X-Api-Key: rsgo_a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6" \
+  -H "Content-Type: application/json" \
+  -d '{"stackName": "ams-project"}'
+
+# Katalog synchronisieren
+curl -X POST https://rsgo.example.com/api/hooks/sync-sources \
+  -H "X-Api-Key: rsgo_..."
+
+# Upgrade
+curl -X POST https://rsgo.example.com/api/hooks/upgrade \
+  -H "X-Api-Key: rsgo_..." \
+  -H "Content-Type: application/json" \
+  -d '{"stackName": "ams-project", "targetVersion": "6.5.0"}'
+```
+
+### GitHub Actions
+
+```yaml
+- name: Trigger Redeploy
+  run: |
+    curl -sf -X POST "${{ secrets.RSGO_URL }}/api/hooks/redeploy" \
+      -H "X-Api-Key: ${{ secrets.RSGO_API_KEY }}" \
+      -H "Content-Type: application/json" \
+      -d '{"stackName": "${{ vars.STACK_NAME }}"}'
+```
+
+### Azure DevOps
+
+```yaml
+- script: |
+    curl -sf -X POST "$(RSGO_URL)/api/hooks/redeploy" \
+      -H "X-Api-Key: $(RSGO_API_KEY)" \
+      -H "Content-Type: application/json" \
+      -d '{"stackName": "$(STACK_NAME)"}'
+  displayName: Trigger Redeploy on ReadyStackGo
+```
+
+---
+
+## Sicherheit
+
+- API Keys werden als **SHA-256 Hash** in der Datenbank gespeichert
+- Keys haben das Format `rsgo_` + 32 alphanumerische Zeichen (~190 Bit Entropie)
+- Keys können jederzeit widerrufen werden (Settings → CI/CD → Revoke)
+- Optional: Environment-Scope beschränkt den Key auf ein bestimmtes Environment
+- Ablaufdatum kann pro Key konfiguriert werden

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/index.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/index.md
@@ -10,3 +10,4 @@ Hier finden Sie detaillierte Anleitungen zur Nutzung von ReadyStackGo.
 - [Stack Deployment](/de/docs/stack-deployment/) - Schritt-für-Schritt Anleitung zum Deployen eines Stacks
 - [Stack Upgrade](/de/docs/stack-upgrade/) - Stacks auf neue Versionen aktualisieren
 - [Registry Management](/de/docs/registry-management/) - Docker Registries verwalten und Image Patterns konfigurieren
+- [CI/CD Integration](/de/docs/ci-cd-integration/) - Automatisierte Deployments über API Keys und Webhooks

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/ci-cd-integration.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/ci-cd-integration.md
@@ -1,0 +1,180 @@
+---
+title: CI/CD Integration
+description: Automated deployments via API keys and webhooks in CI/CD pipelines
+---
+
+ReadyStackGo integrates with automated build and release processes. Using **API Keys** and **Webhook Endpoints**, CI/CD pipelines can trigger deployments, perform upgrades, and synchronize the stack catalog.
+
+## Overview
+
+| Use Case | Webhook | Description |
+|----------|---------|-------------|
+| **Dev/Test** | `/api/hooks/redeploy` | Automatically redeploy the stack after every build (fresh images) |
+| **Release** | `/api/hooks/upgrade` | Upgrade to a new catalog version |
+| **Catalog Sync** | `/api/hooks/sync-sources` | Update the catalog after manifest changes |
+
+---
+
+## Creating an API Key
+
+Pipeline access uses **API Keys** instead of JWT tokens.
+
+1. Navigate to **Settings → CI/CD Integration**
+2. Click **Create API Key**
+3. Choose a descriptive name (e.g., "GitHub Actions Deploy")
+4. Select the required permissions:
+   - **Redeploy** – Restart the stack with fresh images
+   - **Upgrade** – Upgrade the stack to a new catalog version
+   - **Sync Sources** – Synchronize catalog sources
+5. Optional: Set an expiration date and environment scope
+6. **Copy the key immediately** – it will only be shown once!
+
+### Environment Scope
+
+When an API Key is linked to a specific environment, the `environmentId` does not need to be included in every request – it is automatically resolved from the key.
+
+---
+
+## Webhook Endpoints
+
+All endpoints are located under `/api/hooks/` and require API Key authentication via the `X-Api-Key` header.
+
+### Redeploy
+
+`POST /api/hooks/redeploy` – Triggers a redeployment of a running stack with fresh images.
+
+**Request:**
+```json
+{
+  "stackName": "ams-project",
+  "environmentId": "optional-if-key-is-environment-scoped"
+}
+```
+
+**Response (200):**
+```json
+{
+  "success": true,
+  "message": "Successfully triggered redeploy of 'ams-project'.",
+  "deploymentId": "d4f8b2...",
+  "stackName": "ams-project",
+  "stackVersion": "6.4.0"
+}
+```
+
+**Permission:** `Hooks.Redeploy`
+
+### Upgrade
+
+`POST /api/hooks/upgrade` – Upgrades a stack to a specific catalog version.
+
+**Request:**
+```json
+{
+  "stackName": "ams-project",
+  "targetVersion": "6.5.0",
+  "environmentId": "optional",
+  "variables": {
+    "NEW_SETTING": "value"
+  }
+}
+```
+
+**Response (200):**
+```json
+{
+  "success": true,
+  "message": "Successfully upgraded 'ams-project' from 6.4.0 to 6.5.0.",
+  "deploymentId": "d4f8b2...",
+  "previousVersion": "6.4.0",
+  "newVersion": "6.5.0"
+}
+```
+
+**Permission:** `Hooks.Upgrade`
+
+### Sync Catalog Sources
+
+`POST /api/hooks/sync-sources` – Synchronizes all stack catalog sources.
+
+**Request:** No body required.
+
+**Response (200):**
+```json
+{
+  "success": true,
+  "stacksLoaded": 12,
+  "sourcesSynced": 3,
+  "message": "Synced 3 source(s), loaded 12 stack(s)."
+}
+```
+
+**Permission:** `Hooks.SyncSources`
+
+---
+
+## Error Handling
+
+| HTTP Status | Meaning |
+|-------------|---------|
+| 200 | Success |
+| 400 | Invalid request (stack not found, invalid version, etc.) |
+| 401 | Not authenticated (missing or invalid API key) |
+| 403 | Not authorized (API key lacks the required permission) |
+| 500 | Server error |
+
+---
+
+## Pipeline Examples
+
+### curl
+
+```bash
+# Redeploy (fresh images)
+curl -X POST https://rsgo.example.com/api/hooks/redeploy \
+  -H "X-Api-Key: rsgo_a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6" \
+  -H "Content-Type: application/json" \
+  -d '{"stackName": "ams-project"}'
+
+# Sync catalog sources
+curl -X POST https://rsgo.example.com/api/hooks/sync-sources \
+  -H "X-Api-Key: rsgo_..."
+
+# Upgrade
+curl -X POST https://rsgo.example.com/api/hooks/upgrade \
+  -H "X-Api-Key: rsgo_..." \
+  -H "Content-Type: application/json" \
+  -d '{"stackName": "ams-project", "targetVersion": "6.5.0"}'
+```
+
+### GitHub Actions
+
+```yaml
+- name: Trigger Redeploy
+  run: |
+    curl -sf -X POST "${{ secrets.RSGO_URL }}/api/hooks/redeploy" \
+      -H "X-Api-Key: ${{ secrets.RSGO_API_KEY }}" \
+      -H "Content-Type: application/json" \
+      -d '{"stackName": "${{ vars.STACK_NAME }}"}'
+```
+
+### Azure DevOps
+
+```yaml
+- script: |
+    curl -sf -X POST "$(RSGO_URL)/api/hooks/redeploy" \
+      -H "X-Api-Key: $(RSGO_API_KEY)" \
+      -H "Content-Type: application/json" \
+      -d '{"stackName": "$(STACK_NAME)"}'
+  displayName: Trigger Redeploy on ReadyStackGo
+```
+
+---
+
+## Security
+
+- API Keys are stored as **SHA-256 hashes** in the database
+- Keys use the format `rsgo_` + 32 alphanumeric characters (~190 bits of entropy)
+- Keys can be revoked at any time (Settings → CI/CD → Revoke)
+- Optional: Environment scope restricts the key to a specific environment
+- Expiration date can be configured per key

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/index.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/index.md
@@ -10,3 +10,4 @@ Here you'll find detailed guides for using ReadyStackGo.
 - [Stack Deployment](/en/docs/stack-deployment/) - Step-by-step guide to deploying a stack
 - [Stack Upgrade](/en/docs/stack-upgrade/) - Upgrade stacks to new versions
 - [Registry Management](/en/docs/registry-management/) - Manage Docker Registries and configure Image Patterns
+- [CI/CD Integration](/en/docs/ci-cd-integration/) - Automated deployments via API keys and webhooks


### PR DESCRIPTION
## Summary
- Comprehensive CI/CD Pipeline-Integration docs with API key creation guide, all webhook endpoints (redeploy, upgrade, sync-sources), request/response examples, error handling, and security notes
- Pipeline-Examples.md with curl, GitHub Actions, and Azure DevOps examples for both redeploy and sync+upgrade workflows
- Public website documentation pages in German and English
- Roadmap updated: v0.19 CI/CD Integration moved to Released section with actual feature list

## Test plan
- [ ] Verify internal docs render correctly
- [ ] Verify public website builds with new pages (`npm run build` in PublicWeb)
- [ ] Check DE/EN index pages link to new CI/CD doc