### PR TITLE
Add onboarding status API endpoint

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/Onboarding/GetOnboardingStatusEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Onboarding/GetOnboardingStatusEndpoint.cs
@@ -1,0 +1,63 @@
+using FastEndpoints;
+using MediatR;
+using ReadyStackGo.Application.UseCases.Onboarding.GetOnboardingStatus;
+
+namespace ReadyStackGo.API.Endpoints.Onboarding;
+
+/// <summary>
+/// GET /api/onboarding/status - Get onboarding checklist status
+/// </summary>
+public class GetOnboardingStatusEndpoint : EndpointWithoutRequest<OnboardingStatusResponse>
+{
+    private readonly IMediator _mediator;
+
+    public GetOnboardingStatusEndpoint(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Get("/api/onboarding/status");
+        Description(b => b.WithTags("Onboarding"));
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        var result = await _mediator.Send(new GetOnboardingStatusQuery(), ct);
+
+        Response = new OnboardingStatusResponse
+        {
+            IsComplete = result.IsComplete,
+            IsDismissed = result.IsDismissed,
+            Organization = MapItem(result.Organization),
+            Environment = MapItem(result.Environment),
+            StackSources = MapItem(result.StackSources),
+            Registries = MapItem(result.Registries)
+        };
+    }
+
+    private static OnboardingItemDto MapItem(OnboardingItemStatus item) => new()
+    {
+        Done = item.Done,
+        Count = item.Count,
+        Name = item.Name
+    };
+}
+
+public class OnboardingStatusResponse
+{
+    public bool IsComplete { get; set; }
+    public bool IsDismissed { get; set; }
+    public required OnboardingItemDto Organization { get; set; }
+    public required OnboardingItemDto Environment { get; set; }
+    public required OnboardingItemDto StackSources { get; set; }
+    public required OnboardingItemDto Registries { get; set; }
+}
+
+public class OnboardingItemDto
+{
+    public bool Done { get; set; }
+    public int Count { get; set; }
+    public string? Name { get; set; }
+}

--- a/src/ReadyStackGo.Application/Services/IOnboardingStateService.cs
+++ b/src/ReadyStackGo.Application/Services/IOnboardingStateService.cs
@@ -1,0 +1,7 @@
+namespace ReadyStackGo.Application.Services;
+
+public interface IOnboardingStateService
+{
+    Task<bool> IsDismissedAsync(CancellationToken cancellationToken = default);
+    Task DismissAsync(CancellationToken cancellationToken = default);
+}

--- a/src/ReadyStackGo.Application/UseCases/Onboarding/GetOnboardingStatus/GetOnboardingStatusHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Onboarding/GetOnboardingStatus/GetOnboardingStatusHandler.cs
@@ -1,0 +1,63 @@
+using MediatR;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.Deployment.Registries;
+using ReadyStackGo.Domain.IdentityAccess.Organizations;
+using ReadyStackGo.Domain.StackManagement.Sources;
+using DeploymentOrganizationId = ReadyStackGo.Domain.Deployment.OrganizationId;
+
+namespace ReadyStackGo.Application.UseCases.Onboarding.GetOnboardingStatus;
+
+public class GetOnboardingStatusHandler : IRequestHandler<GetOnboardingStatusQuery, OnboardingStatusResult>
+{
+    private readonly IOrganizationRepository _organizationRepository;
+    private readonly IEnvironmentRepository _environmentRepository;
+    private readonly IStackSourceRepository _stackSourceRepository;
+    private readonly IRegistryRepository _registryRepository;
+    private readonly IOnboardingStateService _onboardingStateService;
+
+    public GetOnboardingStatusHandler(
+        IOrganizationRepository organizationRepository,
+        IEnvironmentRepository environmentRepository,
+        IStackSourceRepository stackSourceRepository,
+        IRegistryRepository registryRepository,
+        IOnboardingStateService onboardingStateService)
+    {
+        _organizationRepository = organizationRepository;
+        _environmentRepository = environmentRepository;
+        _stackSourceRepository = stackSourceRepository;
+        _registryRepository = registryRepository;
+        _onboardingStateService = onboardingStateService;
+    }
+
+    public async Task<OnboardingStatusResult> Handle(GetOnboardingStatusQuery request, CancellationToken cancellationToken)
+    {
+        // Check organization
+        var organization = _organizationRepository.GetAll().FirstOrDefault();
+        var hasOrg = organization != null;
+
+        // Count resources (scoped to organization if it exists)
+        var envCount = 0;
+        var registryCount = 0;
+
+        if (hasOrg)
+        {
+            var deploymentOrgId = DeploymentOrganizationId.FromIdentityAccess(organization!.Id);
+            envCount = _environmentRepository.GetByOrganization(deploymentOrgId).Count();
+            registryCount = _registryRepository.GetByOrganization(deploymentOrgId).Count();
+        }
+
+        var sources = await _stackSourceRepository.GetAllAsync(cancellationToken);
+        var sourceCount = sources.Count;
+
+        var isDismissed = await _onboardingStateService.IsDismissedAsync(cancellationToken);
+
+        return new OnboardingStatusResult(
+            IsComplete: hasOrg,
+            IsDismissed: isDismissed,
+            Organization: new OnboardingItemStatus(hasOrg, hasOrg ? 1 : 0, organization?.Name),
+            Environment: new OnboardingItemStatus(envCount > 0, envCount),
+            StackSources: new OnboardingItemStatus(sourceCount > 0, sourceCount),
+            Registries: new OnboardingItemStatus(registryCount > 0, registryCount));
+    }
+}

--- a/src/ReadyStackGo.Application/UseCases/Onboarding/GetOnboardingStatus/GetOnboardingStatusQuery.cs
+++ b/src/ReadyStackGo.Application/UseCases/Onboarding/GetOnboardingStatus/GetOnboardingStatusQuery.cs
@@ -1,0 +1,15 @@
+using MediatR;
+
+namespace ReadyStackGo.Application.UseCases.Onboarding.GetOnboardingStatus;
+
+public record GetOnboardingStatusQuery : IRequest<OnboardingStatusResult>;
+
+public record OnboardingItemStatus(bool Done, int Count, string? Name = null);
+
+public record OnboardingStatusResult(
+    bool IsComplete,
+    bool IsDismissed,
+    OnboardingItemStatus Organization,
+    OnboardingItemStatus Environment,
+    OnboardingItemStatus StackSources,
+    OnboardingItemStatus Registries);

--- a/src/ReadyStackGo.Infrastructure/Configuration/OnboardingStateService.cs
+++ b/src/ReadyStackGo.Infrastructure/Configuration/OnboardingStateService.cs
@@ -1,0 +1,30 @@
+using ReadyStackGo.Application.Services;
+
+namespace ReadyStackGo.Infrastructure.Configuration;
+
+/// <summary>
+/// Infrastructure implementation of IOnboardingStateService.
+/// Persists the onboarding dismissed state via the system config file.
+/// </summary>
+public class OnboardingStateService : IOnboardingStateService
+{
+    private readonly IConfigStore _configStore;
+
+    public OnboardingStateService(IConfigStore configStore)
+    {
+        _configStore = configStore;
+    }
+
+    public async Task<bool> IsDismissedAsync(CancellationToken cancellationToken = default)
+    {
+        var config = await _configStore.GetSystemConfigAsync();
+        return config.OnboardingDismissed;
+    }
+
+    public async Task DismissAsync(CancellationToken cancellationToken = default)
+    {
+        var config = await _configStore.GetSystemConfigAsync();
+        config.OnboardingDismissed = true;
+        await _configStore.SaveSystemConfigAsync(config);
+    }
+}

--- a/src/ReadyStackGo.Infrastructure/Configuration/SystemConfig.cs
+++ b/src/ReadyStackGo.Infrastructure/Configuration/SystemConfig.cs
@@ -52,4 +52,9 @@ public class SystemConfig
     /// Once locked, can only be reset by restarting the container (clears in-memory state).
     /// </summary>
     public bool IsWizardLocked { get; set; }
+
+    /// <summary>
+    /// Whether the user has dismissed the onboarding checklist on the dashboard.
+    /// </summary>
+    public bool OnboardingDismissed { get; set; }
 }

--- a/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
+++ b/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
@@ -47,6 +47,7 @@ public static class DependencyInjection
         // Configuration services
         services.AddSingleton<IConfigStore, ConfigStore>();
         services.AddSingleton<ISystemConfigService, SystemConfigService>();
+        services.AddSingleton<IOnboardingStateService, OnboardingStateService>();
         services.AddSingleton<IWizardTimeoutService, WizardTimeoutService>();
 
         // RSGo Manifest services

--- a/tests/ReadyStackGo.UnitTests/Application/Onboarding/GetOnboardingStatusHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Onboarding/GetOnboardingStatusHandlerTests.cs
@@ -1,0 +1,314 @@
+using FluentAssertions;
+using Moq;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Application.UseCases.Onboarding.GetOnboardingStatus;
+using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.Deployment.Registries;
+using ReadyStackGo.Domain.IdentityAccess.Organizations;
+using ReadyStackGo.Domain.StackManagement.Sources;
+using DeploymentOrgId = ReadyStackGo.Domain.Deployment.OrganizationId;
+using Environment = ReadyStackGo.Domain.Deployment.Environments.Environment;
+
+namespace ReadyStackGo.UnitTests.Application.Onboarding;
+
+public class GetOnboardingStatusHandlerTests
+{
+    private readonly Mock<IOrganizationRepository> _orgRepoMock = new();
+    private readonly Mock<IEnvironmentRepository> _envRepoMock = new();
+    private readonly Mock<IStackSourceRepository> _sourceRepoMock = new();
+    private readonly Mock<IRegistryRepository> _registryRepoMock = new();
+    private readonly Mock<IOnboardingStateService> _onboardingStateMock = new();
+
+    public GetOnboardingStatusHandlerTests()
+    {
+        // Default: no organization, no sources, not dismissed
+        _orgRepoMock.Setup(r => r.GetAll()).Returns([]);
+        _sourceRepoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<StackSource>() as IReadOnlyList<StackSource>);
+        _onboardingStateMock.Setup(s => s.IsDismissedAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+    }
+
+    private GetOnboardingStatusHandler CreateHandler() => new(
+        _orgRepoMock.Object,
+        _envRepoMock.Object,
+        _sourceRepoMock.Object,
+        _registryRepoMock.Object,
+        _onboardingStateMock.Object);
+
+    private Organization SetupOrganization(string name = "Test Org")
+    {
+        var org = Organization.Provision(OrganizationId.NewId(), name, "Test Organization");
+        _orgRepoMock.Setup(r => r.GetAll()).Returns([org]);
+        return org;
+    }
+
+    private void SetupEnvironments(int count)
+    {
+        var environments = Enumerable.Range(0, count)
+            .Select(_ =>
+            {
+                var envId = EnvironmentId.NewId();
+                return Environment.CreateDockerSocket(envId, DeploymentOrgId.NewId(), $"Env-{envId}", null, "unix:///var/run/docker.sock");
+            })
+            .ToList();
+        _envRepoMock.Setup(r => r.GetByOrganization(It.IsAny<DeploymentOrgId>()))
+            .Returns(environments);
+    }
+
+    private void SetupRegistries(int count)
+    {
+        var registries = Enumerable.Range(0, count)
+            .Select(_ => Registry.Create(
+                RegistryId.NewId(),
+                DeploymentOrgId.NewId(),
+                $"Registry-{Guid.NewGuid():N}",
+                "docker.io",
+                "library/*"))
+            .ToList();
+        _registryRepoMock.Setup(r => r.GetByOrganization(It.IsAny<DeploymentOrgId>()))
+            .Returns(registries);
+    }
+
+    private void SetupSources(int count)
+    {
+        var sources = Enumerable.Range(0, count)
+            .Select(_ => StackSource.CreateGitRepository(
+                StackSourceId.NewId(),
+                $"source-{Guid.NewGuid():N}",
+                "https://github.com/example/repo"))
+            .ToList();
+        _sourceRepoMock.Setup(r => r.GetAllAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sources);
+    }
+
+    #region Fresh Install (No Organization)
+
+    [Fact]
+    public async Task Handle_NoOrganization_IsCompleteIsFalse()
+    {
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetOnboardingStatusQuery(), CancellationToken.None);
+
+        result.IsComplete.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_NoOrganization_OrganizationNotDone()
+    {
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetOnboardingStatusQuery(), CancellationToken.None);
+
+        result.Organization.Done.Should().BeFalse();
+        result.Organization.Count.Should().Be(0);
+        result.Organization.Name.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_NoOrganization_DoesNotQueryEnvironmentsOrRegistries()
+    {
+        var handler = CreateHandler();
+
+        await handler.Handle(new GetOnboardingStatusQuery(), CancellationToken.None);
+
+        _envRepoMock.Verify(r => r.GetByOrganization(It.IsAny<DeploymentOrgId>()), Times.Never);
+        _registryRepoMock.Verify(r => r.GetByOrganization(It.IsAny<DeploymentOrgId>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_NoOrganization_EnvironmentAndRegistryCountsAreZero()
+    {
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetOnboardingStatusQuery(), CancellationToken.None);
+
+        result.Environment.Done.Should().BeFalse();
+        result.Environment.Count.Should().Be(0);
+        result.Registries.Done.Should().BeFalse();
+        result.Registries.Count.Should().Be(0);
+    }
+
+    #endregion
+
+    #region Organization Exists
+
+    [Fact]
+    public async Task Handle_WithOrganization_IsCompleteIsTrue()
+    {
+        SetupOrganization();
+        SetupEnvironments(0);
+        SetupRegistries(0);
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetOnboardingStatusQuery(), CancellationToken.None);
+
+        result.IsComplete.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_WithOrganization_OrganizationDoneWithNameAndCount()
+    {
+        SetupOrganization("My Company");
+        SetupEnvironments(0);
+        SetupRegistries(0);
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetOnboardingStatusQuery(), CancellationToken.None);
+
+        result.Organization.Done.Should().BeTrue();
+        result.Organization.Count.Should().Be(1);
+        result.Organization.Name.Should().Be("My Company");
+    }
+
+    [Fact]
+    public async Task Handle_WithOrganizationAndEnvironments_EnvironmentDoneWithCount()
+    {
+        SetupOrganization();
+        SetupEnvironments(3);
+        SetupRegistries(0);
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetOnboardingStatusQuery(), CancellationToken.None);
+
+        result.Environment.Done.Should().BeTrue();
+        result.Environment.Count.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Handle_WithOrganizationNoEnvironments_EnvironmentNotDone()
+    {
+        SetupOrganization();
+        SetupEnvironments(0);
+        SetupRegistries(0);
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetOnboardingStatusQuery(), CancellationToken.None);
+
+        result.Environment.Done.Should().BeFalse();
+        result.Environment.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_WithOrganizationAndRegistries_RegistriesDoneWithCount()
+    {
+        SetupOrganization();
+        SetupEnvironments(0);
+        SetupRegistries(2);
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetOnboardingStatusQuery(), CancellationToken.None);
+
+        result.Registries.Done.Should().BeTrue();
+        result.Registries.Count.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Handle_WithOrganizationNoRegistries_RegistriesNotDone()
+    {
+        SetupOrganization();
+        SetupEnvironments(0);
+        SetupRegistries(0);
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetOnboardingStatusQuery(), CancellationToken.None);
+
+        result.Registries.Done.Should().BeFalse();
+        result.Registries.Count.Should().Be(0);
+    }
+
+    #endregion
+
+    #region Stack Sources
+
+    [Fact]
+    public async Task Handle_WithSources_SourcesDoneWithCount()
+    {
+        SetupSources(5);
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetOnboardingStatusQuery(), CancellationToken.None);
+
+        result.StackSources.Done.Should().BeTrue();
+        result.StackSources.Count.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task Handle_NoSources_SourcesNotDone()
+    {
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetOnboardingStatusQuery(), CancellationToken.None);
+
+        result.StackSources.Done.Should().BeFalse();
+        result.StackSources.Count.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_SourcesQueriedEvenWithoutOrganization()
+    {
+        SetupSources(2);
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetOnboardingStatusQuery(), CancellationToken.None);
+
+        result.StackSources.Done.Should().BeTrue();
+        result.StackSources.Count.Should().Be(2);
+        _sourceRepoMock.Verify(r => r.GetAllAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    #endregion
+
+    #region Dismiss State
+
+    [Fact]
+    public async Task Handle_NotDismissed_IsDismissedFalse()
+    {
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetOnboardingStatusQuery(), CancellationToken.None);
+
+        result.IsDismissed.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_Dismissed_IsDismissedTrue()
+    {
+        _onboardingStateMock.Setup(s => s.IsDismissedAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetOnboardingStatusQuery(), CancellationToken.None);
+
+        result.IsDismissed.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region Full Setup Scenario
+
+    [Fact]
+    public async Task Handle_FullyConfigured_AllItemsDone()
+    {
+        SetupOrganization("Production Corp");
+        SetupEnvironments(2);
+        SetupRegistries(3);
+        SetupSources(4);
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetOnboardingStatusQuery(), CancellationToken.None);
+
+        result.IsComplete.Should().BeTrue();
+        result.Organization.Done.Should().BeTrue();
+        result.Organization.Name.Should().Be("Production Corp");
+        result.Environment.Done.Should().BeTrue();
+        result.Environment.Count.Should().Be(2);
+        result.StackSources.Done.Should().BeTrue();
+        result.StackSources.Count.Should().Be(4);
+        result.Registries.Done.Should().BeTrue();
+        result.Registries.Count.Should().Be(3);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- New `GET /api/onboarding/status` endpoint (JWT-authenticated) returning checklist completion state for organization, environment, stack sources, and registries
- `IOnboardingStateService` interface + `OnboardingStateService` implementation backed by `SystemConfig.OnboardingDismissed`
- `GetOnboardingStatusQuery` + `GetOnboardingStatusHandler` (MediatR) with cross-context org ID mapping
- 16 unit tests covering: fresh install, org exists, all resource counts, dismiss state, full setup scenario

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 1748 tests pass (16 new)