### PR TITLE
Add copy-to-clipboard Stack ID button on catalog StackCard

### DIFF
--- a/src/ReadyStackGo.WebUi/src/pages/Catalog/ProductDetail.tsx
+++ b/src/ReadyStackGo.WebUi/src/pages/Catalog/ProductDetail.tsx
@@ -207,6 +207,24 @@ interface StackCardProps {
 
 function StackCard({ stack, disabled }: StackCardProps) {
   const [showServices, setShowServices] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyStackId = async () => {
+    try {
+      await navigator.clipboard.writeText(stack.id);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      const textArea = document.createElement("textarea");
+      textArea.value = stack.id;
+      document.body.appendChild(textArea);
+      textArea.select();
+      document.execCommand("copy");
+      document.body.removeChild(textArea);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  };
 
   // Group variables by group
   const variableGroups = stack.variables.reduce((acc, variable) => {
@@ -265,6 +283,28 @@ function StackCard({ stack, disabled }: StackCardProps) {
               {stack.variables.length} variable{stack.variables.length !== 1 ? 's' : ''}
             </span>
           )}
+        </div>
+
+        {/* Stack ID for CI/CD */}
+        <div className="flex items-center gap-1.5">
+          <code className="text-xs font-mono text-gray-500 dark:text-gray-400 truncate">
+            {stack.id}
+          </code>
+          <button
+            onClick={handleCopyStackId}
+            className="flex-shrink-0 p-0.5 rounded text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+            title="Copy Stack ID for CI/CD"
+          >
+            {copied ? (
+              <svg className="w-3.5 h-3.5 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+            ) : (
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+              </svg>
+            )}
+          </button>
         </div>
 
         {/* Variable Groups */}


### PR DESCRIPTION
## Summary
- Show the fully qualified `stackId` on the product detail page StackCard component
- Add copy-to-clipboard button so CI/CD pipeline authors can easily grab the correct ID for use with `/api/hooks/deploy`
- Follows existing copy pattern from CiCdList.tsx (clipboard API with fallback)

## Test plan
- [ ] Open catalog, navigate to a product detail page
- [ ] Verify stackId is shown on each StackCard (monospace, muted color)
- [ ] Click copy button, verify clipboard contains the correct stackId
- [ ] Verify "Copied!" checkmark feedback appears for 2 seconds
- [ ] Use copied stackId in deploy hook request, verify it resolves correctly