### PR TITLE
Add organization creation from dashboard

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/Organizations/CreateOrganizationEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Organizations/CreateOrganizationEndpoint.cs
@@ -1,0 +1,71 @@
+using FastEndpoints;
+using FluentValidation;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using ReadyStackGo.Api.Authorization;
+using ReadyStackGo.Application.UseCases.Organizations.ProvisionOrganization;
+
+namespace ReadyStackGo.API.Endpoints.Organizations;
+
+/// <summary>
+/// POST /api/organizations - Create an organization (authenticated).
+/// Used by the onboarding checklist after admin creation.
+/// </summary>
+[RequireSystemAdmin]
+public class CreateOrganizationEndpoint : Endpoint<CreateOrganizationRequest, CreateOrganizationResponse>
+{
+    private readonly IMediator _mediator;
+
+    public CreateOrganizationEndpoint(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Post("/api/organizations");
+        Description(b => b.WithTags("Organizations"));
+        PreProcessor<RbacPreProcessor<CreateOrganizationRequest>>();
+    }
+
+    public override async Task HandleAsync(CreateOrganizationRequest req, CancellationToken ct)
+    {
+        var result = await _mediator.Send(
+            new ProvisionOrganizationCommand(req.Name, req.Name),
+            ct);
+
+        if (!result.Success)
+        {
+            ThrowError(result.ErrorMessage ?? "Failed to create organization");
+            return;
+        }
+
+        HttpContext.Response.StatusCode = StatusCodes.Status201Created;
+        Response = new CreateOrganizationResponse
+        {
+            Success = true,
+            OrganizationId = result.OrganizationId
+        };
+    }
+}
+
+public class CreateOrganizationRequest
+{
+    public required string Name { get; set; }
+}
+
+public class CreateOrganizationResponse
+{
+    public bool Success { get; set; }
+    public string? OrganizationId { get; set; }
+}
+
+public class CreateOrganizationValidator : Validator<CreateOrganizationRequest>
+{
+    public CreateOrganizationValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Organization name is required")
+            .MaximumLength(200).WithMessage("Organization name must not exceed 200 characters");
+    }
+}

--- a/src/ReadyStackGo.WebUi/src/App.tsx
+++ b/src/ReadyStackGo.WebUi/src/App.tsx
@@ -32,6 +32,7 @@ import {
   CiCdList,
 } from "./pages/Settings";
 import SetupEnvironment from "./pages/Environments/SetupEnvironment";
+import SetupOrganization from "./pages/Settings/Organization/SetupOrganization";
 import Login from "./pages/Auth/Login";
 import Wizard from "./pages/Wizard";
 import NotFound from "./pages/NotFound";
@@ -176,6 +177,7 @@ export default function App() {
                 <Route path="/environments" element={<Environments />} />
                 {/* Settings pages - don't require active environment */}
                 <Route path="/settings" element={<SettingsIndex />} />
+                <Route path="/settings/organization" element={<SetupOrganization />} />
                 <Route path="/settings/stack-sources" element={<StackSourcesList />} />
                 <Route path="/settings/stack-sources/add" element={<AddStackSourceSelect />} />
                 <Route path="/settings/stack-sources/add/local" element={<AddLocalSource />} />

--- a/src/ReadyStackGo.WebUi/src/api/organizations.ts
+++ b/src/ReadyStackGo.WebUi/src/api/organizations.ts
@@ -1,0 +1,14 @@
+import { apiPost } from './client';
+
+export interface CreateOrganizationRequest {
+  name: string;
+}
+
+export interface CreateOrganizationResponse {
+  success: boolean;
+  organizationId?: string;
+}
+
+export async function createOrganization(request: CreateOrganizationRequest): Promise<CreateOrganizationResponse> {
+  return apiPost<CreateOrganizationResponse>('/api/organizations', request);
+}

--- a/src/ReadyStackGo.WebUi/src/components/onboarding/OnboardingChecklist.tsx
+++ b/src/ReadyStackGo.WebUi/src/components/onboarding/OnboardingChecklist.tsx
@@ -89,7 +89,7 @@ export default function OnboardingChecklist() {
             ? `Organization configured: ${status.organization.name}`
             : 'Set up your organization'}
           actionLabel={hasOrg ? undefined : 'Configure'}
-          onAction={() => navigate('/settings')}
+          onAction={() => navigate('/settings/organization')}
           required={!hasOrg}
         />
 

--- a/src/ReadyStackGo.WebUi/src/pages/Settings/Organization/SetupOrganization.tsx
+++ b/src/ReadyStackGo.WebUi/src/pages/Settings/Organization/SetupOrganization.tsx
@@ -1,0 +1,106 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { createOrganization } from '../../../api/organizations';
+
+export default function SetupOrganization() {
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [name, setName] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+
+    if (!name.trim()) {
+      setError('Organization name is required');
+      return;
+    }
+
+    try {
+      setLoading(true);
+      const response = await createOrganization({ name: name.trim() });
+      if (response.success) {
+        navigate('/');
+      } else {
+        setError('Failed to create organization');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create organization');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-screen-2xl p-4 md:p-6 2xl:p-10">
+      {/* Breadcrumb */}
+      <div className="mb-6 flex items-center gap-2 text-sm">
+        <Link to="/settings" className="text-gray-500 hover:text-brand-600 dark:text-gray-400">
+          Settings
+        </Link>
+        <span className="text-gray-400 dark:text-gray-500">/</span>
+        <span className="text-gray-900 dark:text-white">Organization</span>
+      </div>
+
+      <div className="mb-8">
+        <h2 className="text-2xl font-bold text-black dark:text-white">
+          Set Up Organization
+        </h2>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Create your organization to start managing environments, stack sources, and registries.
+        </p>
+      </div>
+
+      <div className="max-w-lg">
+        <form onSubmit={handleSubmit}>
+          <div className="rounded-2xl border border-gray-200 bg-white p-6 dark:border-gray-800 dark:bg-white/[0.03]">
+            {error && (
+              <div className="mb-4 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800 dark:border-red-900 dark:bg-red-900/30 dark:text-red-300">
+                {error}
+              </div>
+            )}
+
+            <div className="mb-6">
+              <label
+                htmlFor="org-name"
+                className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300"
+              >
+                Organization Name
+              </label>
+              <input
+                id="org-name"
+                type="text"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="My Company"
+                className="w-full rounded-lg border border-gray-300 bg-white px-4 py-2.5 text-sm text-gray-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:focus:border-brand-500"
+                autoFocus
+                disabled={loading}
+              />
+              <p className="mt-1.5 text-xs text-gray-500 dark:text-gray-400">
+                This is the name of your company or team. You can change it later.
+              </p>
+            </div>
+
+            <div className="flex items-center gap-3">
+              <button
+                type="submit"
+                disabled={loading || !name.trim()}
+                className="rounded-lg bg-brand-500 px-5 py-2.5 text-sm font-medium text-white hover:bg-brand-600 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+              >
+                {loading ? 'Creating...' : 'Create Organization'}
+              </button>
+              <Link
+                to="/"
+                className="text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300"
+              >
+                Cancel
+              </Link>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `POST /api/organizations` endpoint (JWT auth, SystemAdmin required) using existing `ProvisionOrganizationCommand`
- New `/settings/organization` page with simple name form for creating the organization
- OnboardingChecklist "Configure" button now links to `/settings/organization` instead of `/settings`
- `organizations.ts` API client module

## Test plan
- [x] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — 1748 tests pass
- Existing `ProvisionOrganizationHandler` and `OrganizationProvisioningService` unit tests cover the backend logic