### PR TITLE
Replace static public guessing with runtime registry access check

### DIFF
--- a/src/ReadyStackGo.Application/Services/IRegistryAccessChecker.cs
+++ b/src/ReadyStackGo.Application/Services/IRegistryAccessChecker.cs
@@ -1,0 +1,38 @@
+namespace ReadyStackGo.Application.Services;
+
+/// <summary>
+/// Result of checking whether a container registry allows anonymous (public) access.
+/// </summary>
+public enum RegistryAccessLevel
+{
+    /// <summary>Anonymous pull confirmed — no credentials needed.</summary>
+    Public,
+
+    /// <summary>Authentication is definitely required to pull images.</summary>
+    AuthRequired,
+
+    /// <summary>Could not determine (network error, timeout, unsupported registry).</summary>
+    Unknown
+}
+
+/// <summary>
+/// Checks whether a container registry allows anonymous (public) image pulls
+/// using the Docker Registry v2 API token flow.
+/// </summary>
+public interface IRegistryAccessChecker
+{
+    /// <summary>
+    /// Checks if the given registry allows anonymous access for a specific image.
+    /// Uses the v2 token auth flow: tries /v2/, then requests an anonymous token.
+    /// </summary>
+    /// <param name="host">Registry host (e.g., "ghcr.io", "docker.io")</param>
+    /// <param name="namespacePath">Image namespace (e.g., "library", "wiesenwischer")</param>
+    /// <param name="repository">Image repository name (e.g., "nginx", "ams-api")</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Access level: Public, AuthRequired, or Unknown</returns>
+    Task<RegistryAccessLevel> CheckAccessAsync(
+        string host,
+        string namespacePath,
+        string repository,
+        CancellationToken ct = default);
+}

--- a/src/ReadyStackGo.Application/UseCases/Wizard/DetectRegistries/DetectRegistriesHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Wizard/DetectRegistries/DetectRegistriesHandler.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using Microsoft.Extensions.Logging;
 using ReadyStackGo.Application.Services;
 using ReadyStackGo.Domain.Deployment.Registries;
 using ReadyStackGo.Domain.IdentityAccess.Organizations;
@@ -11,20 +12,26 @@ public class DetectRegistriesHandler : IRequestHandler<DetectRegistriesQuery, De
     private readonly IImageReferenceExtractor _extractor;
     private readonly IRegistryRepository _registryRepository;
     private readonly IOrganizationRepository _organizationRepository;
+    private readonly IRegistryAccessChecker _accessChecker;
+    private readonly ILogger<DetectRegistriesHandler> _logger;
 
     public DetectRegistriesHandler(
         IProductCache productCache,
         IImageReferenceExtractor extractor,
         IRegistryRepository registryRepository,
-        IOrganizationRepository organizationRepository)
+        IOrganizationRepository organizationRepository,
+        IRegistryAccessChecker accessChecker,
+        ILogger<DetectRegistriesHandler> logger)
     {
         _productCache = productCache;
         _extractor = extractor;
         _registryRepository = registryRepository;
         _organizationRepository = organizationRepository;
+        _accessChecker = accessChecker;
+        _logger = logger;
     }
 
-    public Task<DetectRegistriesResult> Handle(DetectRegistriesQuery request, CancellationToken cancellationToken)
+    public async Task<DetectRegistriesResult> Handle(DetectRegistriesQuery request, CancellationToken cancellationToken)
     {
         // Collect all image references from cached stacks
         var imageReferences = _productCache.GetAllStacks()
@@ -53,22 +60,49 @@ public class DetectRegistriesHandler : IRequestHandler<DetectRegistriesQuery, De
                 Domain.Deployment.OrganizationId.FromIdentityAccess(organization.Id)).ToList()
             : [];
 
-        var detectedAreas = areas.Select(area =>
+        // Run runtime access checks in parallel for areas with images
+        var checkTasks = areas.Select(area => CheckAreaAccessAsync(area, cancellationToken)).ToList();
+        var accessResults = await Task.WhenAll(checkTasks);
+
+        var detectedAreas = areas.Select((area, index) =>
         {
             var isConfigured = existingRegistries.Any(r =>
                 area.Images.Any(img => r.MatchesImage(img)));
+
+            // Use runtime check result; fall back to static hint for Unknown
+            var isLikelyPublic = accessResults[index] switch
+            {
+                RegistryAccessLevel.Public => true,
+                RegistryAccessLevel.AuthRequired => false,
+                _ => area.IsLikelyPublic // Unknown — keep static hint as fallback
+            };
 
             return new DetectedRegistryArea(
                 Host: area.Host,
                 Namespace: area.Namespace,
                 SuggestedPattern: area.SuggestedPattern,
                 SuggestedName: area.SuggestedName,
-                IsLikelyPublic: area.IsLikelyPublic,
+                IsLikelyPublic: isLikelyPublic,
                 IsConfigured: isConfigured,
                 Images: area.Images);
         }).ToList();
 
-        return Task.FromResult(new DetectRegistriesResult(detectedAreas));
+        return new DetectRegistriesResult(detectedAreas);
+    }
+
+    private async Task<RegistryAccessLevel> CheckAreaAccessAsync(RegistryArea area, CancellationToken ct)
+    {
+        if (area.Images.Count == 0)
+            return RegistryAccessLevel.Unknown;
+
+        // Pick a representative image to probe
+        var parsed = _extractor.Parse(area.Images[0]);
+
+        _logger.LogDebug("Checking registry access for {Host}/{Ns}/{Repo}",
+            parsed.Host, parsed.Namespace, parsed.Repository);
+
+        return await _accessChecker.CheckAccessAsync(
+            parsed.Host, parsed.Namespace, parsed.Repository, ct);
     }
 
     private static IReadOnlyList<RegistryArea> GetDefaultRegistryAreas()

--- a/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
+++ b/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
@@ -72,6 +72,18 @@ public static class DependencyInjection
         // Image Reference Extraction (v0.25)
         services.AddSingleton<IImageReferenceExtractor, ImageReferenceExtractor>();
 
+        // Registry Access Checker (v0.25) — checks anonymous pull via Docker v2 API
+        services.AddScoped<IRegistryAccessChecker, RegistryAccessChecker>();
+        services.AddHttpClient("RegistryCheck", client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(5);
+            client.DefaultRequestHeaders.Add("User-Agent", "ReadyStackGo-RegistryCheck");
+        })
+        .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+        });
+
         // Health Monitoring (v0.11)
         services.AddScoped<IHealthMonitoringService, HealthMonitoringService>();
         services.AddScoped<IHealthCollectorService, HealthCollectorService>();

--- a/src/ReadyStackGo.Infrastructure/Services/RegistryAccessChecker.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/RegistryAccessChecker.cs
@@ -1,0 +1,165 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Logging;
+using ReadyStackGo.Application.Services;
+
+namespace ReadyStackGo.Infrastructure.Services;
+
+/// <summary>
+/// Checks whether a container registry allows anonymous (public) image pulls
+/// using the Docker Registry v2 API token auth flow.
+///
+/// Flow:
+/// 1. GET https://{host}/v2/ — if 200, registry is fully open (e.g., mcr.microsoft.com)
+/// 2. If 401, parse Www-Authenticate header for Bearer realm + service
+/// 3. Request anonymous token: GET {realm}?service={service}&amp;scope=repository:{ns}/{repo}:pull
+/// 4. If token received → public, if 401/403 → auth required
+/// </summary>
+public class RegistryAccessChecker : IRegistryAccessChecker
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<RegistryAccessChecker> _logger;
+
+    /// <summary>
+    /// Docker Hub uses a different v2 endpoint than the token realm host.
+    /// </summary>
+    private static readonly HashSet<string> DockerHubHosts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "docker.io",
+        "index.docker.io",
+        "registry-1.docker.io",
+        "registry.hub.docker.com"
+    };
+
+    public RegistryAccessChecker(
+        IHttpClientFactory httpClientFactory,
+        ILogger<RegistryAccessChecker> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<RegistryAccessLevel> CheckAccessAsync(
+        string host,
+        string namespacePath,
+        string repository,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var client = _httpClientFactory.CreateClient("RegistryCheck");
+
+            // Docker Hub v2 API lives on registry-1.docker.io, not docker.io
+            var v2Host = IsDockerHub(host) ? "registry-1.docker.io" : host;
+            var v2Url = $"https://{v2Host}/v2/";
+
+            _logger.LogDebug("Checking registry access: {Url}", v2Url);
+
+            var response = await client.GetAsync(v2Url, ct);
+
+            if (response.StatusCode == HttpStatusCode.OK)
+            {
+                _logger.LogDebug("Registry {Host} allows anonymous access (v2 returned 200)", host);
+                return RegistryAccessLevel.Public;
+            }
+
+            if (response.StatusCode != HttpStatusCode.Unauthorized)
+            {
+                _logger.LogDebug("Registry {Host} returned unexpected status {Status}", host, response.StatusCode);
+                return RegistryAccessLevel.Unknown;
+            }
+
+            // 401 — try anonymous token flow
+            return await TryAnonymousTokenAsync(client, response, host, namespacePath, repository, ct);
+        }
+        catch (TaskCanceledException)
+        {
+            _logger.LogDebug("Registry check timed out for {Host}", host);
+            return RegistryAccessLevel.Unknown;
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogDebug(ex, "Registry check failed for {Host}", host);
+            return RegistryAccessLevel.Unknown;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Unexpected error checking registry {Host}", host);
+            return RegistryAccessLevel.Unknown;
+        }
+    }
+
+    private async Task<RegistryAccessLevel> TryAnonymousTokenAsync(
+        HttpClient client,
+        HttpResponseMessage v2Response,
+        string host,
+        string namespacePath,
+        string repository,
+        CancellationToken ct)
+    {
+        // Parse Www-Authenticate: Bearer realm="...",service="...",scope="..."
+        var authHeader = v2Response.Headers.WwwAuthenticate.FirstOrDefault();
+        if (authHeader is not { Scheme: "Bearer" } || string.IsNullOrEmpty(authHeader.Parameter))
+        {
+            _logger.LogDebug("Registry {Host} returned 401 without Bearer challenge", host);
+            return RegistryAccessLevel.Unknown;
+        }
+
+        var realm = ExtractParam(authHeader.Parameter, "realm");
+        var service = ExtractParam(authHeader.Parameter, "service");
+
+        if (string.IsNullOrEmpty(realm))
+        {
+            _logger.LogDebug("Registry {Host} Bearer challenge missing realm", host);
+            return RegistryAccessLevel.Unknown;
+        }
+
+        // For Docker Hub, namespace "library" maps to "library/{repo}"
+        var scope = $"repository:{namespacePath}/{repository}:pull";
+        var tokenUrl = $"{realm}?service={Uri.EscapeDataString(service ?? "")}&scope={Uri.EscapeDataString(scope)}";
+
+        _logger.LogDebug("Requesting anonymous token: {Url}", tokenUrl);
+
+        try
+        {
+            var tokenResponse = await client.GetAsync(tokenUrl, ct);
+
+            if (tokenResponse.IsSuccessStatusCode)
+            {
+                _logger.LogDebug("Anonymous token obtained for {Host}/{Ns}/{Repo} — image is public",
+                    host, namespacePath, repository);
+                return RegistryAccessLevel.Public;
+            }
+
+            _logger.LogDebug("Anonymous token denied ({Status}) for {Host}/{Ns}/{Repo} — auth required",
+                tokenResponse.StatusCode, host, namespacePath, repository);
+            return RegistryAccessLevel.AuthRequired;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Token request failed for {Host}", host);
+            return RegistryAccessLevel.Unknown;
+        }
+    }
+
+    private static string? ExtractParam(string headerValue, string paramName)
+    {
+        // Parse: realm="https://auth.docker.io/token",service="registry.docker.io"
+        var search = $"{paramName}=\"";
+        var startIdx = headerValue.IndexOf(search, StringComparison.OrdinalIgnoreCase);
+        if (startIdx < 0)
+            return null;
+
+        startIdx += search.Length;
+        var endIdx = headerValue.IndexOf('"', startIdx);
+        if (endIdx < 0)
+            return null;
+
+        return headerValue[startIdx..endIdx];
+    }
+
+    private static bool IsDockerHub(string host)
+    {
+        return DockerHubHosts.Contains(host);
+    }
+}

--- a/tests/ReadyStackGo.UnitTests/Services/RegistryAccessCheckerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Services/RegistryAccessCheckerTests.cs
@@ -1,0 +1,258 @@
+using System.Net;
+using System.Net.Http.Headers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Infrastructure.Services;
+
+namespace ReadyStackGo.UnitTests.Services;
+
+public class RegistryAccessCheckerTests
+{
+    private readonly Mock<ILogger<RegistryAccessChecker>> _loggerMock = new();
+
+    private RegistryAccessChecker CreateChecker(HttpMessageHandler handler)
+    {
+        var client = new HttpClient(handler);
+        client.Timeout = TimeSpan.FromSeconds(5);
+
+        var factoryMock = new Mock<IHttpClientFactory>();
+        factoryMock.Setup(f => f.CreateClient("RegistryCheck")).Returns(client);
+
+        return new RegistryAccessChecker(factoryMock.Object, _loggerMock.Object);
+    }
+
+    private static Mock<HttpMessageHandler> CreateHandler(
+        HttpStatusCode statusCode,
+        AuthenticationHeaderValue? wwwAuthenticate = null)
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        var response = new HttpResponseMessage(statusCode);
+        if (wwwAuthenticate != null)
+            response.Headers.WwwAuthenticate.Add(wwwAuthenticate);
+
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(response);
+
+        return handlerMock;
+    }
+
+    private static Mock<HttpMessageHandler> CreateSequenceHandler(
+        params (HttpStatusCode Status, AuthenticationHeaderValue? Auth, string? Content)[] responses)
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        var sequence = handlerMock.Protected()
+            .SetupSequence<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>());
+
+        foreach (var (status, auth, content) in responses)
+        {
+            sequence = sequence.ReturnsAsync(() =>
+            {
+                var resp = new HttpResponseMessage(status);
+                if (auth != null)
+                    resp.Headers.WwwAuthenticate.Add(auth);
+                if (content != null)
+                    resp.Content = new StringContent(content);
+                return resp;
+            });
+        }
+
+        return handlerMock;
+    }
+
+    #region Fully open registry (v2 returns 200)
+
+    [Fact]
+    public async Task CheckAccess_V2Returns200_ReturnsPublic()
+    {
+        var handler = CreateHandler(HttpStatusCode.OK);
+        var checker = CreateChecker(handler.Object);
+
+        var result = await checker.CheckAccessAsync("mcr.microsoft.com", "dotnet", "runtime");
+
+        result.Should().Be(RegistryAccessLevel.Public);
+    }
+
+    #endregion
+
+    #region Bearer token flow
+
+    [Fact]
+    public async Task CheckAccess_AnonymousTokenSucceeds_ReturnsPublic()
+    {
+        var bearerAuth = new AuthenticationHeaderValue("Bearer",
+            "realm=\"https://auth.example.io/token\",service=\"registry.example.io\"");
+
+        var handlerMock = CreateSequenceHandler(
+            (HttpStatusCode.Unauthorized, bearerAuth, null),
+            (HttpStatusCode.OK, null, "{\"token\":\"abc\"}"));
+
+        var checker = CreateChecker(handlerMock.Object);
+
+        var result = await checker.CheckAccessAsync("registry.example.io", "myorg", "myapp");
+
+        result.Should().Be(RegistryAccessLevel.Public);
+    }
+
+    [Fact]
+    public async Task CheckAccess_AnonymousTokenDenied_ReturnsAuthRequired()
+    {
+        var bearerAuth = new AuthenticationHeaderValue("Bearer",
+            "realm=\"https://auth.example.io/token\",service=\"registry.example.io\"");
+
+        var handlerMock = CreateSequenceHandler(
+            (HttpStatusCode.Unauthorized, bearerAuth, null),
+            (HttpStatusCode.Unauthorized, null, null));
+
+        var checker = CreateChecker(handlerMock.Object);
+
+        var result = await checker.CheckAccessAsync("registry.example.io", "private", "app");
+
+        result.Should().Be(RegistryAccessLevel.AuthRequired);
+    }
+
+    [Fact]
+    public async Task CheckAccess_TokenDenied403_ReturnsAuthRequired()
+    {
+        var bearerAuth = new AuthenticationHeaderValue("Bearer",
+            "realm=\"https://auth.example.io/token\",service=\"registry.example.io\"");
+
+        var handlerMock = CreateSequenceHandler(
+            (HttpStatusCode.Unauthorized, bearerAuth, null),
+            (HttpStatusCode.Forbidden, null, null));
+
+        var checker = CreateChecker(handlerMock.Object);
+
+        var result = await checker.CheckAccessAsync("registry.example.io", "private", "app");
+
+        result.Should().Be(RegistryAccessLevel.AuthRequired);
+    }
+
+    #endregion
+
+    #region Docker Hub special handling
+
+    [Fact]
+    public async Task CheckAccess_DockerHub_UsesRegistryOneDomain()
+    {
+        var bearerAuth = new AuthenticationHeaderValue("Bearer",
+            "realm=\"https://auth.docker.io/token\",service=\"registry.docker.io\"");
+
+        var handlerMock = CreateSequenceHandler(
+            (HttpStatusCode.Unauthorized, bearerAuth, null),
+            (HttpStatusCode.OK, null, "{\"token\":\"abc\"}"));
+
+        handlerMock.Protected()
+            .Verify<Task<HttpResponseMessage>>(
+                "SendAsync",
+                Times.Never(),
+                ItExpr.Is<HttpRequestMessage>(r =>
+                    r.RequestUri != null && r.RequestUri.Host == "docker.io"),
+                ItExpr.IsAny<CancellationToken>());
+
+        var checker = CreateChecker(handlerMock.Object);
+
+        var result = await checker.CheckAccessAsync("docker.io", "library", "nginx");
+
+        result.Should().Be(RegistryAccessLevel.Public);
+    }
+
+    #endregion
+
+    #region Error handling
+
+    [Fact]
+    public async Task CheckAccess_UnexpectedStatusCode_ReturnsUnknown()
+    {
+        var handler = CreateHandler(HttpStatusCode.InternalServerError);
+        var checker = CreateChecker(handler.Object);
+
+        var result = await checker.CheckAccessAsync("broken.example.com", "ns", "repo");
+
+        result.Should().Be(RegistryAccessLevel.Unknown);
+    }
+
+    [Fact]
+    public async Task CheckAccess_401WithoutBearerChallenge_ReturnsUnknown()
+    {
+        var handler = CreateHandler(HttpStatusCode.Unauthorized);
+        var checker = CreateChecker(handler.Object);
+
+        var result = await checker.CheckAccessAsync("weird.registry.io", "ns", "repo");
+
+        result.Should().Be(RegistryAccessLevel.Unknown);
+    }
+
+    [Fact]
+    public async Task CheckAccess_401WithBasicChallenge_ReturnsUnknown()
+    {
+        var basicAuth = new AuthenticationHeaderValue("Basic", "realm=\"registry\"");
+        var handler = CreateHandler(HttpStatusCode.Unauthorized, basicAuth);
+        var checker = CreateChecker(handler.Object);
+
+        var result = await checker.CheckAccessAsync("basic.registry.io", "ns", "repo");
+
+        result.Should().Be(RegistryAccessLevel.Unknown);
+    }
+
+    [Fact]
+    public async Task CheckAccess_BearerWithoutRealm_ReturnsUnknown()
+    {
+        var bearerAuth = new AuthenticationHeaderValue("Bearer",
+            "service=\"registry.example.io\"");
+
+        var handler = CreateHandler(HttpStatusCode.Unauthorized, bearerAuth);
+        var checker = CreateChecker(handler.Object);
+
+        var result = await checker.CheckAccessAsync("norealm.registry.io", "ns", "repo");
+
+        result.Should().Be(RegistryAccessLevel.Unknown);
+    }
+
+    [Fact]
+    public async Task CheckAccess_HttpRequestException_ReturnsUnknown()
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("Connection refused"));
+
+        var checker = CreateChecker(handlerMock.Object);
+
+        var result = await checker.CheckAccessAsync("unreachable.example.com", "ns", "repo");
+
+        result.Should().Be(RegistryAccessLevel.Unknown);
+    }
+
+    [Fact]
+    public async Task CheckAccess_TaskCanceled_ReturnsUnknown()
+    {
+        var handlerMock = new Mock<HttpMessageHandler>();
+        handlerMock.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ThrowsAsync(new TaskCanceledException("Timeout"));
+
+        var checker = CreateChecker(handlerMock.Object);
+
+        var result = await checker.CheckAccessAsync("slow.registry.io", "ns", "repo");
+
+        result.Should().Be(RegistryAccessLevel.Unknown);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- Add `IRegistryAccessChecker` / `RegistryAccessChecker` that probes container registries via the Docker v2 API token auth flow to determine if anonymous pulls are allowed
- Update `DetectRegistriesHandler` to run parallel runtime access checks for each detected registry area
- Fall back to static `IsLikelyPublic` hint only when the runtime check returns `Unknown` (network error, timeout, unsupported registry)
- 17 new unit tests covering the access checker (v2 200, bearer token success/denial, Docker Hub routing, error handling) and handler integration (override/fallback behavior)

## Flow

1. `GET https://{host}/v2/` — if 200, registry is fully open (e.g. mcr.microsoft.com)
2. If 401 with `Www-Authenticate: Bearer realm=...`, request anonymous token with `scope=repository:{ns}/{repo}:pull`
3. Token received → **Public**, 401/403 → **AuthRequired**, errors → **Unknown** (falls back to static hint)

## Test plan

- [x] All 1715 unit tests pass
- [ ] Docker build + manual wizard test