### PR TITLE
Add bulk create registries endpoint for wizard

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/Wizard/SetRegistriesEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Wizard/SetRegistriesEndpoint.cs
@@ -1,0 +1,70 @@
+using FastEndpoints;
+using MediatR;
+using ReadyStackGo.Application.UseCases.Wizard.SetRegistries;
+
+namespace ReadyStackGo.API.Endpoints.Wizard;
+
+/// <summary>
+/// POST /api/wizard/registries - Bulk create registry configurations from wizard input.
+/// Anonymous access (wizard runs before login).
+/// </summary>
+public class SetRegistriesEndpoint : Endpoint<SetRegistriesRequest, SetRegistriesResponse>
+{
+    private readonly IMediator _mediator;
+
+    public SetRegistriesEndpoint(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Post("/api/wizard/registries");
+        AllowAnonymous();
+        PreProcessor<WizardTimeoutPreProcessor<SetRegistriesRequest>>();
+    }
+
+    public override async Task HandleAsync(SetRegistriesRequest req, CancellationToken ct)
+    {
+        var command = new SetRegistriesCommand(
+            req.Registries.Select(r => new RegistryInput(
+                Name: r.Name,
+                Host: r.Host,
+                Pattern: r.Pattern,
+                RequiresAuth: r.RequiresAuth,
+                Username: r.Username,
+                Password: r.Password
+            )).ToList());
+
+        var result = await _mediator.Send(command, ct);
+
+        Response = new SetRegistriesResponse
+        {
+            Success = result.Success,
+            RegistriesCreated = result.RegistriesCreated,
+            RegistriesSkipped = result.RegistriesSkipped
+        };
+    }
+}
+
+public class SetRegistriesRequest
+{
+    public IReadOnlyList<RegistryInputDto> Registries { get; init; } = [];
+}
+
+public class RegistryInputDto
+{
+    public required string Name { get; init; }
+    public required string Host { get; init; }
+    public required string Pattern { get; init; }
+    public bool RequiresAuth { get; init; }
+    public string? Username { get; init; }
+    public string? Password { get; init; }
+}
+
+public class SetRegistriesResponse
+{
+    public bool Success { get; init; }
+    public int RegistriesCreated { get; init; }
+    public int RegistriesSkipped { get; init; }
+}

--- a/src/ReadyStackGo.Application/UseCases/Wizard/SetRegistries/SetRegistriesCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Wizard/SetRegistries/SetRegistriesCommand.cs
@@ -1,0 +1,19 @@
+using MediatR;
+
+namespace ReadyStackGo.Application.UseCases.Wizard.SetRegistries;
+
+public record RegistryInput(
+    string Name,
+    string Host,
+    string Pattern,
+    bool RequiresAuth,
+    string? Username,
+    string? Password);
+
+public record SetRegistriesCommand(
+    IReadOnlyList<RegistryInput> Registries) : IRequest<SetRegistriesResult>;
+
+public record SetRegistriesResult(
+    bool Success,
+    int RegistriesCreated,
+    int RegistriesSkipped);

--- a/src/ReadyStackGo.Application/UseCases/Wizard/SetRegistries/SetRegistriesHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Wizard/SetRegistries/SetRegistriesHandler.cs
@@ -1,0 +1,107 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using ReadyStackGo.Domain.Deployment.Registries;
+using ReadyStackGo.Domain.IdentityAccess.Organizations;
+
+namespace ReadyStackGo.Application.UseCases.Wizard.SetRegistries;
+
+public class SetRegistriesHandler : IRequestHandler<SetRegistriesCommand, SetRegistriesResult>
+{
+    private readonly IOrganizationRepository _organizationRepository;
+    private readonly IRegistryRepository _registryRepository;
+    private readonly ILogger<SetRegistriesHandler> _logger;
+
+    public SetRegistriesHandler(
+        IOrganizationRepository organizationRepository,
+        IRegistryRepository registryRepository,
+        ILogger<SetRegistriesHandler> logger)
+    {
+        _organizationRepository = organizationRepository;
+        _registryRepository = registryRepository;
+        _logger = logger;
+    }
+
+    public Task<SetRegistriesResult> Handle(SetRegistriesCommand request, CancellationToken cancellationToken)
+    {
+        if (request.Registries.Count == 0)
+            return Task.FromResult(new SetRegistriesResult(true, 0, 0));
+
+        var organization = _organizationRepository.GetAll().FirstOrDefault();
+        if (organization == null)
+        {
+            _logger.LogWarning("No organization found — cannot create registries");
+            return Task.FromResult(new SetRegistriesResult(false, 0, request.Registries.Count));
+        }
+
+        var orgId = Domain.Deployment.OrganizationId.FromIdentityAccess(organization.Id);
+        var existingRegistries = _registryRepository.GetByOrganization(orgId).ToList();
+
+        var created = 0;
+        var skipped = 0;
+
+        foreach (var input in request.Registries)
+        {
+            // Skip public registries — they don't need configuration
+            if (!input.RequiresAuth)
+            {
+                _logger.LogDebug("Skipping public registry area: {Name}", input.Name);
+                skipped++;
+                continue;
+            }
+
+            // Skip if missing credentials
+            if (string.IsNullOrWhiteSpace(input.Username) || string.IsNullOrWhiteSpace(input.Password))
+            {
+                _logger.LogWarning("Skipping registry {Name}: auth required but credentials missing", input.Name);
+                skipped++;
+                continue;
+            }
+
+            // Skip if a registry with matching pattern already exists
+            if (HasMatchingRegistry(existingRegistries, input.Pattern))
+            {
+                _logger.LogDebug("Skipping registry {Name}: matching pattern already exists", input.Name);
+                skipped++;
+                continue;
+            }
+
+            // Create new registry
+            var url = NormalizeHostToUrl(input.Host);
+            var registry = Registry.Create(
+                RegistryId.NewId(),
+                orgId,
+                input.Name,
+                url,
+                input.Username,
+                input.Password);
+
+            registry.SetImagePatterns([input.Pattern]);
+
+            _registryRepository.Add(registry);
+            existingRegistries.Add(registry); // Track for duplicate detection within batch
+            created++;
+
+            _logger.LogInformation("Created registry {Name} with pattern {Pattern}", input.Name, input.Pattern);
+        }
+
+        _registryRepository.SaveChanges();
+
+        return Task.FromResult(new SetRegistriesResult(true, created, skipped));
+    }
+
+    private static bool HasMatchingRegistry(IEnumerable<Registry> registries, string pattern)
+    {
+        return registries.Any(r =>
+            r.ImagePatterns.Any(p =>
+                string.Equals(p, pattern, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    private static string NormalizeHostToUrl(string host)
+    {
+        if (host.StartsWith("http://", StringComparison.OrdinalIgnoreCase) ||
+            host.StartsWith("https://", StringComparison.OrdinalIgnoreCase))
+            return host;
+
+        return $"https://{host}";
+    }
+}

--- a/tests/ReadyStackGo.UnitTests/Application/Wizard/SetRegistriesHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Wizard/SetRegistriesHandlerTests.cs
@@ -1,0 +1,349 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ReadyStackGo.Application.UseCases.Wizard.SetRegistries;
+using ReadyStackGo.Domain.Deployment.Registries;
+using ReadyStackGo.Domain.IdentityAccess.Organizations;
+using DeploymentOrgId = ReadyStackGo.Domain.Deployment.OrganizationId;
+
+namespace ReadyStackGo.UnitTests.Application.Wizard;
+
+public class SetRegistriesHandlerTests
+{
+    private readonly Mock<IOrganizationRepository> _orgRepoMock = new();
+    private readonly Mock<IRegistryRepository> _registryRepoMock = new();
+    private readonly Mock<ILogger<SetRegistriesHandler>> _loggerMock = new();
+
+    private SetRegistriesHandler CreateHandler()
+        => new(_orgRepoMock.Object, _registryRepoMock.Object, _loggerMock.Object);
+
+    private Organization SetupOrganization()
+    {
+        var org = Organization.Provision(
+            OrganizationId.NewId(), "Test Org", "Test Organization");
+        _orgRepoMock.Setup(r => r.GetAll()).Returns([org]);
+        _registryRepoMock
+            .Setup(r => r.GetByOrganization(It.IsAny<DeploymentOrgId>()))
+            .Returns([]);
+        return org;
+    }
+
+    private static RegistryInput CreateInput(
+        string name = "Test Registry",
+        string host = "docker.io",
+        string pattern = "myorg/*",
+        bool requiresAuth = true,
+        string? username = "user",
+        string? password = "pass")
+        => new(name, host, pattern, requiresAuth, username, password);
+
+    #region Empty input
+
+    [Fact]
+    public async Task Handle_EmptyList_ReturnsSuccessWithZeroCounts()
+    {
+        SetupOrganization();
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(
+            new SetRegistriesCommand([]), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.RegistriesCreated.Should().Be(0);
+        result.RegistriesSkipped.Should().Be(0);
+    }
+
+    #endregion
+
+    #region No organization
+
+    [Fact]
+    public async Task Handle_NoOrganization_ReturnsFalse()
+    {
+        _orgRepoMock.Setup(r => r.GetAll()).Returns([]);
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(
+            new SetRegistriesCommand([CreateInput()]), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.RegistriesCreated.Should().Be(0);
+    }
+
+    #endregion
+
+    #region Successful creation
+
+    [Fact]
+    public async Task Handle_ValidInput_CreatesRegistry()
+    {
+        SetupOrganization();
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(
+            new SetRegistriesCommand([CreateInput(name: "My Registry", host: "ghcr.io", pattern: "ghcr.io/myorg/*")]),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.RegistriesCreated.Should().Be(1);
+
+        _registryRepoMock.Verify(
+            r => r.Add(It.Is<Registry>(reg =>
+                reg.Name == "My Registry" &&
+                reg.Url.Contains("ghcr.io") &&
+                reg.Username == "user" &&
+                reg.Password == "pass" &&
+                reg.ImagePatterns.Contains("ghcr.io/myorg/*"))),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_MultipleInputs_CreatesAll()
+    {
+        SetupOrganization();
+        var handler = CreateHandler();
+
+        var inputs = new[]
+        {
+            CreateInput(name: "Registry 1", host: "ghcr.io", pattern: "ghcr.io/org1/*"),
+            CreateInput(name: "Registry 2", host: "docker.io", pattern: "myorg/*")
+        };
+
+        var result = await handler.Handle(
+            new SetRegistriesCommand(inputs), CancellationToken.None);
+
+        result.RegistriesCreated.Should().Be(2);
+        _registryRepoMock.Verify(r => r.Add(It.IsAny<Registry>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task Handle_SaveChangesCalledOnce()
+    {
+        SetupOrganization();
+        var handler = CreateHandler();
+
+        await handler.Handle(
+            new SetRegistriesCommand([CreateInput()]), CancellationToken.None);
+
+        _registryRepoMock.Verify(r => r.SaveChanges(), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_HostNormalized_AddsHttpsPrefix()
+    {
+        SetupOrganization();
+        var handler = CreateHandler();
+
+        await handler.Handle(
+            new SetRegistriesCommand([CreateInput(host: "ghcr.io")]),
+            CancellationToken.None);
+
+        _registryRepoMock.Verify(
+            r => r.Add(It.Is<Registry>(reg => reg.Url.StartsWith("https://"))),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_HostWithHttps_NotDoubled()
+    {
+        SetupOrganization();
+        var handler = CreateHandler();
+
+        await handler.Handle(
+            new SetRegistriesCommand([CreateInput(host: "https://ghcr.io")]),
+            CancellationToken.None);
+
+        _registryRepoMock.Verify(
+            r => r.Add(It.Is<Registry>(reg => !reg.Url.Contains("https://https://"))),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region Public registries — skipped
+
+    [Fact]
+    public async Task Handle_PublicRegistry_Skipped()
+    {
+        SetupOrganization();
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(
+            new SetRegistriesCommand([CreateInput(requiresAuth: false)]),
+            CancellationToken.None);
+
+        result.RegistriesCreated.Should().Be(0);
+        result.RegistriesSkipped.Should().Be(1);
+        _registryRepoMock.Verify(r => r.Add(It.IsAny<Registry>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_MixedPublicAndPrivate_OnlyPrivateCreated()
+    {
+        SetupOrganization();
+        var handler = CreateHandler();
+
+        var inputs = new[]
+        {
+            CreateInput(name: "Public", requiresAuth: false),
+            CreateInput(name: "Private", pattern: "myorg/*", requiresAuth: true)
+        };
+
+        var result = await handler.Handle(
+            new SetRegistriesCommand(inputs), CancellationToken.None);
+
+        result.RegistriesCreated.Should().Be(1);
+        result.RegistriesSkipped.Should().Be(1);
+    }
+
+    #endregion
+
+    #region Missing credentials — skipped
+
+    [Fact]
+    public async Task Handle_AuthRequiredButNoUsername_Skipped()
+    {
+        SetupOrganization();
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(
+            new SetRegistriesCommand([CreateInput(username: null)]),
+            CancellationToken.None);
+
+        result.RegistriesCreated.Should().Be(0);
+        result.RegistriesSkipped.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_AuthRequiredButNoPassword_Skipped()
+    {
+        SetupOrganization();
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(
+            new SetRegistriesCommand([CreateInput(password: null)]),
+            CancellationToken.None);
+
+        result.RegistriesCreated.Should().Be(0);
+        result.RegistriesSkipped.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_AuthRequiredButEmptyUsername_Skipped()
+    {
+        SetupOrganization();
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(
+            new SetRegistriesCommand([CreateInput(username: "  ")]),
+            CancellationToken.None);
+
+        result.RegistriesCreated.Should().Be(0);
+        result.RegistriesSkipped.Should().Be(1);
+    }
+
+    #endregion
+
+    #region Duplicate detection
+
+    [Fact]
+    public async Task Handle_MatchingPatternExists_Skipped()
+    {
+        var org = SetupOrganization();
+
+        var existing = Registry.Create(
+            RegistryId.NewId(),
+            DeploymentOrgId.FromIdentityAccess(org.Id),
+            "Existing",
+            "https://ghcr.io",
+            "user", "pass");
+        existing.SetImagePatterns(["ghcr.io/myorg/*"]);
+
+        _registryRepoMock
+            .Setup(r => r.GetByOrganization(It.IsAny<DeploymentOrgId>()))
+            .Returns([existing]);
+
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(
+            new SetRegistriesCommand([CreateInput(pattern: "ghcr.io/myorg/*")]),
+            CancellationToken.None);
+
+        result.RegistriesCreated.Should().Be(0);
+        result.RegistriesSkipped.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_PatternMatchingIsCaseInsensitive()
+    {
+        var org = SetupOrganization();
+
+        var existing = Registry.Create(
+            RegistryId.NewId(),
+            DeploymentOrgId.FromIdentityAccess(org.Id),
+            "Existing",
+            "https://ghcr.io",
+            "user", "pass");
+        existing.SetImagePatterns(["GHCR.IO/MYORG/*"]);
+
+        _registryRepoMock
+            .Setup(r => r.GetByOrganization(It.IsAny<DeploymentOrgId>()))
+            .Returns([existing]);
+
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(
+            new SetRegistriesCommand([CreateInput(pattern: "ghcr.io/myorg/*")]),
+            CancellationToken.None);
+
+        result.RegistriesCreated.Should().Be(0);
+        result.RegistriesSkipped.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateWithinBatch_SecondSkipped()
+    {
+        SetupOrganization();
+        var handler = CreateHandler();
+
+        var inputs = new[]
+        {
+            CreateInput(name: "First", pattern: "myorg/*"),
+            CreateInput(name: "Second", pattern: "myorg/*")
+        };
+
+        var result = await handler.Handle(
+            new SetRegistriesCommand(inputs), CancellationToken.None);
+
+        result.RegistriesCreated.Should().Be(1);
+        result.RegistriesSkipped.Should().Be(1);
+    }
+
+    #endregion
+
+    #region Mixed scenarios
+
+    [Fact]
+    public async Task Handle_MixedValidInvalidDuplicate_CorrectCounts()
+    {
+        SetupOrganization();
+        var handler = CreateHandler();
+
+        var inputs = new[]
+        {
+            CreateInput(name: "Valid", pattern: "org1/*"),
+            CreateInput(name: "Public", requiresAuth: false),
+            CreateInput(name: "No Creds", pattern: "org2/*", username: null),
+            CreateInput(name: "Duplicate", pattern: "org1/*")
+        };
+
+        var result = await handler.Handle(
+            new SetRegistriesCommand(inputs), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.RegistriesCreated.Should().Be(1);
+        result.RegistriesSkipped.Should().Be(3);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- `SetRegistriesCommand` / `SetRegistriesHandler` creates Registry aggregates from wizard input
- Skips public registries (no auth needed), entries with missing credentials, and duplicates (existing + within-batch)
- Pattern duplicate detection is case-insensitive
- Host normalization: adds `https://` prefix if missing
- `POST /api/wizard/registries` FastEndpoint with anonymous access and WizardTimeoutPreProcessor

## Test plan
- [x] 16 unit tests covering all scenarios
- [x] Empty input, no organization, valid creation, multiple inputs
- [x] Public skip, missing credentials, duplicate detection
- [x] Full test suite passes (1685 tests)