### PR TITLE
Add detect registries endpoint for wizard

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/Wizard/DetectRegistriesEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Wizard/DetectRegistriesEndpoint.cs
@@ -1,0 +1,62 @@
+using FastEndpoints;
+using MediatR;
+using ReadyStackGo.Application.UseCases.Wizard.DetectRegistries;
+
+namespace ReadyStackGo.API.Endpoints.Wizard;
+
+/// <summary>
+/// GET /api/wizard/detected-registries - Detect container registries needed by loaded stacks.
+/// Returns registry areas grouped by host + namespace with configuration status.
+/// Anonymous access (wizard runs before login).
+/// </summary>
+public class DetectRegistriesEndpoint : EndpointWithoutRequest<DetectRegistriesResponse>
+{
+    private readonly IMediator _mediator;
+
+    public DetectRegistriesEndpoint(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Get("/api/wizard/detected-registries");
+        AllowAnonymous();
+        PreProcessor<WizardTimeoutPreProcessor<EmptyRequest>>();
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        var result = await _mediator.Send(new DetectRegistriesQuery(), ct);
+
+        Response = new DetectRegistriesResponse
+        {
+            Areas = result.Areas.Select(a => new DetectedRegistryAreaDto
+            {
+                Host = a.Host,
+                Namespace = a.Namespace,
+                SuggestedPattern = a.SuggestedPattern,
+                SuggestedName = a.SuggestedName,
+                IsLikelyPublic = a.IsLikelyPublic,
+                IsConfigured = a.IsConfigured,
+                Images = a.Images
+            }).ToList()
+        };
+    }
+}
+
+public class DetectRegistriesResponse
+{
+    public IReadOnlyList<DetectedRegistryAreaDto> Areas { get; init; } = [];
+}
+
+public class DetectedRegistryAreaDto
+{
+    public required string Host { get; init; }
+    public required string Namespace { get; init; }
+    public required string SuggestedPattern { get; init; }
+    public required string SuggestedName { get; init; }
+    public bool IsLikelyPublic { get; init; }
+    public bool IsConfigured { get; init; }
+    public IReadOnlyList<string> Images { get; init; } = [];
+}

--- a/src/ReadyStackGo.Application/UseCases/Wizard/DetectRegistries/DetectRegistriesHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Wizard/DetectRegistries/DetectRegistriesHandler.cs
@@ -1,0 +1,108 @@
+using MediatR;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Domain.Deployment.Registries;
+using ReadyStackGo.Domain.IdentityAccess.Organizations;
+
+namespace ReadyStackGo.Application.UseCases.Wizard.DetectRegistries;
+
+public class DetectRegistriesHandler : IRequestHandler<DetectRegistriesQuery, DetectRegistriesResult>
+{
+    private readonly IProductCache _productCache;
+    private readonly IImageReferenceExtractor _extractor;
+    private readonly IRegistryRepository _registryRepository;
+    private readonly IOrganizationRepository _organizationRepository;
+
+    public DetectRegistriesHandler(
+        IProductCache productCache,
+        IImageReferenceExtractor extractor,
+        IRegistryRepository registryRepository,
+        IOrganizationRepository organizationRepository)
+    {
+        _productCache = productCache;
+        _extractor = extractor;
+        _registryRepository = registryRepository;
+        _organizationRepository = organizationRepository;
+    }
+
+    public Task<DetectRegistriesResult> Handle(DetectRegistriesQuery request, CancellationToken cancellationToken)
+    {
+        // Collect all image references from cached stacks
+        var imageReferences = _productCache.GetAllStacks()
+            .SelectMany(s => s.Services)
+            .Select(svc => svc.Image)
+            .Where(img => !string.IsNullOrWhiteSpace(img))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        IReadOnlyList<RegistryArea> areas;
+
+        if (imageReferences.Count > 0)
+        {
+            areas = _extractor.GroupByRegistryArea(imageReferences);
+        }
+        else
+        {
+            // No stacks loaded — provide default registry set
+            areas = GetDefaultRegistryAreas();
+        }
+
+        // Cross-reference with existing registries
+        var organization = _organizationRepository.GetAll().FirstOrDefault();
+        var existingRegistries = organization != null
+            ? _registryRepository.GetByOrganization(
+                Domain.Deployment.OrganizationId.FromIdentityAccess(organization.Id)).ToList()
+            : [];
+
+        var detectedAreas = areas.Select(area =>
+        {
+            var isConfigured = existingRegistries.Any(r =>
+                area.Images.Any(img => r.MatchesImage(img)));
+
+            return new DetectedRegistryArea(
+                Host: area.Host,
+                Namespace: area.Namespace,
+                SuggestedPattern: area.SuggestedPattern,
+                SuggestedName: area.SuggestedName,
+                IsLikelyPublic: area.IsLikelyPublic,
+                IsConfigured: isConfigured,
+                Images: area.Images);
+        }).ToList();
+
+        return Task.FromResult(new DetectRegistriesResult(detectedAreas));
+    }
+
+    private static IReadOnlyList<RegistryArea> GetDefaultRegistryAreas()
+    {
+        return
+        [
+            new RegistryArea(
+                Host: "docker.io",
+                Namespace: "library",
+                SuggestedPattern: "library/*",
+                SuggestedName: "Docker Hub (Official Images)",
+                IsLikelyPublic: true,
+                Images: []),
+            new RegistryArea(
+                Host: "ghcr.io",
+                Namespace: "*",
+                SuggestedPattern: "ghcr.io/**",
+                SuggestedName: "GitHub Container Registry",
+                IsLikelyPublic: false,
+                Images: []),
+            new RegistryArea(
+                Host: "registry.gitlab.com",
+                Namespace: "*",
+                SuggestedPattern: "registry.gitlab.com/**",
+                SuggestedName: "GitLab Container Registry",
+                IsLikelyPublic: false,
+                Images: []),
+            new RegistryArea(
+                Host: "quay.io",
+                Namespace: "*",
+                SuggestedPattern: "quay.io/**",
+                SuggestedName: "Quay.io",
+                IsLikelyPublic: false,
+                Images: [])
+        ];
+    }
+}

--- a/src/ReadyStackGo.Application/UseCases/Wizard/DetectRegistries/DetectRegistriesQuery.cs
+++ b/src/ReadyStackGo.Application/UseCases/Wizard/DetectRegistries/DetectRegistriesQuery.cs
@@ -1,0 +1,16 @@
+using MediatR;
+
+namespace ReadyStackGo.Application.UseCases.Wizard.DetectRegistries;
+
+public record DetectRegistriesQuery : IRequest<DetectRegistriesResult>;
+
+public record DetectRegistriesResult(IReadOnlyList<DetectedRegistryArea> Areas);
+
+public record DetectedRegistryArea(
+    string Host,
+    string Namespace,
+    string SuggestedPattern,
+    string SuggestedName,
+    bool IsLikelyPublic,
+    bool IsConfigured,
+    IReadOnlyList<string> Images);

--- a/tests/ReadyStackGo.UnitTests/Application/Wizard/DetectRegistriesHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Wizard/DetectRegistriesHandlerTests.cs
@@ -1,0 +1,337 @@
+using FluentAssertions;
+using Moq;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Application.UseCases.Wizard.DetectRegistries;
+using ReadyStackGo.Domain.Deployment.Registries;
+using ReadyStackGo.Domain.IdentityAccess.Organizations;
+using ReadyStackGo.Domain.StackManagement.Stacks;
+using DeploymentOrgId = ReadyStackGo.Domain.Deployment.OrganizationId;
+
+namespace ReadyStackGo.UnitTests.Application.Wizard;
+
+public class DetectRegistriesHandlerTests
+{
+    private readonly Mock<IProductCache> _productCacheMock = new();
+    private readonly Mock<IImageReferenceExtractor> _extractorMock = new();
+    private readonly Mock<IRegistryRepository> _registryRepoMock = new();
+    private readonly Mock<IOrganizationRepository> _orgRepoMock = new();
+
+    private DetectRegistriesHandler CreateHandler()
+        => new(_productCacheMock.Object, _extractorMock.Object,
+            _registryRepoMock.Object, _orgRepoMock.Object);
+
+    private static StackDefinition CreateStack(params string[] images)
+    {
+        var services = images.Select(img => new ServiceTemplate
+        {
+            Name = $"svc-{Guid.NewGuid():N}",
+            Image = img
+        }).ToList();
+
+        return new StackDefinition(
+            sourceId: "test-source",
+            name: "test-stack",
+            productId: new ProductId("test-source:test-product"),
+            services: services);
+    }
+
+    private void SetupStacks(params StackDefinition[] stacks)
+    {
+        _productCacheMock.Setup(c => c.GetAllStacks()).Returns(stacks);
+    }
+
+    private void SetupExtractorResult(IReadOnlyList<RegistryArea> areas)
+    {
+        _extractorMock
+            .Setup(e => e.GroupByRegistryArea(It.IsAny<IEnumerable<string>>()))
+            .Returns(areas);
+    }
+
+    private void SetupOrganization()
+    {
+        var org = Organization.Provision(
+            OrganizationId.NewId(), "Test Org", "Test Organization");
+        _orgRepoMock.Setup(r => r.GetAll()).Returns([org]);
+        _registryRepoMock
+            .Setup(r => r.GetByOrganization(It.IsAny<DeploymentOrgId>()))
+            .Returns([]);
+    }
+
+    private void SetupNoOrganization()
+    {
+        _orgRepoMock.Setup(r => r.GetAll()).Returns([]);
+    }
+
+    #region No stacks — default registries
+
+    [Fact]
+    public async Task Handle_NoStacks_ReturnsDefaultRegistryAreas()
+    {
+        SetupStacks();
+        SetupNoOrganization();
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new DetectRegistriesQuery(), CancellationToken.None);
+
+        result.Areas.Should().NotBeEmpty();
+        result.Areas.Should().Contain(a => a.Host == "docker.io");
+        result.Areas.Should().Contain(a => a.Host == "ghcr.io");
+        result.Areas.Should().Contain(a => a.Host == "registry.gitlab.com");
+        result.Areas.Should().Contain(a => a.Host == "quay.io");
+    }
+
+    [Fact]
+    public async Task Handle_NoStacks_DefaultDockerHubIsLikelyPublic()
+    {
+        SetupStacks();
+        SetupNoOrganization();
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new DetectRegistriesQuery(), CancellationToken.None);
+
+        var dockerHub = result.Areas.First(a => a.Host == "docker.io");
+        dockerHub.IsLikelyPublic.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_NoStacks_DoesNotCallExtractor()
+    {
+        SetupStacks();
+        SetupNoOrganization();
+        var handler = CreateHandler();
+
+        await handler.Handle(new DetectRegistriesQuery(), CancellationToken.None);
+
+        _extractorMock.Verify(
+            e => e.GroupByRegistryArea(It.IsAny<IEnumerable<string>>()),
+            Times.Never);
+    }
+
+    #endregion
+
+    #region With stacks — extraction
+
+    [Fact]
+    public async Task Handle_WithStacks_CallsExtractorWithImages()
+    {
+        var stack = CreateStack("nginx:latest", "amssolution/ams-api:1.0");
+        SetupStacks(stack);
+        SetupExtractorResult([]);
+        SetupNoOrganization();
+        var handler = CreateHandler();
+
+        await handler.Handle(new DetectRegistriesQuery(), CancellationToken.None);
+
+        _extractorMock.Verify(
+            e => e.GroupByRegistryArea(It.Is<IEnumerable<string>>(imgs =>
+                imgs.Contains("nginx:latest") && imgs.Contains("amssolution/ams-api:1.0"))),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithStacks_ReturnsExtractorResults()
+    {
+        var stack = CreateStack("nginx:latest");
+        SetupStacks(stack);
+        SetupExtractorResult([
+            new RegistryArea("docker.io", "library", "library/*",
+                "Docker Hub (Official Images)", true, ["nginx:latest"])
+        ]);
+        SetupNoOrganization();
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new DetectRegistriesQuery(), CancellationToken.None);
+
+        result.Areas.Should().HaveCount(1);
+        result.Areas[0].Host.Should().Be("docker.io");
+        result.Areas[0].SuggestedPattern.Should().Be("library/*");
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateImages_DeduplicatedBeforeExtraction()
+    {
+        var stack1 = CreateStack("nginx:latest");
+        var stack2 = CreateStack("nginx:latest");
+        SetupStacks(stack1, stack2);
+        SetupExtractorResult([]);
+        SetupNoOrganization();
+        var handler = CreateHandler();
+
+        await handler.Handle(new DetectRegistriesQuery(), CancellationToken.None);
+
+        _extractorMock.Verify(
+            e => e.GroupByRegistryArea(It.Is<IEnumerable<string>>(imgs =>
+                imgs.Count() == 1)),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyImageStrings_FilteredOut()
+    {
+        var stack = CreateStack("nginx:latest", "", "  ");
+        SetupStacks(stack);
+        SetupExtractorResult([]);
+        SetupNoOrganization();
+        var handler = CreateHandler();
+
+        await handler.Handle(new DetectRegistriesQuery(), CancellationToken.None);
+
+        _extractorMock.Verify(
+            e => e.GroupByRegistryArea(It.Is<IEnumerable<string>>(imgs =>
+                imgs.All(i => !string.IsNullOrWhiteSpace(i)))),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_MultipleStacks_CollectsAllImages()
+    {
+        var stack1 = CreateStack("nginx:latest", "redis:7");
+        var stack2 = CreateStack("postgres:16", "amssolution/ams-api:1.0");
+        SetupStacks(stack1, stack2);
+        SetupExtractorResult([]);
+        SetupNoOrganization();
+        var handler = CreateHandler();
+
+        await handler.Handle(new DetectRegistriesQuery(), CancellationToken.None);
+
+        _extractorMock.Verify(
+            e => e.GroupByRegistryArea(It.Is<IEnumerable<string>>(imgs =>
+                imgs.Count() == 4)),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region IsConfigured detection
+
+    [Fact]
+    public async Task Handle_NoExistingRegistries_AllAreasNotConfigured()
+    {
+        var stack = CreateStack("nginx:latest");
+        SetupStacks(stack);
+        SetupExtractorResult([
+            new RegistryArea("docker.io", "library", "library/*",
+                "Docker Hub", true, ["nginx:latest"])
+        ]);
+        SetupOrganization();
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new DetectRegistriesQuery(), CancellationToken.None);
+
+        result.Areas.Should().AllSatisfy(a => a.IsConfigured.Should().BeFalse());
+    }
+
+    [Fact]
+    public async Task Handle_MatchingRegistryExists_IsConfiguredTrue()
+    {
+        var stack = CreateStack("ghcr.io/myorg/app:v1");
+        SetupStacks(stack);
+        SetupExtractorResult([
+            new RegistryArea("ghcr.io", "myorg", "ghcr.io/myorg/*",
+                "ghcr.io – myorg", false, ["ghcr.io/myorg/app:v1"])
+        ]);
+
+        var org = Organization.Provision(OrganizationId.NewId(), "Test Org", "Test Organization");
+        _orgRepoMock.Setup(r => r.GetAll()).Returns([org]);
+
+        var registry = Registry.Create(
+            RegistryId.NewId(),
+            DeploymentOrgId.FromIdentityAccess(org.Id),
+            "GHCR",
+            "https://ghcr.io",
+            "user", "token");
+        registry.SetImagePatterns(["ghcr.io/myorg/*"]);
+
+        _registryRepoMock
+            .Setup(r => r.GetByOrganization(It.IsAny<DeploymentOrgId>()))
+            .Returns([registry]);
+
+        var handler = CreateHandler();
+        var result = await handler.Handle(new DetectRegistriesQuery(), CancellationToken.None);
+
+        result.Areas.Should().HaveCount(1);
+        result.Areas[0].IsConfigured.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_NoOrganization_AllNotConfigured()
+    {
+        var stack = CreateStack("nginx:latest");
+        SetupStacks(stack);
+        SetupExtractorResult([
+            new RegistryArea("docker.io", "library", "library/*",
+                "Docker Hub", true, ["nginx:latest"])
+        ]);
+        SetupNoOrganization();
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new DetectRegistriesQuery(), CancellationToken.None);
+
+        result.Areas.Should().AllSatisfy(a => a.IsConfigured.Should().BeFalse());
+    }
+
+    [Fact]
+    public async Task Handle_MixedConfiguredAndNotConfigured()
+    {
+        var stack = CreateStack("nginx:latest", "ghcr.io/myorg/app:v1");
+        SetupStacks(stack);
+        SetupExtractorResult([
+            new RegistryArea("docker.io", "library", "library/*",
+                "Docker Hub", true, ["nginx:latest"]),
+            new RegistryArea("ghcr.io", "myorg", "ghcr.io/myorg/*",
+                "ghcr.io – myorg", false, ["ghcr.io/myorg/app:v1"])
+        ]);
+
+        var org = Organization.Provision(OrganizationId.NewId(), "Test Org", "Test Organization");
+        _orgRepoMock.Setup(r => r.GetAll()).Returns([org]);
+
+        var registry = Registry.Create(
+            RegistryId.NewId(),
+            DeploymentOrgId.FromIdentityAccess(org.Id),
+            "GHCR",
+            "https://ghcr.io",
+            "user", "token");
+        registry.SetImagePatterns(["ghcr.io/myorg/*"]);
+
+        _registryRepoMock
+            .Setup(r => r.GetByOrganization(It.IsAny<DeploymentOrgId>()))
+            .Returns([registry]);
+
+        var handler = CreateHandler();
+        var result = await handler.Handle(new DetectRegistriesQuery(), CancellationToken.None);
+
+        result.Areas.First(a => a.Host == "docker.io").IsConfigured.Should().BeFalse();
+        result.Areas.First(a => a.Host == "ghcr.io").IsConfigured.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region Field mapping
+
+    [Fact]
+    public async Task Handle_MapsAllFieldsCorrectly()
+    {
+        var stack = CreateStack("amssolution/ams-api:1.0");
+        SetupStacks(stack);
+        SetupExtractorResult([
+            new RegistryArea("docker.io", "amssolution", "amssolution/*",
+                "Docker Hub – amssolution", false,
+                ["amssolution/ams-api:1.0"])
+        ]);
+        SetupNoOrganization();
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new DetectRegistriesQuery(), CancellationToken.None);
+
+        var area = result.Areas.Single();
+        area.Host.Should().Be("docker.io");
+        area.Namespace.Should().Be("amssolution");
+        area.SuggestedPattern.Should().Be("amssolution/*");
+        area.SuggestedName.Should().Be("Docker Hub – amssolution");
+        area.IsLikelyPublic.Should().BeFalse();
+        area.IsConfigured.Should().BeFalse();
+        area.Images.Should().Contain("amssolution/ams-api:1.0");
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- `DetectRegistriesQuery` / `DetectRegistriesHandler` in Application layer extracts images from cached stacks and groups by registry area
- Cross-references detected areas with existing Registry configurations to mark `IsConfigured`
- Falls back to default registry set (Docker Hub, GHCR, GitLab, Quay.io) when no stacks are loaded
- `GET /api/wizard/detected-registries` FastEndpoint with anonymous access and WizardTimeoutPreProcessor

## Test plan
- [x] 13 unit tests for handler (empty stacks, extraction, dedup, IsConfigured, field mapping)
- [x] Full test suite passes (1669 tests)