### PR TITLE
Add idempotent deploy hook and fix variable defaults

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/Hooks/DeployEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Hooks/DeployEndpoint.cs
@@ -1,0 +1,50 @@
+using FastEndpoints;
+using MediatR;
+using ReadyStackGo.Api.Authorization;
+using ReadyStackGo.Application.UseCases.Hooks.DeployStack;
+using ReadyStackGo.Infrastructure.Security.Authentication;
+
+namespace ReadyStackGo.Api.Endpoints.Hooks;
+
+[RequirePermission("Hooks", "Deploy")]
+public class DeployEndpoint : Endpoint<DeployViaHookRequest, DeployViaHookResponse>
+{
+    private readonly IMediator _mediator;
+
+    public DeployEndpoint(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Post("/api/hooks/deploy");
+        PreProcessor<RbacPreProcessor<DeployViaHookRequest>>();
+    }
+
+    public override async Task HandleAsync(DeployViaHookRequest req, CancellationToken ct)
+    {
+        // Resolve EnvironmentId: from request body, or fallback to API Key's env_id claim
+        var environmentId = req.EnvironmentId;
+
+        if (string.IsNullOrEmpty(environmentId))
+        {
+            environmentId = HttpContext.User.FindFirst(RbacClaimTypes.EnvironmentId)?.Value;
+        }
+
+        if (string.IsNullOrEmpty(environmentId))
+        {
+            ThrowError("EnvironmentId is required. Provide it in the request body or use an environment-scoped API key.");
+        }
+
+        var response = await _mediator.Send(
+            new DeployViaHookCommand(req.StackId, req.StackName, environmentId!, req.Variables), ct);
+
+        if (!response.Success)
+        {
+            HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+        }
+
+        Response = response;
+    }
+}

--- a/src/ReadyStackGo.Application/UseCases/Hooks/DeployStack/DeployViaHookCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Hooks/DeployStack/DeployViaHookCommand.cs
@@ -1,0 +1,138 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using ReadyStackGo.Application.UseCases.Deployments.DeployStack;
+using ReadyStackGo.Domain.Deployment.Deployments;
+using ReadyStackGo.Domain.Deployment.Environments;
+
+namespace ReadyStackGo.Application.UseCases.Hooks.DeployStack;
+
+public record DeployViaHookRequest
+{
+    public required string StackId { get; init; }
+    public required string StackName { get; init; }
+    public string? EnvironmentId { get; init; }
+    public Dictionary<string, string> Variables { get; init; } = new();
+}
+
+public record DeployViaHookResponse
+{
+    public bool Success { get; init; }
+    public string? Message { get; init; }
+    public string? DeploymentId { get; init; }
+    public string? StackName { get; init; }
+    public string? StackVersion { get; init; }
+    public string? Action { get; init; }
+
+    public static DeployViaHookResponse Failed(string message) =>
+        new() { Success = false, Message = message };
+}
+
+public record DeployViaHookCommand(
+    string StackId,
+    string StackName,
+    string EnvironmentId,
+    Dictionary<string, string> Variables
+) : IRequest<DeployViaHookResponse>;
+
+public class DeployViaHookHandler : IRequestHandler<DeployViaHookCommand, DeployViaHookResponse>
+{
+    private readonly IDeploymentRepository _deploymentRepository;
+    private readonly IMediator _mediator;
+    private readonly ILogger<DeployViaHookHandler> _logger;
+
+    public DeployViaHookHandler(
+        IDeploymentRepository deploymentRepository,
+        IMediator mediator,
+        ILogger<DeployViaHookHandler> logger)
+    {
+        _deploymentRepository = deploymentRepository;
+        _mediator = mediator;
+        _logger = logger;
+    }
+
+    public async Task<DeployViaHookResponse> Handle(DeployViaHookCommand request, CancellationToken cancellationToken)
+    {
+        // 1. Validate inputs
+        if (string.IsNullOrWhiteSpace(request.StackId))
+        {
+            return DeployViaHookResponse.Failed("StackId is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.StackName))
+        {
+            return DeployViaHookResponse.Failed("StackName is required.");
+        }
+
+        if (!Guid.TryParse(request.EnvironmentId, out var envGuid))
+        {
+            return DeployViaHookResponse.Failed("Invalid environment ID format.");
+        }
+
+        var environmentId = new EnvironmentId(envGuid);
+
+        // 2. Check for existing deployment (idempotent behavior)
+        var existing = _deploymentRepository.GetByStackName(environmentId, request.StackName);
+        string action;
+        string stackId;
+
+        if (existing != null)
+        {
+            // Stack already deployed — redeploy if running, error otherwise
+            if (existing.Status != DeploymentStatus.Running)
+            {
+                return DeployViaHookResponse.Failed(
+                    $"Stack '{request.StackName}' exists but is not running (status: {existing.Status}). " +
+                    "Only running deployments can be redeployed.");
+            }
+
+            var (existingStackId, _, _) = existing.GetRedeploymentData();
+            stackId = existingStackId;
+            action = "redeployed";
+
+            _logger.LogInformation(
+                "Stack '{StackName}' already running in environment {EnvironmentId}, triggering redeploy",
+                request.StackName, request.EnvironmentId);
+        }
+        else
+        {
+            // Fresh deploy
+            stackId = request.StackId;
+            action = "deployed";
+
+            _logger.LogInformation(
+                "Deploying stack '{StackName}' ({StackId}) to environment {EnvironmentId}",
+                request.StackName, request.StackId, request.EnvironmentId);
+        }
+
+        // 3. Delegate to DeployStackCommand
+        var deployResult = await _mediator.Send(new DeployStackCommand(
+            request.EnvironmentId,
+            stackId,
+            request.StackName,
+            request.Variables,
+            null), cancellationToken);
+
+        if (!deployResult.Success)
+        {
+            _logger.LogWarning(
+                "Deploy of stack '{StackName}' failed: {Message}",
+                request.StackName, deployResult.Message);
+
+            return DeployViaHookResponse.Failed(deployResult.Message ?? "Deploy failed.");
+        }
+
+        _logger.LogInformation(
+            "Successfully {Action} stack '{StackName}' (version {Version})",
+            action, request.StackName, deployResult.StackVersion);
+
+        return new DeployViaHookResponse
+        {
+            Success = true,
+            Message = $"Successfully {action} '{request.StackName}'.",
+            DeploymentId = deployResult.DeploymentId,
+            StackName = request.StackName,
+            StackVersion = deployResult.StackVersion,
+            Action = action
+        };
+    }
+}

--- a/src/ReadyStackGo.Domain/IdentityAccess/Roles/Permission.cs
+++ b/src/ReadyStackGo.Domain/IdentityAccess/Roles/Permission.cs
@@ -96,6 +96,7 @@ public sealed class Permission : ValueObject
 
     public static class Hooks
     {
+        public static Permission Deploy => new("Hooks", "Deploy");
         public static Permission Redeploy => new("Hooks", "Redeploy");
         public static Permission Upgrade => new("Hooks", "Upgrade");
         public static Permission SyncSources => new("Hooks", "SyncSources");

--- a/src/ReadyStackGo.Domain/StackManagement/Manifests/RsgoVariable.cs
+++ b/src/ReadyStackGo.Domain/StackManagement/Manifests/RsgoVariable.cs
@@ -27,8 +27,9 @@ public class RsgoVariable
 
     /// <summary>
     /// Whether the variable is required.
+    /// Null means "not explicitly set" — Variable constructor infers from default value.
     /// </summary>
-    public bool Required { get; set; } = false;
+    public bool? Required { get; set; }
 
     /// <summary>
     /// Regex pattern for validation (only for String type).

--- a/tests/ReadyStackGo.IntegrationTests/DeployEndpointIntegrationTests.cs
+++ b/tests/ReadyStackGo.IntegrationTests/DeployEndpointIntegrationTests.cs
@@ -1,0 +1,191 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using ReadyStackGo.IntegrationTests.Infrastructure;
+using Xunit;
+
+namespace ReadyStackGo.IntegrationTests;
+
+/// <summary>
+/// Integration tests for the Deploy Webhook Endpoint (idempotent deploy/redeploy).
+/// Tests authentication, authorization, and request validation.
+/// </summary>
+public class DeployEndpointIntegrationTests : AuthenticatedTestBase
+{
+    #region Authentication
+
+    [Fact]
+    public async Task POST_Deploy_WithoutAuth_ReturnsUnauthorized()
+    {
+        using var unauthenticatedClient = CreateUnauthenticatedClient();
+
+        var request = new
+        {
+            stackId = "source:product:stack",
+            stackName = "my-stack",
+            environmentId = Guid.NewGuid().ToString()
+        };
+        var response = await unauthenticatedClient.PostAsJsonAsync("/api/hooks/deploy", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task POST_Deploy_WithJwtAuth_IsAllowed()
+    {
+        // JWT-authenticated admin has all permissions including Hooks.Deploy
+        var request = new
+        {
+            stackId = "source:product:stack",
+            stackName = "nonexistent-stack",
+            environmentId = EnvironmentId
+        };
+        var response = await Client.PostAsJsonAsync("/api/hooks/deploy", request);
+
+        // Should reach the handler (not 401/403) — will fail during actual deployment
+        // but the point is it gets past auth
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden);
+    }
+
+    #endregion
+
+    #region Validation
+
+    [Fact]
+    public async Task POST_Deploy_InvalidEnvironmentId_ReturnsBadRequest()
+    {
+        var request = new
+        {
+            stackId = "source:product:stack",
+            stackName = "my-stack",
+            environmentId = "not-a-guid"
+        };
+        var response = await Client.PostAsJsonAsync("/api/hooks/deploy", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("Invalid environment ID");
+    }
+
+    [Fact]
+    public async Task POST_Deploy_EmptyStackId_ReturnsBadRequest()
+    {
+        var request = new
+        {
+            stackId = "",
+            stackName = "my-stack",
+            environmentId = EnvironmentId
+        };
+        var response = await Client.PostAsJsonAsync("/api/hooks/deploy", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("StackId is required");
+    }
+
+    [Fact]
+    public async Task POST_Deploy_EmptyStackName_ReturnsBadRequest()
+    {
+        var request = new
+        {
+            stackId = "source:product:stack",
+            stackName = "",
+            environmentId = EnvironmentId
+        };
+        var response = await Client.PostAsJsonAsync("/api/hooks/deploy", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+        var body = await response.Content.ReadAsStringAsync();
+        body.Should().Contain("StackName is required");
+    }
+
+    [Fact]
+    public async Task POST_Deploy_WithoutEnvironmentId_ReturnsError()
+    {
+        var request = new
+        {
+            stackId = "source:product:stack",
+            stackName = "my-stack"
+        };
+        var response = await Client.PostAsJsonAsync("/api/hooks/deploy", request);
+
+        // Should fail because no environmentId and no env_id claim in JWT
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.BadRequest, HttpStatusCode.InternalServerError);
+    }
+
+    #endregion
+
+    #region API Key Authentication
+
+    [Fact]
+    public async Task POST_Deploy_WithApiKey_IsAllowed()
+    {
+        // Create an API key with Hooks.Deploy permission
+        var createKeyRequest = new
+        {
+            name = "Deploy Test Key",
+            permissions = new[] { "Hooks.Deploy" }
+        };
+        var createResponse = await Client.PostAsJsonAsync("/api/api-keys", createKeyRequest);
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var keyResult = await createResponse.Content.ReadFromJsonAsync<CreateApiKeyResponse>();
+        var apiKey = keyResult!.ApiKey!.FullKey;
+
+        // Use the API key to call the deploy endpoint
+        using var apiKeyClient = CreateUnauthenticatedClient();
+        apiKeyClient.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
+
+        var request = new
+        {
+            stackId = "source:product:stack",
+            stackName = "test-stack",
+            environmentId = EnvironmentId
+        };
+        var response = await apiKeyClient.PostAsJsonAsync("/api/hooks/deploy", request);
+
+        // Should reach handler (not 401/403)
+        response.StatusCode.Should().NotBe(HttpStatusCode.Unauthorized);
+        response.StatusCode.Should().NotBe(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task POST_Deploy_WithApiKeyWithoutDeployPermission_ReturnsForbidden()
+    {
+        // Create an API key with only SyncSources permission (not Deploy)
+        var createKeyRequest = new
+        {
+            name = "Sync Only Key",
+            permissions = new[] { "Hooks.SyncSources" }
+        };
+        var createResponse = await Client.PostAsJsonAsync("/api/api-keys", createKeyRequest);
+        createResponse.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var keyResult = await createResponse.Content.ReadFromJsonAsync<CreateApiKeyResponse>();
+        var apiKey = keyResult!.ApiKey!.FullKey;
+
+        // Use the API key — should be forbidden since it lacks Hooks.Deploy
+        using var apiKeyClient = CreateUnauthenticatedClient();
+        apiKeyClient.DefaultRequestHeaders.Add("X-Api-Key", apiKey);
+
+        var request = new
+        {
+            stackId = "source:product:stack",
+            stackName = "test-stack",
+            environmentId = EnvironmentId
+        };
+        var response = await apiKeyClient.PostAsJsonAsync("/api/hooks/deploy", request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    #endregion
+
+    #region DTOs
+
+    private record CreateApiKeyResponse(bool Success, string? Message, ApiKeyCreatedDto? ApiKey = null);
+    private record ApiKeyCreatedDto(string Id, string Name, string KeyPrefix, string FullKey);
+
+    #endregion
+}

--- a/tests/ReadyStackGo.UnitTests/Application/Hooks/DeployViaHookHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Hooks/DeployViaHookHandlerTests.cs
@@ -1,0 +1,475 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ReadyStackGo.Application.UseCases.Deployments.DeployStack;
+using ReadyStackGo.Application.UseCases.Hooks.DeployStack;
+using ReadyStackGo.Domain.Deployment;
+using ReadyStackGo.Domain.Deployment.Deployments;
+using ReadyStackGo.Domain.Deployment.Environments;
+
+namespace ReadyStackGo.UnitTests.Application.Hooks;
+
+public class DeployViaHookHandlerTests
+{
+    private readonly Mock<IDeploymentRepository> _deploymentRepoMock;
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<ILogger<DeployViaHookHandler>> _loggerMock;
+    private readonly DeployViaHookHandler _handler;
+
+    private static readonly string TestEnvironmentId = Guid.NewGuid().ToString();
+    private static readonly string TestStackId = "source1:product1:my-stack";
+    private const string TestStackName = "my-stack";
+
+    public DeployViaHookHandlerTests()
+    {
+        _deploymentRepoMock = new Mock<IDeploymentRepository>();
+        _mediatorMock = new Mock<IMediator>();
+        _loggerMock = new Mock<ILogger<DeployViaHookHandler>>();
+        _handler = new DeployViaHookHandler(
+            _deploymentRepoMock.Object,
+            _mediatorMock.Object,
+            _loggerMock.Object);
+    }
+
+    private static Deployment CreateRunningDeployment(
+        string stackName = TestStackName,
+        string? stackId = null,
+        string? environmentId = null,
+        Dictionary<string, string>? variables = null)
+    {
+        var envId = new EnvironmentId(Guid.Parse(environmentId ?? TestEnvironmentId));
+        var deployment = Deployment.StartInstallation(
+            DeploymentId.Create(),
+            envId,
+            stackId ?? TestStackId,
+            stackName,
+            $"rsgo-{stackName}",
+            UserId.Create());
+
+        if (variables != null)
+        {
+            deployment.SetVariables(variables);
+        }
+
+        deployment.MarkAsRunning();
+        return deployment;
+    }
+
+    #region Fresh Deploy (No Existing Deployment)
+
+    [Fact]
+    public async Task Handle_NoExistingDeployment_ReturnsSuccessWithDeployedAction()
+    {
+        SetupNoExistingDeployment();
+        SetupSuccessfulDeploy();
+
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(TestStackId, TestStackName, TestEnvironmentId, new()),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Action.Should().Be("deployed");
+        result.StackName.Should().Be(TestStackName);
+        result.Message.Should().Contain("deployed");
+    }
+
+    [Fact]
+    public async Task Handle_NoExistingDeployment_DelegatesToDeployStackCommand()
+    {
+        var variables = new Dictionary<string, string>
+        {
+            ["DB_HOST"] = "localhost",
+            ["DB_PORT"] = "5432"
+        };
+        SetupNoExistingDeployment();
+        SetupSuccessfulDeploy();
+
+        await _handler.Handle(
+            new DeployViaHookCommand(TestStackId, TestStackName, TestEnvironmentId, variables),
+            CancellationToken.None);
+
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<DeployStackCommand>(cmd =>
+                cmd.EnvironmentId == TestEnvironmentId &&
+                cmd.StackId == TestStackId &&
+                cmd.StackName == TestStackName &&
+                cmd.Variables["DB_HOST"] == "localhost" &&
+                cmd.Variables["DB_PORT"] == "5432" &&
+                cmd.SessionId == null),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NoExistingDeployment_ReturnsDeploymentIdFromResult()
+    {
+        SetupNoExistingDeployment();
+
+        var expectedDeploymentId = Guid.NewGuid().ToString();
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<DeployStackCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeployStackResponse
+            {
+                Success = true,
+                DeploymentId = expectedDeploymentId,
+                StackVersion = "1.0.0"
+            });
+
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(TestStackId, TestStackName, TestEnvironmentId, new()),
+            CancellationToken.None);
+
+        result.DeploymentId.Should().Be(expectedDeploymentId);
+        result.StackVersion.Should().Be("1.0.0");
+    }
+
+    [Fact]
+    public async Task Handle_FreshDeploy_AlwaysSendsNullSessionId()
+    {
+        SetupNoExistingDeployment();
+        SetupSuccessfulDeploy();
+
+        await _handler.Handle(
+            new DeployViaHookCommand(TestStackId, TestStackName, TestEnvironmentId, new()),
+            CancellationToken.None);
+
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<DeployStackCommand>(cmd => cmd.SessionId == null),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    #endregion
+
+    #region Idempotent Redeploy (Existing Running Deployment)
+
+    [Fact]
+    public async Task Handle_ExistingRunningDeployment_ReturnsSuccessWithRedeployedAction()
+    {
+        var deployment = CreateRunningDeployment();
+        SetupDeploymentLookup(deployment);
+        SetupSuccessfulDeploy();
+
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(TestStackId, TestStackName, TestEnvironmentId, new()),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Action.Should().Be("redeployed");
+        result.StackName.Should().Be(TestStackName);
+        result.Message.Should().Contain("redeployed");
+    }
+
+    [Fact]
+    public async Task Handle_ExistingRunningDeployment_UsesExistingStackId()
+    {
+        var existingStackId = "existing-source:existing-product:my-stack";
+        var deployment = CreateRunningDeployment(stackId: existingStackId);
+        SetupDeploymentLookup(deployment);
+        SetupSuccessfulDeploy();
+
+        await _handler.Handle(
+            new DeployViaHookCommand("different-stack-id", TestStackName, TestEnvironmentId, new()),
+            CancellationToken.None);
+
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<DeployStackCommand>(cmd => cmd.StackId == existingStackId),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ExistingRunningDeployment_UsesRequestVariables()
+    {
+        var existingVariables = new Dictionary<string, string>
+        {
+            ["OLD_VAR"] = "old-value"
+        };
+        var deployment = CreateRunningDeployment(variables: existingVariables);
+        SetupDeploymentLookup(deployment);
+        SetupSuccessfulDeploy();
+
+        var requestVariables = new Dictionary<string, string>
+        {
+            ["NEW_VAR"] = "new-value"
+        };
+
+        await _handler.Handle(
+            new DeployViaHookCommand(TestStackId, TestStackName, TestEnvironmentId, requestVariables),
+            CancellationToken.None);
+
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<DeployStackCommand>(cmd =>
+                cmd.Variables.ContainsKey("NEW_VAR") &&
+                cmd.Variables["NEW_VAR"] == "new-value"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ExistingRunningDeployment_ReturnsVersionFromDeployResult()
+    {
+        var deployment = CreateRunningDeployment();
+        SetupDeploymentLookup(deployment);
+
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<DeployStackCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeployStackResponse
+            {
+                Success = true,
+                DeploymentId = Guid.NewGuid().ToString(),
+                StackVersion = "3.0.0"
+            });
+
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(TestStackId, TestStackName, TestEnvironmentId, new()),
+            CancellationToken.None);
+
+        result.StackVersion.Should().Be("3.0.0");
+    }
+
+    #endregion
+
+    #region Existing Non-Running Deployment
+
+    [Fact]
+    public async Task Handle_FailedDeployment_ReturnsError()
+    {
+        var deployment = CreateFailedDeployment();
+        SetupDeploymentLookup(deployment);
+
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(TestStackId, TestStackName, TestEnvironmentId, new()),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Only running deployments");
+        result.Message.Should().Contain("Failed");
+    }
+
+    [Fact]
+    public async Task Handle_InstallingDeployment_ReturnsError()
+    {
+        var deployment = CreateInstallingDeployment();
+        SetupDeploymentLookup(deployment);
+
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(TestStackId, TestStackName, TestEnvironmentId, new()),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Only running deployments");
+        result.Message.Should().Contain("Installing");
+    }
+
+    [Fact]
+    public async Task Handle_RemovedDeployment_ReturnsError()
+    {
+        var deployment = CreateRemovedDeployment();
+        SetupDeploymentLookup(deployment);
+
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(TestStackId, TestStackName, TestEnvironmentId, new()),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Only running deployments");
+        result.Message.Should().Contain("Removed");
+    }
+
+    [Fact]
+    public async Task Handle_NonRunningDeployment_DoesNotDelegateToDeployCommand()
+    {
+        var deployment = CreateFailedDeployment();
+        SetupDeploymentLookup(deployment);
+
+        await _handler.Handle(
+            new DeployViaHookCommand(TestStackId, TestStackName, TestEnvironmentId, new()),
+            CancellationToken.None);
+
+        _mediatorMock.Verify(m => m.Send(
+            It.IsAny<DeployStackCommand>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    #endregion
+
+    #region Invalid Input
+
+    [Fact]
+    public async Task Handle_InvalidEnvironmentId_ReturnsError()
+    {
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(TestStackId, TestStackName, "not-a-guid", new()),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Invalid environment ID");
+    }
+
+    [Fact]
+    public async Task Handle_EmptyEnvironmentId_ReturnsError()
+    {
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(TestStackId, TestStackName, "", new()),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Invalid environment ID");
+    }
+
+    [Fact]
+    public async Task Handle_EmptyStackId_ReturnsError()
+    {
+        var result = await _handler.Handle(
+            new DeployViaHookCommand("", TestStackName, TestEnvironmentId, new()),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("StackId is required");
+    }
+
+    [Fact]
+    public async Task Handle_WhitespaceStackId_ReturnsError()
+    {
+        var result = await _handler.Handle(
+            new DeployViaHookCommand("   ", TestStackName, TestEnvironmentId, new()),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("StackId is required");
+    }
+
+    [Fact]
+    public async Task Handle_EmptyStackName_ReturnsError()
+    {
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(TestStackId, "", TestEnvironmentId, new()),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("StackName is required");
+    }
+
+    [Fact]
+    public async Task Handle_WhitespaceStackName_ReturnsError()
+    {
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(TestStackId, "   ", TestEnvironmentId, new()),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("StackName is required");
+    }
+
+    #endregion
+
+    #region Deploy Failure Propagation
+
+    [Fact]
+    public async Task Handle_DeployCommandFails_PropagatesError()
+    {
+        SetupNoExistingDeployment();
+
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<DeployStackCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DeployStackResponse.Failed("Image pull failed"));
+
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(TestStackId, TestStackName, TestEnvironmentId, new()),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Image pull failed");
+    }
+
+    [Fact]
+    public async Task Handle_DeployCommandFails_DoesNotReturnDeploymentId()
+    {
+        SetupNoExistingDeployment();
+
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<DeployStackCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DeployStackResponse.Failed("Connection refused"));
+
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(TestStackId, TestStackName, TestEnvironmentId, new()),
+            CancellationToken.None);
+
+        result.DeploymentId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_RedeployCommandFails_PropagatesError()
+    {
+        var deployment = CreateRunningDeployment();
+        SetupDeploymentLookup(deployment);
+
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<DeployStackCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DeployStackResponse.Failed("Container restart failed"));
+
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(TestStackId, TestStackName, TestEnvironmentId, new()),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Container restart failed");
+    }
+
+    #endregion
+
+    #region Helpers
+
+    private void SetupNoExistingDeployment()
+    {
+        _deploymentRepoMock
+            .Setup(r => r.GetByStackName(It.IsAny<EnvironmentId>(), It.IsAny<string>()))
+            .Returns((Deployment?)null);
+    }
+
+    private void SetupDeploymentLookup(Deployment deployment)
+    {
+        _deploymentRepoMock
+            .Setup(r => r.GetByStackName(
+                It.Is<EnvironmentId>(e => e.Value == Guid.Parse(TestEnvironmentId)),
+                It.Is<string>(s => s == deployment.StackName)))
+            .Returns(deployment);
+    }
+
+    private void SetupSuccessfulDeploy()
+    {
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<DeployStackCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeployStackResponse
+            {
+                Success = true,
+                DeploymentId = Guid.NewGuid().ToString()
+            });
+    }
+
+    private static Deployment CreateFailedDeployment()
+    {
+        var envId = new EnvironmentId(Guid.Parse(TestEnvironmentId));
+        var deployment = Deployment.StartInstallation(
+            DeploymentId.Create(), envId, TestStackId, TestStackName, $"rsgo-{TestStackName}", UserId.Create());
+        deployment.MarkAsFailed("Something went wrong");
+        return deployment;
+    }
+
+    private static Deployment CreateInstallingDeployment()
+    {
+        var envId = new EnvironmentId(Guid.Parse(TestEnvironmentId));
+        return Deployment.StartInstallation(
+            DeploymentId.Create(), envId, TestStackId, TestStackName, $"rsgo-{TestStackName}", UserId.Create());
+    }
+
+    private static Deployment CreateRemovedDeployment()
+    {
+        var envId = new EnvironmentId(Guid.Parse(TestEnvironmentId));
+        var deployment = Deployment.StartInstallation(
+            DeploymentId.Create(), envId, TestStackId, TestStackName, $"rsgo-{TestStackName}", UserId.Create());
+        deployment.MarkAsRunning();
+        deployment.MarkAsRemoved();
+        return deployment;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Add `POST /api/hooks/deploy` endpoint for CI/CD pipelines with idempotent behavior: deploys fresh if no deployment exists, redeploys if already running, errors on other states
- Fix `RsgoVariable.Required` type from `bool` to `bool?` so optional variables without explicit `required:` in YAML correctly infer `IsRequired` from the presence of a default value

## Changes
- **Permission**: `Hooks.Deploy` added to Permission.cs
- **Handler**: `DeployViaHookCommand` + `DeployViaHookHandler` with idempotent deploy logic
- **Endpoint**: `POST /api/hooks/deploy` with RBAC, environment ID fallback from API key claim
- **Bugfix**: `RsgoVariable.Required` changed from `bool` (default `false`) to `bool?` (default `null`), fixing the long-standing `GET_GetStackDefinition_IncludesVariablesWithDefaults` test failure
- **Docs**: Pipeline-Integration.md updated with deploy endpoint documentation
- **Tests**: 21 unit tests + 16 integration tests

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] All 1872 tests pass (1514 unit + 358 integration, including previously failing variable defaults test)