### PR TITLE
Add Deploy permission option to API key creation UI

### DIFF
--- a/src/ReadyStackGo.WebUi/src/pages/Settings/CiCd/CiCdList.tsx
+++ b/src/ReadyStackGo.WebUi/src/pages/Settings/CiCd/CiCdList.tsx
@@ -10,6 +10,7 @@ import {
 import { useEnvironment } from "../../../context/EnvironmentContext";
 
 const AVAILABLE_PERMISSIONS = [
+  { value: "Hooks.Deploy", label: "Deploy", description: "Deploy or redeploy stacks (idempotent)" },
   { value: "Hooks.Redeploy", label: "Redeploy", description: "Trigger redeployment of running stacks" },
   { value: "Hooks.Upgrade", label: "Upgrade", description: "Upgrade stacks to a new version" },
   { value: "Hooks.SyncSources", label: "Sync Sources", description: "Synchronize stack catalog sources" },


### PR DESCRIPTION
## Summary
- Add `Hooks.Deploy` permission to the available permissions in the CI/CD API key creation modal
- Default selection remains `Hooks.Redeploy`