### PR TITLE
Add WebUI headless refactoring spec and roadmap v0.20

### DIFF
--- a/docs/Plans/PLAN-webui-headless-refactoring.md
+++ b/docs/Plans/PLAN-webui-headless-refactoring.md
@@ -1,0 +1,227 @@
+# Phase: WebUI Headless Refactoring
+
+## Ziel
+
+Die WebUI so refactoren, dass Business-Logik (API-Calls, State-Management, SignalR, Validierung) in einem framework-unabhängigen `core/`-Layer liegt und die Darstellungsschicht (`ui/`) austauschbar ist. Damit kann ein Downstream-Fork (z.B. für Corporate Identity mit eigenem UI-Framework) den `ui/`-Layer komplett ersetzen und `core/` 1:1 wiederverwenden.
+
+**Nicht-Ziel**: Die bestehende UI visuell verändern. Nach dem Refactoring muss die Anwendung identisch aussehen und funktionieren.
+
+## Analyse
+
+### Ist-Zustand
+
+Die WebUI ist eine React SPA mit Tailwind CSS. Aktuell gibt es bereits eine gute Trennung beim API-Layer (`src/api/`), aber Seiten und Komponenten vermischen Business-Logik mit Darstellung.
+
+| Layer | Dateien | Kopplung | Status |
+|-------|---------|----------|--------|
+| `api/` | 12 | Kein React, reines TypeScript | Sauber — verschieben |
+| `hooks/` | 4 | SignalR + React vermischt | Aufteilen |
+| `context/` | 4 | React Context + API-Calls | Aufteilen |
+| `components/` | ~25 | Business-Logik + Tailwind inline | Aufteilen |
+| `pages/` | ~20 | State + API + SignalR + Tailwind | Aufteilen |
+| `layout/` | 5 | Sidebar/Header + Tailwind | UI-Layer |
+
+### Detailanalyse pro Layer
+
+#### `api/` — Sofort wiederverwendbar
+- 12 Dateien, kein React-Import
+- `client.ts`: HTTP-Abstraktion (`apiGet<T>`, `apiPost<T>`, etc.) mit Auth-Header-Injection
+- Pro Domain: `deployments.ts`, `environments.ts`, `stacks.ts`, `registries.ts`, `apiKeys.ts`, etc.
+- **Aktion**: 1:1 nach `core/api/` verschieben
+
+#### `hooks/` — SignalR muss raus
+- `useDeploymentHub.ts`: SignalR-Connection für Deployment-Progress (Events, Session-ID, Refs)
+- `useHealthHub.ts`: SignalR-Connection für Health-Monitoring
+- `useModal.ts`: Einfacher Boolean-Toggle
+- `useGoBack.ts`: Navigation-History
+- **Problem**: SignalR-Infrastruktur lebt in React-Hooks statt in einem Service
+- **Aktion**: SignalR-Connection-Management → `core/services/`, React-Hooks als dünne Wrapper behalten
+
+#### `context/` — API-Logik extrahieren
+- `AuthContext.tsx`: Login/Logout, Token-Persistenz (localStorage), User-State
+- `EnvironmentContext.tsx`: Environments laden, aktives Environment setzen, localStorage-Persistenz
+- `SidebarContext.tsx`: Sidebar-Zustand (expand/hover/mobile)
+- `ThemeContext.tsx`: Dark-Mode-Toggle
+- **Problem**: Auth und Environment rufen API direkt auf und persistieren in localStorage
+- **Aktion**: Auth-Service und Environment-Service → `core/services/`, Contexts delegieren nur
+
+#### `components/` — Gemischte Qualität
+- **Gut**: `components/variables/` hat Factory-Pattern (`VariableInput.tsx` → `inputs/*`)
+- **Schlecht**: `components/settings/RegistrySettings.tsx` (460 Zeilen) — CRUD-State, API-Calls, Modals, Tailwind alles in einer Datei
+- **Ähnlich**: `StackSourcesSettings.tsx`, `TlsSettings.tsx`
+- **Aktion**: Store-Hooks extrahieren, Komponenten werden rein darstellend
+
+#### `pages/` — Hauptaufwand
+- Komplexeste Seiten: `DeployStack.tsx` (~300 Zeilen, State-Machine + SignalR + Form), `StackCatalog.tsx`, Wizard-Steps
+- Pattern: `useState`-Soup + `useEffect`-Chains + API-Calls + Tailwind-Rendering in einer Datei
+- **Aktion**: Pro Seite einen Store-Hook extrahieren, Seite wird reine Composition
+
+### Ziel-Architektur
+
+```
+src/ReadyStackGo.WebUi/src/
+├── core/                          ← Framework-unabhängig (kein React, kein Tailwind)
+│   ├── api/                       ← HTTP-Client + Domain-APIs (existiert, verschieben)
+│   │   ├── client.ts
+│   │   ├── deployments.ts
+│   │   ├── environments.ts
+│   │   ├── stacks.ts
+│   │   ├── registries.ts
+│   │   ├── apiKeys.ts
+│   │   └── ...
+│   ├── services/                  ← Infrastruktur-Services
+│   │   ├── AuthService.ts         ← Login/Logout/Token (aus AuthContext)
+│   │   ├── EnvironmentService.ts  ← Load/Select Environment (aus EnvironmentContext)
+│   │   ├── DeploymentHub.ts       ← SignalR Deployment-Connection (aus useDeploymentHub)
+│   │   └── HealthHub.ts           ← SignalR Health-Connection (aus useHealthHub)
+│   └── types/                     ← Shared TypeScript Interfaces
+│       ├── deployment.ts
+│       ├── environment.ts
+│       ├── stack.ts
+│       └── ...
+│
+├── ui/                            ← React + Tailwind (austauschbar)
+│   ├── components/                ← UI-Primitives und Domain-Komponenten
+│   │   ├── variables/             ← Variable-Input-Komponenten (bestehend)
+│   │   ├── settings/              ← Nur UI, kein State (refactored)
+│   │   ├── health/                ← Health-Cards (bestehend, leicht)
+│   │   ├── header/                ← Header-Komponenten (bestehend)
+│   │   └── ...
+│   ├── hooks/                     ← React-Wrapper für core/services
+│   │   ├── useAuth.ts             ← Delegiert an AuthService
+│   │   ├── useEnvironments.ts     ← Delegiert an EnvironmentService
+│   │   ├── useDeploymentHub.ts    ← Delegiert an DeploymentHub
+│   │   ├── useHealthHub.ts        ← Delegiert an HealthHub
+│   │   ├── useModal.ts            ← Bleibt (rein UI)
+│   │   └── useGoBack.ts           ← Bleibt (rein UI)
+│   ├── context/                   ← React Contexts (dünn, delegieren an services)
+│   │   ├── AuthContext.tsx
+│   │   ├── EnvironmentContext.tsx
+│   │   ├── SidebarContext.tsx
+│   │   └── ThemeContext.tsx
+│   ├── layouts/                   ← App-Shell (bestehend)
+│   ├── pages/                     ← Nur Composition, Logik in Hooks
+│   └── stores/                    ← Page-level State-Hooks
+│       ├── useDeployStore.ts      ← State-Machine für DeployStack
+│       ├── useRegistryStore.ts    ← CRUD-State für Registries
+│       ├── useCatalogStore.ts     ← Filter/Suche für Stack-Katalog
+│       ├── useStackSourceStore.ts ← CRUD-State für Stack Sources
+│       └── ...
+│
+├── App.tsx
+├── main.tsx
+└── index.css
+```
+
+### Konvention für Store-Hooks
+
+Jeder Store-Hook folgt dem gleichen Pattern:
+
+```typescript
+// ui/stores/useRegistryStore.ts
+import { useState, useEffect, useCallback } from 'react';
+import { getRegistries, createRegistry, ... } from '../../core/api/registries';
+import type { Registry, CreateRegistryRequest } from '../../core/types/registry';
+
+export function useRegistryStore() {
+  const [registries, setRegistries] = useState<Registry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => { ... }, []);
+  const create = useCallback(async (req: CreateRegistryRequest) => { ... }, []);
+  const remove = useCallback(async (id: string) => { ... }, []);
+
+  useEffect(() => { load(); }, [load]);
+
+  return { registries, isLoading, error, create, remove, ... } as const;
+}
+```
+
+Die zugehörige Page wird dann rein darstellend:
+
+```tsx
+// ui/pages/Settings/RegistrySettings.tsx
+export default function RegistrySettings() {
+  const store = useRegistryStore();
+  const modal = useModal();
+
+  if (store.isLoading) return <LoadingSpinner />;
+  return (
+    <>
+      <RegistryTable registries={store.registries} onDelete={store.remove} />
+      <RegistryModal isOpen={modal.isOpen} onSubmit={store.create} onClose={modal.close} />
+    </>
+  );
+}
+```
+
+## Features / Schritte
+
+Reihenfolge basierend auf Abhängigkeiten — von innen nach außen:
+
+- [ ] **Feature 1: Core API Layer** — `api/` nach `core/api/` verschieben, Types extrahieren nach `core/types/`
+  - Betroffene Dateien: Alle 12 `api/*.ts`, neue `core/types/*.ts`
+  - Import-Pfade in allen Konsumenten aktualisieren
+  - Abhängig von: -
+  - Tests: Build + `npm run dev` muss funktionieren, kein visueller Unterschied
+
+- [ ] **Feature 2: Core Services** — SignalR und Auth/Environment-Logik in `core/services/` extrahieren
+  - `AuthService.ts` aus `AuthContext.tsx` (Login, Logout, Token-Management, localStorage)
+  - `EnvironmentService.ts` aus `EnvironmentContext.tsx` (Load, Select, Persist)
+  - `DeploymentHub.ts` aus `useDeploymentHub.ts` (SignalR-Connection, Event-Subscriptions)
+  - `HealthHub.ts` aus `useHealthHub.ts` (SignalR-Connection)
+  - Betroffene Dateien: `context/AuthContext.tsx`, `context/EnvironmentContext.tsx`, `hooks/useDeploymentHub.ts`, `hooks/useHealthHub.ts`
+  - Abhängig von: Feature 1
+  - Tests: Login, Environment-Wechsel, Deployment-Progress, Health-Updates müssen funktionieren
+
+- [ ] **Feature 3: Store-Hooks für Settings-Seiten** — Business-Logik aus den schwersten Komponenten extrahieren
+  - `useRegistryStore.ts` aus `RegistrySettings.tsx` (460 Zeilen → Store + UI)
+  - `useStackSourceStore.ts` aus `StackSourcesSettings.tsx`
+  - `useTlsStore.ts` aus `TlsSettings.tsx`
+  - `useApiKeyStore.ts` aus der API-Key-Settings-Seite
+  - Betroffene Dateien: `components/settings/*`, `pages/Settings/*`
+  - Abhängig von: Feature 1
+  - Tests: Alle Settings-Seiten funktional testen (CRUD-Operationen, Modals, Error-States)
+
+- [ ] **Feature 4: Store-Hooks für Deployment-Seiten** — Komplexeste Business-Logik extrahieren
+  - `useDeployStore.ts` aus `DeployStack.tsx` (State-Machine: loading → configure → deploying → success/error)
+  - `useRollbackStore.ts` aus der Rollback-Seite
+  - `useUpgradeStore.ts` aus der Upgrade-Seite
+  - `useRemoveStore.ts` aus der Remove-Seite
+  - Betroffene Dateien: `pages/Deployments/*`
+  - Abhängig von: Feature 2 (wegen SignalR-Dependency)
+  - Tests: Deploy-Flow end-to-end, Progress-Updates, Error-Handling
+
+- [ ] **Feature 5: Store-Hooks für restliche Seiten** — Katalog, Environments, Monitoring, Wizard
+  - `useCatalogStore.ts` für StackCatalog + ProductDetail
+  - `useEnvironmentStore.ts` für Environments-Seite
+  - `useHealthDashboardStore.ts` für Health-Dashboard
+  - `useContainerStore.ts` für Container-Monitoring
+  - `useWizardStore.ts` für Wizard-Steps
+  - Betroffene Dateien: Alle verbleibenden `pages/*`
+  - Abhängig von: Feature 1, 2
+  - Tests: Navigation, Filter, Wizard-Flow
+
+- [ ] **Feature 6: Cleanup und Dokumentation** — Alte Importe bereinigen, README für Downstream-Forks
+  - Alte Import-Pfade final prüfen
+  - `core/README.md` mit API-Dokumentation für Fork-Teams
+  - Bestehende E2E-Tests müssen alle grün sein
+  - Abhängig von: Feature 1-5
+
+- [ ] **Phase abschließen** — Alle Tests grün, PR gegen main
+
+## Offene Punkte
+
+- [ ] Soll `core/` als eigenständiges npm-Package extrahiert werden (für Fork als Dependency), oder reicht die Ordner-Trennung?
+- [ ] Sollen die Store-Hooks in `ui/stores/` oder `ui/hooks/` leben?
+- [ ] Brauchen wir ein State-Management-Library (Zustand, Jotai) oder reichen React-Hooks?
+
+## Entscheidungen
+
+| Entscheidung | Optionen | Gewählt | Begründung |
+|---|---|---|---|
+| State-Management | A) Zustand, B) Jotai, C) React Hooks | - | Noch offen |
+| Core-Packaging | A) Ordner-Trennung, B) npm-Package | - | Noch offen |
+| Store-Location | A) `ui/stores/`, B) `ui/hooks/` | - | Noch offen |
+| SignalR-Abstraktion | A) Event-Emitter, B) Callback-basiert, C) Observable | - | Noch offen |

--- a/docs/Reference/Roadmap.md
+++ b/docs/Reference/Roadmap.md
@@ -147,22 +147,30 @@ Rough outlook on planned versions and features.
   - Optional Environment-Scope for API Keys
   - Pipeline Examples for curl, GitHub Actions, and Azure DevOps
 
-### v0.20 – Docker Volumes Management
+### v0.20 – WebUI Headless Refactoring
+- Extract Framework-Independent Core Layer (API, Services, Types)
+- SignalR Connection Management as Standalone Services
+- Store-Hooks for Settings Pages (Registry, Stack Sources, TLS, API Keys)
+- Store-Hooks for Deployment Pages (Deploy, Upgrade, Rollback, Remove)
+- Store-Hooks for Remaining Pages (Catalog, Environments, Health, Wizard)
+- Downstream Fork Documentation
+
+### v0.21 – Docker Volumes Management
 - Docker Volumes View (List All Volumes per Environment)
 - Volume Details (Size, Mount Points, Labels)
 - Create/Delete Volumes
 - Detect Orphaned Volumes
 
-### v0.21 – Metrics & Audit
+### v0.22 – Metrics & Audit
 - Metrics & Alerting
 - Audit Logs
 
-### v0.22 – Multi-User Support
+### v0.23 – Multi-User Support
 - User Management UI
 - Create/Edit Users
 - Password Reset Flow
 
-### v0.23 – Feature Flags
+### v0.24 – Feature Flags
 - Feature Flags UI in Admin
 - Feature Toggle at Organization Level
 - Environment Variables for Feature Flags


### PR DESCRIPTION
## Summary
- Add `docs/Plans/PLAN-webui-headless-refactoring.md` with full architecture analysis, target structure, and 6-feature implementation plan
- Update roadmap: insert v0.20 WebUI Headless Refactoring, shift subsequent versions

## Context
Preparing for a downstream fork that needs the same functionality with a different UI framework (corporate identity). The spec describes how to split the WebUI into a framework-independent `core/` layer and a swappable `ui/` layer.

## Test plan
- [x] Documentation only, no code changes