### PR TITLE
Feature 2: Reduce wizard to admin creation only

### DIFF
--- a/src/ReadyStackGo.WebUi/src/pages/Wizard/WizardLayout.tsx
+++ b/src/ReadyStackGo.WebUi/src/pages/Wizard/WizardLayout.tsx
@@ -3,34 +3,23 @@ import type { WizardTimeoutInfo } from '../../api/wizard';
 import WizardCountdown from '../../components/wizard/WizardCountdown';
 
 interface WizardLayoutProps {
-  currentStep: number;
-  totalSteps: number;
   children: ReactNode;
   timeout?: WizardTimeoutInfo | null;
   onTimeout?: () => void;
 }
 
-export default function WizardLayout({ currentStep, children, timeout, onTimeout }: WizardLayoutProps) {
-  const steps = [
-    { number: 1, name: 'Admin', description: 'Create admin user' },
-    { number: 2, name: 'Organization', description: 'Set organization' },
-    { number: 3, name: 'Environment', description: 'Configure Docker' },
-    { number: 4, name: 'Sources', description: 'Stack sources' },
-    { number: 5, name: 'Registries', description: 'Container auth' },
-    { number: 6, name: 'Complete', description: 'Finish setup' },
-  ];
-
+export default function WizardLayout({ children, timeout, onTimeout }: WizardLayoutProps) {
   return (
     <div className="relative min-h-screen p-6 bg-white dark:bg-gray-900">
       <div className="flex flex-col items-center justify-center w-full min-h-screen">
         {/* Header */}
-        <div className="w-full max-w-5xl mb-8">
+        <div className="w-full max-w-2xl mb-8">
           <div className="text-center mb-8">
             <h1 className="mb-2 text-3xl font-bold text-gray-800 dark:text-white">
-              ReadyStackGo Setup Wizard
+              Welcome to ReadyStackGo
             </h1>
             <p className="text-gray-500 dark:text-gray-400">
-              Let's get your system configured in a few easy steps
+              Create your admin account to get started
             </p>
             {/* Timeout Countdown */}
             {timeout && onTimeout && !timeout.isTimedOut && (
@@ -38,55 +27,6 @@ export default function WizardLayout({ currentStep, children, timeout, onTimeout
                 <WizardCountdown timeout={timeout} onTimeout={onTimeout} />
               </div>
             )}
-          </div>
-
-          {/* Step Progress Indicator */}
-          <div className="flex items-center justify-between mb-12">
-            {steps.map((step, index) => (
-              <div key={step.number} className="flex items-center flex-1">
-                {/* Step Circle */}
-                <div className="flex flex-col items-center flex-shrink-0">
-                  <div
-                    className={`flex items-center justify-center w-12 h-12 rounded-full border-2 transition-colors ${
-                      currentStep >= step.number
-                        ? 'bg-brand-600 border-brand-600 text-white'
-                        : 'bg-white dark:bg-gray-800 border-gray-300 dark:border-gray-700 text-gray-400 dark:text-gray-500'
-                    }`}
-                  >
-                    {currentStep > step.number ? (
-                      <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
-                      </svg>
-                    ) : (
-                      <span className="text-sm font-semibold">{step.number}</span>
-                    )}
-                  </div>
-                  <div className="mt-2 text-center">
-                    <p className={`text-sm font-medium ${
-                      currentStep >= step.number
-                        ? 'text-gray-800 dark:text-white'
-                        : 'text-gray-400 dark:text-gray-500'
-                    }`}>
-                      {step.name}
-                    </p>
-                    <p className="text-xs text-gray-400 dark:text-gray-600 hidden sm:block">
-                      {step.description}
-                    </p>
-                  </div>
-                </div>
-
-                {/* Connector Line */}
-                {index < steps.length - 1 && (
-                  <div className="flex-1 h-0.5 mx-4 bg-gray-300 dark:bg-gray-700">
-                    <div
-                      className={`h-full transition-all duration-300 ${
-                        currentStep > step.number ? 'bg-brand-600' : 'bg-transparent'
-                      }`}
-                    />
-                  </div>
-                )}
-              </div>
-            ))}
           </div>
         </div>
 


### PR DESCRIPTION
## Summary

- Wizard reduced from 6 steps to single admin creation step
- After admin creation: auto-login (Feature 1) + redirect to dashboard
- WizardLayout simplified: no step progress indicator, clean single-step design
- Old step components preserved for API/E2E backward compatibility

## Changes

**Wizard/index.tsx:**
- Removed all step handlers (organization, environment, sources, registries, install)
- Single `handleAdminCreated` flow: createAdmin → setAuthDirectly → installStack → navigate to dashboard
- Simplified state: no more `currentStep`, just loading/timeout states
- On `isCompleted`: redirect to `/` instead of `/login`

**WizardLayout.tsx:**
- Removed `currentStep` and `totalSteps` props
- Removed 6-step progress indicator with connector lines
- Title: "Welcome to ReadyStackGo" / "Create your admin account to get started"
- Countdown timer preserved for the 5-minute timeout window

**Unchanged:**
- WizardGuard.tsx: Already works correctly (checks `isCompleted`)
- Old step components: Kept as files for backward compatibility
- Backend wizard endpoints: Unchanged, all still functional

## Test plan

- [ ] Fresh container: wizard shows only admin creation form
- [ ] No step progress bar visible
- [ ] After admin creation: auto-login + redirect to dashboard
- [ ] Timeout/lock behavior still works
- [ ] Completed wizard redirects to `/` (not `/login`)