### PR TITLE
Restrict wizard timeout scope to admin creation only

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/Wizard/CheckRegistryAccessEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Wizard/CheckRegistryAccessEndpoint.cs
@@ -25,7 +25,6 @@ public class CheckRegistryAccessEndpoint : Endpoint<CheckRegistryAccessRequest, 
     {
         Get("/api/wizard/check-registry-access");
         AllowAnonymous();
-        PreProcessor<WizardTimeoutPreProcessor<CheckRegistryAccessRequest>>();
     }
 
     public override async Task HandleAsync(CheckRegistryAccessRequest req, CancellationToken ct)

--- a/src/ReadyStackGo.Api/Endpoints/Wizard/DetectRegistriesEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Wizard/DetectRegistriesEndpoint.cs
@@ -22,7 +22,6 @@ public class DetectRegistriesEndpoint : EndpointWithoutRequest<DetectRegistriesR
     {
         Get("/api/wizard/detected-registries");
         AllowAnonymous();
-        PreProcessor<WizardTimeoutPreProcessor<EmptyRequest>>();
     }
 
     public override async Task HandleAsync(CancellationToken ct)

--- a/src/ReadyStackGo.Api/Endpoints/Wizard/InstallStackEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Wizard/InstallStackEndpoint.cs
@@ -24,13 +24,10 @@ public class InstallStackEndpoint : Endpoint<InstallStackRequest, InstallStackRe
     {
         Post("/api/wizard/install");
         AllowAnonymous();
-        PreProcessor<WizardTimeoutPreProcessor<InstallStackRequest>>();
     }
 
     public override async Task HandleAsync(InstallStackRequest req, CancellationToken ct)
     {
-        // Timeout check is handled by WizardTimeoutPreProcessor
-
         var result = await _mediator.Send(new CompleteWizardCommand(req.ManifestPath), ct);
 
         // Clear timeout tracking on successful completion

--- a/src/ReadyStackGo.Api/Endpoints/Wizard/ListRegistryForWizardEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Wizard/ListRegistryForWizardEndpoint.cs
@@ -20,7 +20,6 @@ public class ListRegistryForWizardEndpoint : EndpointWithoutRequest<IEnumerable<
     {
         Get("/api/wizard/registry");
         AllowAnonymous();
-        PreProcessor<WizardTimeoutPreProcessor<EmptyRequest>>();
     }
 
     public override Task HandleAsync(CancellationToken ct)

--- a/src/ReadyStackGo.Api/Endpoints/Wizard/SetEnvironmentEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Wizard/SetEnvironmentEndpoint.cs
@@ -21,13 +21,10 @@ public class SetEnvironmentEndpoint : Endpoint<SetEnvironmentRequest, SetEnviron
     {
         Post("/api/wizard/environment");
         AllowAnonymous();
-        PreProcessor<WizardTimeoutPreProcessor<SetEnvironmentRequest>>();
     }
 
     public override async Task HandleAsync(SetEnvironmentRequest req, CancellationToken ct)
     {
-        // Timeout check is handled by WizardTimeoutPreProcessor
-
         var result = await _mediator.Send(
             new CreateEnvironmentCommand(req.Name, req.SocketPath),
             ct);

--- a/src/ReadyStackGo.Api/Endpoints/Wizard/SetOrganizationEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Wizard/SetOrganizationEndpoint.cs
@@ -21,13 +21,10 @@ public class SetOrganizationEndpoint : Endpoint<SetOrganizationRequest, SetOrgan
     {
         Post("/api/wizard/organization");
         AllowAnonymous();
-        PreProcessor<WizardTimeoutPreProcessor<SetOrganizationRequest>>();
     }
 
     public override async Task HandleAsync(SetOrganizationRequest req, CancellationToken ct)
     {
-        // Timeout check is handled by WizardTimeoutPreProcessor
-
         var result = await _mediator.Send(
             new ProvisionOrganizationCommand(req.Name, req.Name),
             ct);

--- a/src/ReadyStackGo.Api/Endpoints/Wizard/SetRegistriesEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Wizard/SetRegistriesEndpoint.cs
@@ -21,7 +21,6 @@ public class SetRegistriesEndpoint : Endpoint<SetRegistriesRequest, SetRegistrie
     {
         Post("/api/wizard/registries");
         AllowAnonymous();
-        PreProcessor<WizardTimeoutPreProcessor<SetRegistriesRequest>>();
     }
 
     public override async Task HandleAsync(SetRegistriesRequest req, CancellationToken ct)

--- a/src/ReadyStackGo.Api/Endpoints/Wizard/SetSourcesEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Wizard/SetSourcesEndpoint.cs
@@ -21,7 +21,6 @@ public class SetSourcesEndpoint : Endpoint<SetSourcesRequest, SetSourcesResponse
     {
         Post("/api/wizard/sources");
         AllowAnonymous();
-        PreProcessor<WizardTimeoutPreProcessor<SetSourcesRequest>>();
     }
 
     public override async Task HandleAsync(SetSourcesRequest req, CancellationToken ct)

--- a/src/ReadyStackGo.Api/Endpoints/Wizard/VerifyRegistryAccessEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Wizard/VerifyRegistryAccessEndpoint.cs
@@ -26,7 +26,6 @@ public class VerifyRegistryAccessEndpoint : Endpoint<VerifyRegistryAccessRequest
     {
         Post("/api/wizard/verify-registry-access");
         AllowAnonymous();
-        PreProcessor<WizardTimeoutPreProcessor<VerifyRegistryAccessRequest>>();
     }
 
     public override async Task HandleAsync(VerifyRegistryAccessRequest req, CancellationToken ct)

--- a/src/ReadyStackGo.Application/Services/WizardState.cs
+++ b/src/ReadyStackGo.Application/Services/WizardState.cs
@@ -2,27 +2,19 @@ namespace ReadyStackGo.Application.Services;
 
 /// <summary>
 /// Represents the state of the setup wizard.
-/// v0.4: Simplified from 4 steps to 3 steps (ConnectionsSet removed).
+/// v0.26: Simplified to 2 states only. Admin creation (Phase 1) transitions
+/// directly to Installed. Organization setup moved to post-login onboarding.
 /// </summary>
 public enum WizardState
 {
     /// <summary>
-    /// Initial state - no configuration exists
+    /// Initial state - no admin user exists yet (Phase 1: unauthenticated setup)
     /// </summary>
     NotStarted,
 
     /// <summary>
-    /// Admin user has been created (Step 1 complete)
-    /// </summary>
-    AdminCreated,
-
-    /// <summary>
-    /// Organization has been set (Step 2 complete)
-    /// </summary>
-    OrganizationSet,
-
-    /// <summary>
-    /// Wizard completed - system is ready to use (Step 3 complete)
+    /// Admin created, wizard complete. Organization and further setup
+    /// happen via the authenticated onboarding checklist (Phase 2).
     /// </summary>
     Installed
 }

--- a/src/ReadyStackGo.Infrastructure/Configuration/SystemConfigService.cs
+++ b/src/ReadyStackGo.Infrastructure/Configuration/SystemConfigService.cs
@@ -35,8 +35,6 @@ public class SystemConfigService : ISystemConfigService
         return state switch
         {
             InfraWizardState.NotStarted => AppWizardState.NotStarted,
-            InfraWizardState.AdminCreated => AppWizardState.AdminCreated,
-            InfraWizardState.OrganizationSet => AppWizardState.OrganizationSet,
             InfraWizardState.Installed => AppWizardState.Installed,
             _ => AppWizardState.NotStarted
         };
@@ -47,8 +45,6 @@ public class SystemConfigService : ISystemConfigService
         return state switch
         {
             AppWizardState.NotStarted => InfraWizardState.NotStarted,
-            AppWizardState.AdminCreated => InfraWizardState.AdminCreated,
-            AppWizardState.OrganizationSet => InfraWizardState.OrganizationSet,
             AppWizardState.Installed => InfraWizardState.Installed,
             _ => InfraWizardState.NotStarted
         };

--- a/src/ReadyStackGo.Infrastructure/Configuration/WizardState.cs
+++ b/src/ReadyStackGo.Infrastructure/Configuration/WizardState.cs
@@ -2,27 +2,19 @@ namespace ReadyStackGo.Infrastructure.Configuration;
 
 /// <summary>
 /// Represents the state of the setup wizard.
-/// v0.4: Simplified from 4 steps to 3 steps (ConnectionsSet removed).
+/// v0.26: Simplified to 2 states only. Admin creation (Phase 1) transitions
+/// directly to Installed. Organization setup moved to post-login onboarding.
 /// </summary>
 public enum WizardState
 {
     /// <summary>
-    /// Initial state - no configuration exists
+    /// Initial state - no admin user exists yet (Phase 1: unauthenticated setup)
     /// </summary>
     NotStarted,
 
     /// <summary>
-    /// Admin user has been created (Step 1 complete)
-    /// </summary>
-    AdminCreated,
-
-    /// <summary>
-    /// Organization has been set (Step 2 complete)
-    /// </summary>
-    OrganizationSet,
-
-    /// <summary>
-    /// Wizard completed - system is ready to use (Step 3 complete)
+    /// Admin created, wizard complete. Organization and further setup
+    /// happen via the authenticated onboarding checklist (Phase 2).
     /// </summary>
     Installed
 }

--- a/src/ReadyStackGo.WebUi/e2e/wizard-registries.spec.ts
+++ b/src/ReadyStackGo.WebUi/e2e/wizard-registries.spec.ts
@@ -46,7 +46,7 @@ async function setupWizardViaApi() {
 /** Navigate from wizard step 3 (env) through to the Registries step */
 async function navigateToRegistriesStep(page: Page) {
   await page.goto('/wizard');
-  // Backend state is OrganizationSet → frontend shows step 3 (Environment)
+  // Backend state is not yet Installed → frontend shows step 3 (Environment)
   // Environment was already created via API, but wizard doesn't track that
 
   // Step 3: Environment — wait for the heading, then skip

--- a/src/ReadyStackGo.WebUi/src/api/wizard.ts
+++ b/src/ReadyStackGo.WebUi/src/api/wizard.ts
@@ -19,7 +19,7 @@ export interface WizardTimeoutInfo {
 }
 
 export interface WizardStatusResponse {
-  wizardState: 'NotStarted' | 'AdminCreated' | 'OrganizationSet' | 'Installed';
+  wizardState: 'NotStarted' | 'Installed';
   isCompleted: boolean;
   /** Default Docker socket path for the server's OS (e.g., "npipe://./pipe/docker_engine" for Windows) */
   defaultDockerSocketPath: string;

--- a/tests/ReadyStackGo.IntegrationTests/WizardEndpointsIntegrationTests.cs
+++ b/tests/ReadyStackGo.IntegrationTests/WizardEndpointsIntegrationTests.cs
@@ -210,9 +210,9 @@ public class WizardEndpointsIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task POST_Install_WithoutOrganization_ReturnsError()
+    public async Task POST_Install_WithoutOrganization_SucceedsAfterAdminCreation()
     {
-        // Arrange - Only create admin, skip organization
+        // Arrange - Only create admin, skip organization (org setup moved to onboarding)
         await CreateAdminForTest();
 
         var request = new
@@ -223,11 +223,10 @@ public class WizardEndpointsIntegrationTests : IAsyncLifetime
         // Act
         var response = await _client.PostAsJsonAsync("/api/wizard/install", request);
 
-        // Assert
-        // Should fail because organization wasn't set
+        // Assert - Wizard only requires admin; org setup happens post-login via onboarding
         var result = await response.Content.ReadFromJsonAsync<InstallStackResponseSimple>();
         result.Should().NotBeNull();
-        result!.Success.Should().BeFalse();
+        result!.Success.Should().BeTrue();
     }
 
     [Fact]

--- a/tests/ReadyStackGo.UnitTests/Configuration/WizardTimeoutServiceTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Configuration/WizardTimeoutServiceTests.cs
@@ -92,7 +92,7 @@ public class WizardTimeoutServiceTests
     {
         // Arrange
         var startedAt = DateTime.UtcNow.AddMinutes(-2); // Started 2 minutes ago
-        _systemConfig.WizardState = WizardState.AdminCreated;
+        _systemConfig.WizardState = WizardState.NotStarted;
         _systemConfig.WizardStartedAt = startedAt;
         var service = CreateService();
 
@@ -111,7 +111,7 @@ public class WizardTimeoutServiceTests
     {
         // Arrange
         var startedAt = DateTime.UtcNow.AddMinutes(-10); // Started 10 minutes ago
-        _systemConfig.WizardState = WizardState.AdminCreated;
+        _systemConfig.WizardState = WizardState.NotStarted;
         _systemConfig.WizardStartedAt = startedAt;
         var service = CreateService();
 
@@ -162,7 +162,7 @@ public class WizardTimeoutServiceTests
     public async Task IsTimedOutAsync_WhenExpired_ReturnsTrue()
     {
         // Arrange
-        _systemConfig.WizardState = WizardState.AdminCreated;
+        _systemConfig.WizardState = WizardState.NotStarted;
         _systemConfig.WizardStartedAt = DateTime.UtcNow.AddMinutes(-10);
         var service = CreateService();
 
@@ -205,7 +205,7 @@ public class WizardTimeoutServiceTests
     public async Task ResetTimeoutAsync_WhenLocked_DoesNotReset()
     {
         // Arrange
-        _systemConfig.WizardState = WizardState.AdminCreated;
+        _systemConfig.WizardState = WizardState.NotStarted;
         _systemConfig.IsWizardLocked = true;
         _systemConfig.WizardStartedAt = DateTime.UtcNow.AddMinutes(-10);
         var service = CreateService();
@@ -222,7 +222,7 @@ public class WizardTimeoutServiceTests
     public async Task ResetTimeoutAsync_WhenNotLocked_ResetsPartialState()
     {
         // Arrange
-        _systemConfig.WizardState = WizardState.AdminCreated;
+        _systemConfig.WizardState = WizardState.NotStarted;
         _systemConfig.IsWizardLocked = false;
         _systemConfig.WizardStartedAt = DateTime.UtcNow;
         var service = CreateService();


### PR DESCRIPTION
## Summary
- Simplify wizard states from 4 (NotStarted/AdminCreated/OrganizationSet/Installed) to 2 (NotStarted/Installed)
- Remove `WizardTimeoutPreProcessor` from 9 wizard endpoints, keeping it only on `CreateAdminEndpoint`
- Remove organization existence check from `CompleteWizardHandler` — org setup moved to post-login onboarding
- Simplify `GetWizardStatusHandler` to derive state from admin existence only

## Changes
- **WizardState enums** (Application + Infrastructure): Remove `AdminCreated` and `OrganizationSet`
- **GetWizardStatusHandler**: Two states only — admin exists → Installed, else NotStarted
- **CompleteWizardHandler**: Only requires admin, no org check
- **SystemConfigService**: Remove intermediate state mappings
- **9 wizard endpoints**: Remove `WizardTimeoutPreProcessor` (timeout only on CreateAdmin)
- **Frontend**: Update `WizardStatusResponse` type to match simplified states
- **Tests**: Update unit + integration tests for new behavior

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings (pre-existing warnings only)
- [x] `dotnet test` — All 1748 unit tests pass
- [x] TypeScript compiles clean