### PR TITLE
Feature 1: Auto-login after admin creation

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/Wizard/CreateAdminEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Wizard/CreateAdminEndpoint.cs
@@ -41,7 +41,10 @@ public class CreateAdminEndpoint : Endpoint<CreateAdminRequest, CreateAdminRespo
         Response = new CreateAdminResponse
         {
             Success = true,
-            Message = "Admin user created successfully"
+            Message = "Admin user created successfully",
+            Token = result.Token,
+            Username = result.Username,
+            Role = result.Role
         };
     }
 }

--- a/src/ReadyStackGo.Application/UseCases/Administration/RegisterSystemAdmin/RegisterSystemAdminCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Administration/RegisterSystemAdmin/RegisterSystemAdminCommand.cs
@@ -9,4 +9,7 @@ public record RegisterSystemAdminCommand(
 public record RegisterSystemAdminResult(
     bool Success,
     string? UserId = null,
+    string? Token = null,
+    string? Username = null,
+    string? Role = null,
     string? ErrorMessage = null);

--- a/src/ReadyStackGo.Application/UseCases/Wizard/WizardDtos.cs
+++ b/src/ReadyStackGo.Application/UseCases/Wizard/WizardDtos.cs
@@ -11,6 +11,9 @@ public class CreateAdminResponse
 {
     public bool Success { get; set; }
     public string? Message { get; set; }
+    public string? Token { get; set; }
+    public string? Username { get; set; }
+    public string? Role { get; set; }
 }
 
 // Step 2: Organization Setup

--- a/src/ReadyStackGo.WebUi/src/api/wizard.ts
+++ b/src/ReadyStackGo.WebUi/src/api/wizard.ts
@@ -35,6 +35,9 @@ export interface CreateAdminRequest {
 export interface CreateAdminResponse {
   success: boolean;
   message?: string;
+  token?: string;
+  username?: string;
+  role?: string;
 }
 
 export interface SetOrganizationRequest {

--- a/src/ReadyStackGo.WebUi/src/context/AuthContext.tsx
+++ b/src/ReadyStackGo.WebUi/src/context/AuthContext.tsx
@@ -9,6 +9,7 @@ interface AuthContextType {
   user: User | null;
   token: string | null;
   login: (username: string, password: string) => Promise<void>;
+  setAuthDirectly: (token: string, username: string, role: string) => void;
   logout: () => void;
   isAuthenticated: boolean;
   isLoading: boolean;
@@ -67,6 +68,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   };
 
+  const setAuthDirectly = (token: string, username: string, role: string) => {
+    const userData = { username, role };
+    setToken(token);
+    setUser(userData);
+    localStorage.setItem('auth_token', token);
+    localStorage.setItem('auth_user', JSON.stringify(userData));
+  };
+
   const logout = () => {
     setToken(null);
     setUser(null);
@@ -87,6 +96,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         user,
         token,
         login,
+        setAuthDirectly,
         logout,
         isAuthenticated: !!token,
         isLoading,

--- a/src/ReadyStackGo.WebUi/src/pages/Wizard/index.tsx
+++ b/src/ReadyStackGo.WebUi/src/pages/Wizard/index.tsx
@@ -8,6 +8,7 @@ import StackSourcesStep from './StackSourcesStep';
 import RegistriesStep from './RegistriesStep';
 import InstallStep from './InstallStep';
 import { createAdmin, setOrganization, setEnvironment, setSources, setRegistries, installStack, getWizardStatus, type WizardTimeoutInfo, type RegistryInputDto } from '../../api/wizard';
+import { useAuth } from '../../context/AuthContext';
 
 export default function Wizard() {
   const [currentStep, setCurrentStep] = useState(1);
@@ -16,6 +17,7 @@ export default function Wizard() {
   const [isTimedOut, setIsTimedOut] = useState(false);
   const [isLocked, setIsLocked] = useState(false);
   const navigate = useNavigate();
+  const { setAuthDirectly } = useAuth();
 
   // Handle wizard timeout - show timeout message
   const handleTimeout = useCallback(() => {
@@ -76,7 +78,10 @@ export default function Wizard() {
   }, [reloadWizardState]);
 
   const handleAdminNext = async (data: { username: string; password: string }) => {
-    await createAdmin(data);
+    const response = await createAdmin(data);
+    if (response.token && response.username && response.role) {
+      setAuthDirectly(response.token, response.username, response.role);
+    }
     setCurrentStep(2);
   };
 

--- a/tests/ReadyStackGo.UnitTests/Application/Wizard/RegisterSystemAdminHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Wizard/RegisterSystemAdminHandlerTests.cs
@@ -1,0 +1,200 @@
+using FluentAssertions;
+using Moq;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Application.UseCases.Administration.RegisterSystemAdmin;
+using ReadyStackGo.Domain.IdentityAccess.Roles;
+using ReadyStackGo.Domain.IdentityAccess.Users;
+
+namespace ReadyStackGo.UnitTests.Application.Wizard;
+
+public class RegisterSystemAdminHandlerTests
+{
+    private readonly Mock<IUserRepository> _userRepositoryMock;
+    private readonly Mock<IPasswordHasher> _passwordHasherMock;
+    private readonly Mock<ITokenService> _tokenServiceMock;
+    private readonly RegisterSystemAdminHandler _handler;
+
+    public RegisterSystemAdminHandlerTests()
+    {
+        _userRepositoryMock = new Mock<IUserRepository>();
+        _passwordHasherMock = new Mock<IPasswordHasher>();
+        _tokenServiceMock = new Mock<ITokenService>();
+
+        // Default setup - no existing users
+        _userRepositoryMock.Setup(r => r.GetAll()).Returns(new List<User>());
+        _userRepositoryMock.Setup(r => r.NextIdentity()).Returns(UserId.NewId());
+        _passwordHasherMock.Setup(h => h.Hash(It.IsAny<string>())).Returns("hashed_password");
+        _tokenServiceMock.Setup(s => s.GenerateToken(It.IsAny<User>())).Returns("jwt-test-token");
+
+        var registrationService = new SystemAdminRegistrationService(
+            _userRepositoryMock.Object,
+            _passwordHasherMock.Object);
+
+        _handler = new RegisterSystemAdminHandler(registrationService, _tokenServiceMock.Object);
+    }
+
+    #region Success Cases
+
+    [Fact]
+    public async Task Handle_WithValidCredentials_ReturnsSuccess()
+    {
+        // Act
+        var result = await _handler.Handle(
+            new RegisterSystemAdminCommand("admin", "ValidPass1"),
+            CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+        result.ErrorMessage.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WithValidCredentials_ReturnsToken()
+    {
+        // Act
+        var result = await _handler.Handle(
+            new RegisterSystemAdminCommand("admin", "ValidPass1"),
+            CancellationToken.None);
+
+        // Assert
+        result.Token.Should().Be("jwt-test-token");
+    }
+
+    [Fact]
+    public async Task Handle_WithValidCredentials_ReturnsUsernameAndRole()
+    {
+        // Act
+        var result = await _handler.Handle(
+            new RegisterSystemAdminCommand("admin", "ValidPass1"),
+            CancellationToken.None);
+
+        // Assert
+        result.Username.Should().Be("admin");
+        result.Role.Should().Be("admin");
+    }
+
+    [Fact]
+    public async Task Handle_WithValidCredentials_ReturnsUserId()
+    {
+        // Act
+        var result = await _handler.Handle(
+            new RegisterSystemAdminCommand("admin", "ValidPass1"),
+            CancellationToken.None);
+
+        // Assert
+        result.UserId.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_WithValidCredentials_CallsTokenServiceWithCreatedUser()
+    {
+        // Act
+        await _handler.Handle(
+            new RegisterSystemAdminCommand("admin", "ValidPass1"),
+            CancellationToken.None);
+
+        // Assert
+        _tokenServiceMock.Verify(
+            s => s.GenerateToken(It.Is<User>(u => u.Username == "admin")),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region Error Cases
+
+    [Fact]
+    public async Task Handle_WhenAdminAlreadyExists_ReturnsFailure()
+    {
+        // Arrange
+        var existingAdmin = CreateExistingSystemAdmin();
+        _userRepositoryMock.Setup(r => r.GetAll()).Returns(new List<User> { existingAdmin });
+
+        // Act
+        var result = await _handler.Handle(
+            new RegisterSystemAdminCommand("admin", "ValidPass1"),
+            CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("already exists");
+    }
+
+    [Fact]
+    public async Task Handle_WhenAdminAlreadyExists_DoesNotReturnToken()
+    {
+        // Arrange
+        var existingAdmin = CreateExistingSystemAdmin();
+        _userRepositoryMock.Setup(r => r.GetAll()).Returns(new List<User> { existingAdmin });
+
+        // Act
+        var result = await _handler.Handle(
+            new RegisterSystemAdminCommand("admin", "ValidPass1"),
+            CancellationToken.None);
+
+        // Assert
+        result.Token.Should().BeNull();
+        result.Username.Should().BeNull();
+        result.Role.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WhenAdminAlreadyExists_DoesNotGenerateToken()
+    {
+        // Arrange
+        var existingAdmin = CreateExistingSystemAdmin();
+        _userRepositoryMock.Setup(r => r.GetAll()).Returns(new List<User> { existingAdmin });
+
+        // Act
+        await _handler.Handle(
+            new RegisterSystemAdminCommand("admin", "ValidPass1"),
+            CancellationToken.None);
+
+        // Assert
+        _tokenServiceMock.Verify(s => s.GenerateToken(It.IsAny<User>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WithWeakPassword_ReturnsFailure()
+    {
+        // Act
+        var result = await _handler.Handle(
+            new RegisterSystemAdminCommand("admin", "weak"),
+            CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().NotBeNullOrEmpty();
+        result.Token.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WithShortUsername_ReturnsFailure()
+    {
+        // Act
+        var result = await _handler.Handle(
+            new RegisterSystemAdminCommand("ab", "ValidPass1"),
+            CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeFalse();
+        result.Token.Should().BeNull();
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private static User CreateExistingSystemAdmin()
+    {
+        var user = User.Register(
+            UserId.NewId(),
+            "existingadmin",
+            new EmailAddress("existing@system.local"),
+            HashedPassword.FromHash("hashed"));
+        user.AssignRole(RoleAssignment.Global(RoleId.SystemAdmin));
+        return user;
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

- CreateAdminEndpoint returns JWT token, username, and role after successful admin creation
- RegisterSystemAdminHandler generates token via ITokenService immediately after registration
- Frontend AuthContext gains `setAuthDirectly()` method for token injection without login API call
- Wizard stores auth credentials after admin creation, establishing an authenticated session

## Changes

**Backend:**
- `RegisterSystemAdminResult` extended with Token, Username, Role fields
- `RegisterSystemAdminHandler` injects `ITokenService`, generates JWT after registration
- `CreateAdminResponse` DTO extended with Token, Username, Role
- `CreateAdminEndpoint` maps token data to response

**Frontend:**
- `AuthContext.tsx`: New `setAuthDirectly(token, username, role)` method
- `wizard.ts`: `CreateAdminResponse` interface extended
- `Wizard/index.tsx`: Calls `setAuthDirectly` after admin creation

**Tests:**
- 10 new unit tests for `RegisterSystemAdminHandler` (success + error cases)
- All 1732 unit tests pass

## Test plan

- [ ] Verify admin creation returns JWT token in response
- [ ] Verify frontend stores token in localStorage after admin creation
- [ ] Verify subsequent wizard steps can make authenticated API calls
- [ ] Verify token is not generated when admin already exists
- [ ] Verify weak password still returns error without token