### PR TITLE
Add image reference extraction service

### DIFF
--- a/docs/Plans/PLAN-registry-wizard-ux.md
+++ b/docs/Plans/PLAN-registry-wizard-ux.md
@@ -1,0 +1,244 @@
+# Phase: Registry Wizard UX (v0.25)
+
+## Ziel
+
+Neuer Wizard-Schritt, der Container-Registries automatisch aus den gewählten Stack-Quellen erkennt und dem Benutzer ermöglicht, Zugangsdaten inline (ohne Modals) zu konfigurieren.
+
+## Analyse
+
+### Bestehende Infrastruktur (Wiederverwendung)
+
+- **Registry Aggregate Root** (`Domain/Deployment/Registries/Registry.cs`): `MatchesImage()` mit Glob-Patterns, `GetRegistryHost()`, `ImagePatterns`, Credentials
+- **Registry CRUD** (`Api/Endpoints/Registries/`): Vollständige REST-API mit MediatR + FastEndpoints
+- **Registry Settings UI** (`WebUi/src/pages/Settings/Registries/`): AddRegistry mit Preset-Templates (Docker Hub, GHCR, GitLab, Quay.io, Custom), Patterns-Textarea, Credential-Felder
+- **5-Schritt-Wizard** (`WebUi/src/pages/Wizard/`): WizardLayout mit Stepper, State Machine (NotStarted → AdminCreated → OrganizationSet → Installed), 5-Minuten-Timeout
+- **ServiceTemplate.Image** (`Domain/StackManagement/Stacks/ServiceTemplate.cs`): Enthält parseable Image-Referenzen
+- **ParseImageReference** (`Infrastructure.Docker/Services/DeploymentEngine.cs:1013`): Existierende name:tag-Splitlogik
+- **Three-Tier Credentials** (`RegistryCredentialProvider.cs`): DB → Config → Docker Config mit Pattern-Matching
+- **IProductSourceService**: `SyncSourceAsync()` für Source-Sync, `GetProductsAsync()` für geladene Produkte
+- **IProductCache**: `GetAllStacks()`, `GetStack()` für Zugriff auf geladene StackDefinitions
+
+### Architektur-Pattern (Vorbilder)
+
+| Pattern | Vorbild | Pfad |
+|---------|---------|------|
+| MediatR Query/Command | ListRegistrySourcesQuery | `Application/UseCases/StackSources/ListRegistrySources/` |
+| FastEndpoint (Wizard) | ListRegistryForWizardEndpoint | `Api/Endpoints/Wizard/ListRegistryForWizardEndpoint.cs` |
+| Wizard UI Step | StackSourcesStep.tsx | `WebUi/src/pages/Wizard/StackSourcesStep.tsx` |
+| Wizard API Client | wizard.ts | `WebUi/src/api/wizard.ts` |
+| Image Parsing | ParseImageReference | `Infrastructure.Docker/Services/DeploymentEngine.cs` |
+
+## Features / Schritte
+
+Reihenfolge basierend auf Abhängigkeiten:
+
+- [ ] **Feature 1: Image Reference Extraction Service** – Parst `ServiceTemplate.Image`-Strings, gruppiert nach Host+Namespace
+  - Neue Dateien:
+    - `Application/Services/IImageReferenceExtractor.cs` (Interface + DTOs)
+    - `Infrastructure/Services/ImageReferenceExtractor.cs` (Implementierung)
+    - `Infrastructure/DependencyInjection.cs` (Registration)
+  - Tests:
+    - `UnitTests/Services/ImageReferenceExtractorTests.cs`
+  - Abhängig von: –
+
+- [ ] **Feature 2: Detect Registries Endpoint** – Synced Sources, extrahiert Images, gruppiert in Registry-Areas
+  - Neue Dateien:
+    - `Application/UseCases/Wizard/DetectRegistries/DetectRegistriesQuery.cs`
+    - `Application/UseCases/Wizard/DetectRegistries/DetectRegistriesHandler.cs`
+    - `Api/Endpoints/Wizard/DetectRegistriesEndpoint.cs`
+  - Tests:
+    - `UnitTests/Application/Wizard/DetectRegistriesHandlerTests.cs`
+  - Abhängig von: Feature 1
+
+- [ ] **Feature 3: Bulk Create Registries Endpoint** – Erstellt Registry-Einträge aus Wizard-Input
+  - Neue Dateien:
+    - `Application/UseCases/Wizard/SetRegistries/SetRegistriesCommand.cs`
+    - `Application/UseCases/Wizard/SetRegistries/SetRegistriesHandler.cs`
+    - `Api/Endpoints/Wizard/SetRegistriesEndpoint.cs`
+  - Tests:
+    - `UnitTests/Application/Wizard/SetRegistriesHandlerTests.cs`
+  - Abhängig von: –
+
+- [ ] **Feature 4: Wizard Step UI** – Step 5 (Container Registries), Install wird Step 6
+  - Geänderte Dateien:
+    - `WebUi/src/pages/Wizard/index.tsx` (6 Steps statt 5)
+    - `WebUi/src/pages/Wizard/WizardLayout.tsx` (6 Steps)
+  - Neue Dateien:
+    - `WebUi/src/pages/Wizard/RegistriesStep.tsx`
+    - `WebUi/src/api/wizard.ts` (neue API-Funktionen)
+  - Abhängig von: Feature 2, Feature 3
+
+- [ ] **Feature 5: Tests (Unit + Integration)** – Umfassende Tests für alle neuen Komponenten
+  - Tests laufen parallel zur Implementierung, werden hier als Phase zusammengefasst
+  - Abhängig von: Feature 1-4
+
+- [ ] **Dokumentation & Website** – PublicWeb (DE/EN), Roadmap
+  - Abhängig von: Feature 1-5
+
+- [ ] **Phase abschließen** – Alle Tests grün, PR gegen main
+  - Abhängig von: alle
+
+## Detailplan pro Feature
+
+### Feature 1: Image Reference Extraction Service
+
+**Ziel:** Service der Image-Referenzen aus StackDefinitions extrahiert und in Registry-Bereiche gruppiert.
+
+**Interface (`Application/Services/IImageReferenceExtractor.cs`):**
+
+```csharp
+public record ParsedImageReference(
+    string OriginalReference,
+    string Host,          // z.B. "docker.io", "ghcr.io"
+    string Namespace,     // z.B. "amssolution", "library", "wiesenwischer"
+    string Repository,    // z.B. "ams-api"
+    string? Tag);
+
+public record RegistryArea(
+    string Host,
+    string Namespace,
+    string SuggestedPattern,  // z.B. "amssolution/*"
+    string SuggestedName,     // z.B. "Docker Hub – amssolution"
+    bool IsLikelyPublic,      // true für "library" Namespace auf docker.io
+    IReadOnlyList<string> Images);  // Alle Image-Referenzen in diesem Bereich
+
+public interface IImageReferenceExtractor
+{
+    ParsedImageReference ParseImageReference(string imageReference);
+    IReadOnlyList<RegistryArea> GroupByRegistryArea(IEnumerable<string> imageReferences);
+}
+```
+
+**Parsing-Logik:**
+- Kein Host → `docker.io` (Docker Hub Default)
+- Kein Namespace (z.B. `nginx:latest`) → Namespace = `library`
+- Host mit Port (z.B. `registry:5000/img`) → Host = `registry:5000`
+- Variable-Referenzen (`${VERSION}`) → Tag ignorieren, Rest parsen
+- Digest-Referenzen (`@sha256:...`) → Digest ignorieren
+
+**Gruppierung:**
+- Gruppiert nach `Host + Namespace`
+- SuggestedPattern: `{namespace}/*` (für docker.io), `{host}/{namespace}/*` (für andere)
+- SuggestedName: `{Host} – {Namespace}` oder `Docker Hub – {Namespace}`
+- IsLikelyPublic: true wenn `docker.io` + `library` (offizielle Docker Hub Images)
+
+**Edge Cases:**
+- Leere Image-Strings → ignorieren
+- Nur Tag ohne Image → ignorieren
+- Duplikate → deduplizieren innerhalb RegistryArea.Images
+
+### Feature 2: Detect Registries Endpoint
+
+**Ziel:** Endpoint der basierend auf den bereits gesyncten Stacks die benötigten Registry-Bereiche erkennt und mit bestehenden Registry-Konfigurationen abgleicht.
+
+**Query:**
+```csharp
+public record DetectRegistriesQuery() : IRequest<DetectRegistriesResult>;
+
+public record DetectRegistriesResult(
+    IReadOnlyList<DetectedRegistryArea> Areas);
+
+public record DetectedRegistryArea(
+    string Host,
+    string Namespace,
+    string SuggestedPattern,
+    string SuggestedName,
+    bool IsLikelyPublic,
+    bool IsConfigured,       // Bereits eine passende Registry in DB vorhanden
+    IReadOnlyList<string> Images);
+```
+
+**Handler-Logik:**
+1. Lade alle Stacks aus `IProductCache.GetAllStacks()`
+2. Sammle alle `ServiceTemplate.Image`-Werte (alle Lifecycles, dedupliziert)
+3. Übergib an `IImageReferenceExtractor.GroupByRegistryArea()`
+4. **Falls keine Stacks vorhanden:** Liefere Default-Registry-Set (Docker Hub, GHCR, GitLab Registry, Quay.io) als Fallback
+5. Für jede RegistryArea: Prüfe ob eine bestehende Registry in der DB diese Images matcht
+6. Markiere `IsConfigured = true` wenn ein Match gefunden wird
+
+**Endpoint:**
+- `GET /api/wizard/detected-registries`
+- AllowAnonymous + WizardTimeoutPreProcessor
+- Response: `DetectedRegistryArea[]`
+
+### Feature 3: Bulk Create Registries Endpoint
+
+**Ziel:** Erstellt Registry-Einträge für die im Wizard konfigurierten Registry-Bereiche.
+
+**Command:**
+```csharp
+public record RegistryInput(
+    string Name,
+    string Host,
+    string Pattern,
+    bool RequiresAuth,
+    string? Username,
+    string? Password);
+
+public record SetRegistriesCommand(
+    IReadOnlyList<RegistryInput> Registries) : IRequest<SetRegistriesResult>;
+
+public record SetRegistriesResult(
+    bool Success,
+    int RegistriesCreated);
+```
+
+**Handler-Logik:**
+1. Lade die erste Organization (wie in RegistryCredentialProvider)
+2. Für jede RegistryInput:
+   - Überspringe wenn `RequiresAuth == false` (public, keine Konfiguration nötig)
+   - Prüfe ob bereits eine Registry mit gleichem Pattern/Host existiert → Überspringe
+   - Erstelle `Registry` Aggregate mit `Name`, `Url` (aus Host), `ImagePatterns`, Credentials
+   - Persistiere via `IRegistryRepository`
+3. Return count
+
+**Endpoint:**
+- `POST /api/wizard/registries`
+- AllowAnonymous + WizardTimeoutPreProcessor
+- Request Body: `SetRegistriesRequest { Registries: RegistryInput[] }`
+- Response: `SetRegistriesResponse { Success, RegistriesCreated }`
+
+### Feature 4: Wizard Step UI
+
+**Ziel:** Neuer Wizard-Step "Container Registries" als Step 5 (Install verschiebt sich auf Step 6).
+
+**Stepper-Änderungen:**
+1. Admin → 2. Organization → 3. Environment → 4. Stack Sources → **5. Container Registries** → 6. Install
+
+**RegistriesStep.tsx:**
+- Lädt beim Mount `GET /api/wizard/detected-registries`
+- Loading-State während Detection läuft
+- Pro RegistryArea eine Card:
+  - Titel: `{Host} – {SuggestedPattern}` oder `Docker Hub – {Namespace}`
+  - Image-Liste (collapsible): Alle betroffenen Images
+  - Badge: "Bereits konfiguriert" (grün) oder "Konfiguration nötig" (gelb) oder "Public" (grau)
+  - Auth-Radio: ● Authentifizierung erforderlich / ○ Public (kein Login nötig)
+  - Wenn Auth: Username + Password/Token Felder inline
+  - Pattern-Feld (editierbar, vorausgefüllt mit SuggestedPattern)
+  - Name-Feld (editierbar, vorausgefüllt mit SuggestedName)
+- Public Areas (IsLikelyPublic): Radio defaultmäßig auf "Public", Hinweistext
+- "Skip" Button (optional, alle überspringen)
+- "Continue" Button → validiert, erstellt Registries via POST, geht weiter
+
+**State Management:**
+- Lokaler State pro Card: `{ name, pattern, requiresAuth, username, password }`
+- Cards mit `IsConfigured = true` → bereits konfiguriert-Badge, kein Formular
+- Cards mit `IsLikelyPublic = true` → defaultmäßig auf "Public"
+
+**Wizard-Flow Anpassung:**
+- `index.tsx`: wizardState-Mapping anpassen, Step 5 = RegistriesStep, Step 6 = Install
+- `WizardLayout.tsx`: 6 Steps statt 5
+- Step 5 ist optional (Skip möglich) — wie Environment und StackSources
+
+## Offene Punkte
+
+Alle geklärt ✓
+
+## Entscheidungen
+
+| Entscheidung | Optionen | Gewählt | Begründung |
+|---|---|---|---|
+| Image-Quelle | A) Sync triggern B) Nur Cache | **B) Nur Cache** | Sync passiert in Step 4. Doppelter Sync wäre langsam und überflüssig. |
+| Leere Sources | A) Hinweis B) Skip C) Default-Registries | **C) Default-Registries** | Auch ohne Stacks: typische Registries (Docker Hub, GHCR, GitLab) als Default-Set anbieten. |
+| Wizard State | A) Neuer State B) Optional wie Step 3+4 | **A) Neuer State `RegistriesConfigured`** | Explizites Tracking des Registry-Schritts in der State Machine. |
+| Init-Container | A) Separat B) Zusammen | **B) Zusammen** | Alle Images aus allen ServiceTemplates fließen in die Erkennung ein, unabhängig vom Lifecycle. |

--- a/src/ReadyStackGo.Application/Services/IImageReferenceExtractor.cs
+++ b/src/ReadyStackGo.Application/Services/IImageReferenceExtractor.cs
@@ -1,0 +1,38 @@
+namespace ReadyStackGo.Application.Services;
+
+/// <summary>
+/// Parsed components of a Docker image reference.
+/// </summary>
+public record ParsedImageReference(
+    string OriginalReference,
+    string Host,
+    string Namespace,
+    string Repository,
+    string? Tag);
+
+/// <summary>
+/// A group of images sharing the same registry host and namespace.
+/// </summary>
+public record RegistryArea(
+    string Host,
+    string Namespace,
+    string SuggestedPattern,
+    string SuggestedName,
+    bool IsLikelyPublic,
+    IReadOnlyList<string> Images);
+
+/// <summary>
+/// Parses Docker image references and groups them by registry area.
+/// </summary>
+public interface IImageReferenceExtractor
+{
+    /// <summary>
+    /// Parses a single image reference into its components (host, namespace, repository, tag).
+    /// </summary>
+    ParsedImageReference Parse(string imageReference);
+
+    /// <summary>
+    /// Groups image references by registry area (host + namespace).
+    /// </summary>
+    IReadOnlyList<RegistryArea> GroupByRegistryArea(IEnumerable<string> imageReferences);
+}

--- a/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
+++ b/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
@@ -69,6 +69,9 @@ public static class DependencyInjection
         // Source Registry (v0.24)
         services.AddSingleton<ISourceRegistryService, SourceRegistryService>();
 
+        // Image Reference Extraction (v0.25)
+        services.AddSingleton<IImageReferenceExtractor, ImageReferenceExtractor>();
+
         // Health Monitoring (v0.11)
         services.AddScoped<IHealthMonitoringService, HealthMonitoringService>();
         services.AddScoped<IHealthCollectorService, HealthCollectorService>();

--- a/src/ReadyStackGo.Infrastructure/Services/ImageReferenceExtractor.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/ImageReferenceExtractor.cs
@@ -1,0 +1,164 @@
+using ReadyStackGo.Application.Services;
+
+namespace ReadyStackGo.Infrastructure.Services;
+
+/// <summary>
+/// Parses Docker image references and groups them by registry area (host + namespace).
+/// </summary>
+public class ImageReferenceExtractor : IImageReferenceExtractor
+{
+    private static readonly HashSet<string> DockerHubHosts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "docker.io",
+        "index.docker.io",
+        "registry-1.docker.io",
+        "registry.hub.docker.com"
+    };
+
+    public ParsedImageReference Parse(string imageReference)
+    {
+        if (string.IsNullOrWhiteSpace(imageReference))
+            return new ParsedImageReference(imageReference, "docker.io", "library", "", null);
+
+        var original = imageReference.Trim();
+        var working = original;
+
+        // Remove digest (@sha256:...)
+        var atIndex = working.IndexOf('@');
+        if (atIndex > 0)
+            working = working[..atIndex];
+
+        // Extract tag - find last colon after last slash
+        string? tag = null;
+        var lastSlash = working.LastIndexOf('/');
+        var lastColon = working.LastIndexOf(':');
+
+        if (lastColon > lastSlash && lastColon < working.Length - 1)
+        {
+            tag = working[(lastColon + 1)..];
+            working = working[..lastColon];
+        }
+
+        // Now working = image name without tag/digest
+        // Determine host, namespace, and repository
+        var parts = working.Split('/');
+
+        if (parts.Length == 1)
+        {
+            // Simple image: "nginx" → docker.io/library/nginx
+            return new ParsedImageReference(original, "docker.io", "library", parts[0], tag);
+        }
+
+        if (parts.Length == 2)
+        {
+            // Could be "user/image" (Docker Hub) or "host/image" (custom registry)
+            if (LooksLikeRegistryHost(parts[0]))
+            {
+                // host/image → host + library + image
+                var host = NormalizeHost(parts[0]);
+                return new ParsedImageReference(original, host, "library", parts[1], tag);
+            }
+
+            // user/image → docker.io + user + image
+            return new ParsedImageReference(original, "docker.io", parts[0], parts[1], tag);
+        }
+
+        // 3+ parts: first part is host (or Docker Hub namespace/sub-namespace)
+        if (LooksLikeRegistryHost(parts[0]))
+        {
+            var host = NormalizeHost(parts[0]);
+            var ns = parts[1];
+            var repo = string.Join("/", parts.Skip(2));
+            return new ParsedImageReference(original, host, ns, repo, tag);
+        }
+
+        // No registry host → Docker Hub with nested namespace
+        var dockerNs = parts[0];
+        var dockerRepo = string.Join("/", parts.Skip(1));
+        return new ParsedImageReference(original, "docker.io", dockerNs, dockerRepo, tag);
+    }
+
+    public IReadOnlyList<RegistryArea> GroupByRegistryArea(IEnumerable<string> imageReferences)
+    {
+        var parsed = imageReferences
+            .Where(r => !string.IsNullOrWhiteSpace(r))
+            .Select(Parse)
+            .Where(p => !string.IsNullOrEmpty(p.Repository))
+            .ToList();
+
+        var groups = parsed
+            .GroupBy(p => (Host: p.Host.ToLowerInvariant(), Namespace: p.Namespace.ToLowerInvariant()))
+            .OrderBy(g => g.Key.Host)
+            .ThenBy(g => g.Key.Namespace);
+
+        var areas = new List<RegistryArea>();
+
+        foreach (var group in groups)
+        {
+            var host = group.First().Host;
+            var ns = group.First().Namespace;
+            var images = group
+                .Select(p => p.OriginalReference)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(i => i)
+                .ToList();
+
+            var suggestedPattern = BuildSuggestedPattern(host, ns);
+            var suggestedName = BuildSuggestedName(host, ns);
+            var isLikelyPublic = IsLikelyPublic(host, ns);
+
+            areas.Add(new RegistryArea(
+                Host: host,
+                Namespace: ns,
+                SuggestedPattern: suggestedPattern,
+                SuggestedName: suggestedName,
+                IsLikelyPublic: isLikelyPublic,
+                Images: images));
+        }
+
+        return areas;
+    }
+
+    private static bool LooksLikeRegistryHost(string segment)
+    {
+        // Contains dot → likely a hostname (ghcr.io, registry.example.com)
+        // Contains colon → port number (localhost:5000)
+        return segment.Contains('.') || segment.Contains(':');
+    }
+
+    private static string NormalizeHost(string host)
+    {
+        // Normalize Docker Hub variants to docker.io
+        if (DockerHubHosts.Contains(host))
+            return "docker.io";
+
+        return host.ToLowerInvariant();
+    }
+
+    private static string BuildSuggestedPattern(string host, string ns)
+    {
+        if (IsDockerHub(host))
+            return $"{ns}/*";
+
+        return $"{host}/{ns}/*";
+    }
+
+    private static string BuildSuggestedName(string host, string ns)
+    {
+        if (IsDockerHub(host))
+            return ns == "library" ? "Docker Hub (Official Images)" : $"Docker Hub – {ns}";
+
+        return $"{host} – {ns}";
+    }
+
+    private static bool IsLikelyPublic(string host, string ns)
+    {
+        // Official Docker Hub images (library namespace) are almost always public
+        return IsDockerHub(host) && ns.Equals("library", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool IsDockerHub(string host)
+    {
+        return DockerHubHosts.Contains(host);
+    }
+}

--- a/tests/ReadyStackGo.UnitTests/Services/ImageReferenceExtractorTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Services/ImageReferenceExtractorTests.cs
@@ -1,0 +1,476 @@
+using FluentAssertions;
+using ReadyStackGo.Infrastructure.Services;
+
+namespace ReadyStackGo.UnitTests.Services;
+
+public class ImageReferenceExtractorTests
+{
+    private readonly ImageReferenceExtractor _extractor = new();
+
+    #region Parse - Docker Hub (default host)
+
+    [Fact]
+    public void Parse_SimpleImage_ReturnsDockerHubLibrary()
+    {
+        var result = _extractor.Parse("nginx");
+
+        result.Host.Should().Be("docker.io");
+        result.Namespace.Should().Be("library");
+        result.Repository.Should().Be("nginx");
+        result.Tag.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_SimpleImageWithTag_ExtractsTag()
+    {
+        var result = _extractor.Parse("nginx:latest");
+
+        result.Host.Should().Be("docker.io");
+        result.Namespace.Should().Be("library");
+        result.Repository.Should().Be("nginx");
+        result.Tag.Should().Be("latest");
+    }
+
+    [Fact]
+    public void Parse_UserImage_ReturnsDockerHubWithNamespace()
+    {
+        var result = _extractor.Parse("amssolution/ams-api:0.5.0");
+
+        result.Host.Should().Be("docker.io");
+        result.Namespace.Should().Be("amssolution");
+        result.Repository.Should().Be("ams-api");
+        result.Tag.Should().Be("0.5.0");
+    }
+
+    [Fact]
+    public void Parse_UserImageWithoutTag_NoTag()
+    {
+        var result = _extractor.Parse("amssolution/ams-api");
+
+        result.Host.Should().Be("docker.io");
+        result.Namespace.Should().Be("amssolution");
+        result.Repository.Should().Be("ams-api");
+        result.Tag.Should().BeNull();
+    }
+
+    #endregion
+
+    #region Parse - Explicit Docker Hub hosts
+
+    [Theory]
+    [InlineData("docker.io/amssolution/ams-api:1.0")]
+    [InlineData("index.docker.io/amssolution/ams-api:1.0")]
+    [InlineData("registry-1.docker.io/amssolution/ams-api:1.0")]
+    [InlineData("registry.hub.docker.com/amssolution/ams-api:1.0")]
+    public void Parse_ExplicitDockerHubHosts_NormalizedToDockerIo(string imageRef)
+    {
+        var result = _extractor.Parse(imageRef);
+
+        result.Host.Should().Be("docker.io");
+        result.Namespace.Should().Be("amssolution");
+        result.Repository.Should().Be("ams-api");
+        result.Tag.Should().Be("1.0");
+    }
+
+    #endregion
+
+    #region Parse - Custom registries
+
+    [Fact]
+    public void Parse_GhcrImage_ExtractsHostAndNamespace()
+    {
+        var result = _extractor.Parse("ghcr.io/wiesenwischer/ams-project-api:0.5.0");
+
+        result.Host.Should().Be("ghcr.io");
+        result.Namespace.Should().Be("wiesenwischer");
+        result.Repository.Should().Be("ams-project-api");
+        result.Tag.Should().Be("0.5.0");
+    }
+
+    [Fact]
+    public void Parse_CustomRegistryWithPort_ExtractsHostWithPort()
+    {
+        var result = _extractor.Parse("registry.example.com:5000/myorg/myimage:v1");
+
+        result.Host.Should().Be("registry.example.com:5000");
+        result.Namespace.Should().Be("myorg");
+        result.Repository.Should().Be("myimage");
+        result.Tag.Should().Be("v1");
+    }
+
+    [Fact]
+    public void Parse_CustomRegistryNoNamespace_UsesLibrary()
+    {
+        var result = _extractor.Parse("ghcr.io/myimage:v1");
+
+        result.Host.Should().Be("ghcr.io");
+        result.Namespace.Should().Be("library");
+        result.Repository.Should().Be("myimage");
+        result.Tag.Should().Be("v1");
+    }
+
+    [Fact]
+    public void Parse_GitLabRegistry_ExtractsCorrectly()
+    {
+        var result = _extractor.Parse("registry.gitlab.com/mygroup/myproject:latest");
+
+        result.Host.Should().Be("registry.gitlab.com");
+        result.Namespace.Should().Be("mygroup");
+        result.Repository.Should().Be("myproject");
+        result.Tag.Should().Be("latest");
+    }
+
+    [Fact]
+    public void Parse_QuayRegistry_ExtractsCorrectly()
+    {
+        var result = _extractor.Parse("quay.io/coreos/etcd:v3.5.0");
+
+        result.Host.Should().Be("quay.io");
+        result.Namespace.Should().Be("coreos");
+        result.Repository.Should().Be("etcd");
+        result.Tag.Should().Be("v3.5.0");
+    }
+
+    [Fact]
+    public void Parse_DeepNestedPath_ExtractsFirstAsNamespace()
+    {
+        var result = _extractor.Parse("ghcr.io/org/sub/project:v1");
+
+        result.Host.Should().Be("ghcr.io");
+        result.Namespace.Should().Be("org");
+        result.Repository.Should().Be("sub/project");
+        result.Tag.Should().Be("v1");
+    }
+
+    #endregion
+
+    #region Parse - Digest references
+
+    [Fact]
+    public void Parse_DigestReference_IgnoresDigest()
+    {
+        var result = _extractor.Parse("nginx@sha256:abc123def456");
+
+        result.Host.Should().Be("docker.io");
+        result.Namespace.Should().Be("library");
+        result.Repository.Should().Be("nginx");
+        result.Tag.Should().BeNull();
+    }
+
+    [Fact]
+    public void Parse_TagAndDigest_ExtractsTagIgnoresDigest()
+    {
+        var result = _extractor.Parse("nginx:1.25@sha256:abc123def456");
+
+        result.Host.Should().Be("docker.io");
+        result.Namespace.Should().Be("library");
+        result.Repository.Should().Be("nginx");
+        result.Tag.Should().Be("1.25");
+    }
+
+    #endregion
+
+    #region Parse - Variable references
+
+    [Fact]
+    public void Parse_VariableTag_ExtractsVariableAsTag()
+    {
+        var result = _extractor.Parse("amssolution/ams-api:${VERSION}");
+
+        result.Host.Should().Be("docker.io");
+        result.Namespace.Should().Be("amssolution");
+        result.Repository.Should().Be("ams-api");
+        result.Tag.Should().Be("${VERSION}");
+    }
+
+    [Fact]
+    public void Parse_VariableInImage_ExtractsAsIs()
+    {
+        var result = _extractor.Parse("${REGISTRY}/myimage:latest");
+
+        // Variable substitution not resolved — parse as-is
+        result.OriginalReference.Should().Be("${REGISTRY}/myimage:latest");
+    }
+
+    #endregion
+
+    #region Parse - Edge cases
+
+    [Fact]
+    public void Parse_EmptyString_ReturnsDefaults()
+    {
+        var result = _extractor.Parse("");
+
+        result.Host.Should().Be("docker.io");
+        result.Namespace.Should().Be("library");
+        result.Repository.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_WhitespaceString_ReturnsDefaults()
+    {
+        var result = _extractor.Parse("   ");
+
+        result.Host.Should().Be("docker.io");
+        result.Namespace.Should().Be("library");
+        result.Repository.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Parse_PreservesOriginalReference()
+    {
+        var result = _extractor.Parse("  ghcr.io/org/image:v1  ");
+
+        result.OriginalReference.Should().Be("ghcr.io/org/image:v1");
+    }
+
+    [Fact]
+    public void Parse_LocalhostWithPort_ExtractsCorrectly()
+    {
+        var result = _extractor.Parse("localhost:5000/myapp:dev");
+
+        result.Host.Should().Be("localhost:5000");
+        result.Namespace.Should().Be("library");
+        result.Repository.Should().Be("myapp");
+        result.Tag.Should().Be("dev");
+    }
+
+    #endregion
+
+    #region GroupByRegistryArea - Basic grouping
+
+    [Fact]
+    public void GroupByRegistryArea_EmptyList_ReturnsEmpty()
+    {
+        var result = _extractor.GroupByRegistryArea([]);
+
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GroupByRegistryArea_SingleImage_ReturnsSingleArea()
+    {
+        var result = _extractor.GroupByRegistryArea(["nginx:latest"]);
+
+        result.Should().HaveCount(1);
+        result[0].Host.Should().Be("docker.io");
+        result[0].Namespace.Should().Be("library");
+        result[0].Images.Should().ContainSingle().Which.Should().Be("nginx:latest");
+    }
+
+    [Fact]
+    public void GroupByRegistryArea_SameNamespace_GroupedTogether()
+    {
+        var images = new[]
+        {
+            "amssolution/ams-api:0.5.0",
+            "amssolution/ams-worker:0.5.0",
+            "amssolution/ams-web:latest"
+        };
+
+        var result = _extractor.GroupByRegistryArea(images);
+
+        result.Should().HaveCount(1);
+        result[0].Namespace.Should().Be("amssolution");
+        result[0].Images.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void GroupByRegistryArea_DifferentNamespaces_SeparateAreas()
+    {
+        var images = new[]
+        {
+            "amssolution/ams-api:0.5.0",
+            "nginx:latest",
+            "ghcr.io/wiesenwischer/app:1.0"
+        };
+
+        var result = _extractor.GroupByRegistryArea(images);
+
+        result.Should().HaveCount(3);
+        result.Select(a => a.Namespace).Should()
+            .Contain("amssolution")
+            .And.Contain("library")
+            .And.Contain("wiesenwischer");
+    }
+
+    [Fact]
+    public void GroupByRegistryArea_DuplicateImages_Deduplicated()
+    {
+        var images = new[]
+        {
+            "nginx:latest",
+            "nginx:latest",
+            "nginx:1.25"
+        };
+
+        var result = _extractor.GroupByRegistryArea(images);
+
+        result.Should().HaveCount(1);
+        result[0].Images.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void GroupByRegistryArea_CaseInsensitiveGrouping()
+    {
+        var images = new[]
+        {
+            "Amssolution/ams-api:1.0",
+            "amssolution/ams-worker:1.0"
+        };
+
+        var result = _extractor.GroupByRegistryArea(images);
+
+        result.Should().HaveCount(1);
+        result[0].Images.Should().HaveCount(2);
+    }
+
+    #endregion
+
+    #region GroupByRegistryArea - Suggested patterns
+
+    [Fact]
+    public void GroupByRegistryArea_DockerHub_SuggestsNamespacePattern()
+    {
+        var result = _extractor.GroupByRegistryArea(["amssolution/ams-api:1.0"]);
+
+        result[0].SuggestedPattern.Should().Be("amssolution/*");
+    }
+
+    [Fact]
+    public void GroupByRegistryArea_DockerHubLibrary_SuggestsLibraryPattern()
+    {
+        var result = _extractor.GroupByRegistryArea(["nginx:latest"]);
+
+        result[0].SuggestedPattern.Should().Be("library/*");
+    }
+
+    [Fact]
+    public void GroupByRegistryArea_CustomRegistry_IncludesHostInPattern()
+    {
+        var result = _extractor.GroupByRegistryArea(["ghcr.io/myorg/app:v1"]);
+
+        result[0].SuggestedPattern.Should().Be("ghcr.io/myorg/*");
+    }
+
+    #endregion
+
+    #region GroupByRegistryArea - Suggested names
+
+    [Fact]
+    public void GroupByRegistryArea_DockerHubUser_NameIncludesNamespace()
+    {
+        var result = _extractor.GroupByRegistryArea(["amssolution/ams-api:1.0"]);
+
+        result[0].SuggestedName.Should().Be("Docker Hub – amssolution");
+    }
+
+    [Fact]
+    public void GroupByRegistryArea_DockerHubLibrary_NameIsOfficialImages()
+    {
+        var result = _extractor.GroupByRegistryArea(["nginx:latest"]);
+
+        result[0].SuggestedName.Should().Be("Docker Hub (Official Images)");
+    }
+
+    [Fact]
+    public void GroupByRegistryArea_CustomRegistry_NameIncludesHost()
+    {
+        var result = _extractor.GroupByRegistryArea(["ghcr.io/myorg/app:v1"]);
+
+        result[0].SuggestedName.Should().Be("ghcr.io – myorg");
+    }
+
+    #endregion
+
+    #region GroupByRegistryArea - IsLikelyPublic
+
+    [Fact]
+    public void GroupByRegistryArea_DockerHubLibrary_IsLikelyPublic()
+    {
+        var result = _extractor.GroupByRegistryArea(["nginx:latest", "redis:7", "postgres:16"]);
+
+        result[0].IsLikelyPublic.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GroupByRegistryArea_DockerHubUser_NotLikelyPublic()
+    {
+        var result = _extractor.GroupByRegistryArea(["amssolution/ams-api:1.0"]);
+
+        result[0].IsLikelyPublic.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GroupByRegistryArea_CustomRegistry_NotLikelyPublic()
+    {
+        var result = _extractor.GroupByRegistryArea(["ghcr.io/myorg/app:v1"]);
+
+        result[0].IsLikelyPublic.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region GroupByRegistryArea - Edge cases
+
+    [Fact]
+    public void GroupByRegistryArea_NullAndEmptyStrings_Ignored()
+    {
+        var images = new[] { "", "  ", "nginx:latest" };
+
+        var result = _extractor.GroupByRegistryArea(images);
+
+        result.Should().HaveCount(1);
+        result[0].Images.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void GroupByRegistryArea_MixedRegistries_CorrectGrouping()
+    {
+        var images = new[]
+        {
+            "nginx:latest",
+            "redis:7",
+            "amssolution/ams-api:1.0",
+            "amssolution/ams-worker:1.0",
+            "ghcr.io/wiesenwischer/app:v1",
+            "ghcr.io/wiesenwischer/web:v2"
+        };
+
+        var result = _extractor.GroupByRegistryArea(images);
+
+        result.Should().HaveCount(3);
+
+        var dockerHubLibrary = result.First(a => a.Namespace == "library");
+        dockerHubLibrary.Images.Should().HaveCount(2);
+        dockerHubLibrary.IsLikelyPublic.Should().BeTrue();
+
+        var dockerHubAms = result.First(a => a.Namespace == "amssolution");
+        dockerHubAms.Images.Should().HaveCount(2);
+        dockerHubAms.IsLikelyPublic.Should().BeFalse();
+
+        var ghcr = result.First(a => a.Host == "ghcr.io");
+        ghcr.Images.Should().HaveCount(2);
+        ghcr.IsLikelyPublic.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GroupByRegistryArea_ResultsAreSortedByHostThenNamespace()
+    {
+        var images = new[]
+        {
+            "ghcr.io/zorg/app:v1",
+            "nginx:latest",
+            "ghcr.io/aorg/app:v1",
+            "amssolution/ams-api:1.0"
+        };
+
+        var result = _extractor.GroupByRegistryArea(images);
+
+        result.Should().HaveCount(4);
+        var keys = result.Select(a => $"{a.Host}/{a.Namespace}").ToList();
+        keys.Should().BeInAscendingOrder();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- New `IImageReferenceExtractor` interface in Application layer with `Parse()` and `GroupByRegistryArea()` methods
- `ImageReferenceExtractor` implementation in Infrastructure layer parsing Docker image references into components (host, namespace, repository, tag)
- Groups images by registry area (host + namespace) with suggested patterns, names, and public image detection
- Handles Docker Hub defaults, explicit Docker Hub hosts (index.docker.io, registry-1.docker.io), custom registries, ports, digests, variable references
- Registered as singleton in DI container
- v0.25 plan file added (`docs/Plans/PLAN-registry-wizard-ux.md`)

## Test plan
- [x] 40 unit tests covering all parsing scenarios
- [x] Edge cases: empty strings, whitespace, digests, variables, localhost with port
- [x] Grouping: deduplication, case-insensitive, sorted output
- [x] Suggestions: pattern generation, name generation, IsLikelyPublic
- [x] Full test suite passes (1656 tests)