### PR TITLE
Add dismiss onboarding endpoint and service tests

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/Onboarding/DismissOnboardingEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Onboarding/DismissOnboardingEndpoint.cs
@@ -1,0 +1,30 @@
+using FastEndpoints;
+using Microsoft.AspNetCore.Http;
+using ReadyStackGo.Application.Services;
+
+namespace ReadyStackGo.API.Endpoints.Onboarding;
+
+/// <summary>
+/// POST /api/onboarding/dismiss - Dismiss the onboarding checklist
+/// </summary>
+public class DismissOnboardingEndpoint : EndpointWithoutRequest
+{
+    private readonly IOnboardingStateService _onboardingStateService;
+
+    public DismissOnboardingEndpoint(IOnboardingStateService onboardingStateService)
+    {
+        _onboardingStateService = onboardingStateService;
+    }
+
+    public override void Configure()
+    {
+        Post("/api/onboarding/dismiss");
+        Description(b => b.WithTags("Onboarding"));
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        await _onboardingStateService.DismissAsync(ct);
+        HttpContext.Response.StatusCode = StatusCodes.Status204NoContent;
+    }
+}

--- a/tests/ReadyStackGo.UnitTests/Configuration/OnboardingStateServiceTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Configuration/OnboardingStateServiceTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using Moq;
+using ReadyStackGo.Infrastructure.Configuration;
+
+namespace ReadyStackGo.UnitTests.Configuration;
+
+public class OnboardingStateServiceTests
+{
+    private readonly Mock<IConfigStore> _configStoreMock;
+    private SystemConfig _systemConfig;
+
+    public OnboardingStateServiceTests()
+    {
+        _configStoreMock = new Mock<IConfigStore>();
+        _systemConfig = new SystemConfig();
+
+        _configStoreMock
+            .Setup(x => x.GetSystemConfigAsync())
+            .ReturnsAsync(() => _systemConfig);
+
+        _configStoreMock
+            .Setup(x => x.SaveSystemConfigAsync(It.IsAny<SystemConfig>()))
+            .Callback<SystemConfig>(config => _systemConfig = config)
+            .Returns(Task.CompletedTask);
+    }
+
+    private OnboardingStateService CreateService() => new(_configStoreMock.Object);
+
+    [Fact]
+    public async Task IsDismissedAsync_WhenNotDismissed_ReturnsFalse()
+    {
+        // Arrange
+        _systemConfig.OnboardingDismissed = false;
+        var service = CreateService();
+
+        // Act
+        var result = await service.IsDismissedAsync();
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsDismissedAsync_WhenDismissed_ReturnsTrue()
+    {
+        // Arrange
+        _systemConfig.OnboardingDismissed = true;
+        var service = CreateService();
+
+        // Act
+        var result = await service.IsDismissedAsync();
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task DismissAsync_SetsOnboardingDismissedToTrue()
+    {
+        // Arrange
+        _systemConfig.OnboardingDismissed = false;
+        var service = CreateService();
+
+        // Act
+        await service.DismissAsync();
+
+        // Assert
+        _systemConfig.OnboardingDismissed.Should().BeTrue();
+        _configStoreMock.Verify(x => x.SaveSystemConfigAsync(It.IsAny<SystemConfig>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DismissAsync_WhenAlreadyDismissed_StillSaves()
+    {
+        // Arrange
+        _systemConfig.OnboardingDismissed = true;
+        var service = CreateService();
+
+        // Act
+        await service.DismissAsync();
+
+        // Assert
+        _systemConfig.OnboardingDismissed.Should().BeTrue();
+        _configStoreMock.Verify(x => x.SaveSystemConfigAsync(It.IsAny<SystemConfig>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task IsDismissedAsync_DefaultConfig_ReturnsFalse()
+    {
+        // Arrange - fresh SystemConfig with defaults
+        var service = CreateService();
+
+        // Act
+        var result = await service.IsDismissedAsync();
+
+        // Assert
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `POST /api/onboarding/dismiss` endpoint to persist onboarding checklist dismissal
- Add unit tests for `OnboardingStateService` (IsDismissed, Dismiss, idempotent dismiss, defaults)

## Changes
- **New**: `DismissOnboardingEndpoint.cs` — authenticated POST, returns 204, calls `IOnboardingStateService.DismissAsync()`
- **New**: `OnboardingStateServiceTests.cs` — 5 unit tests for dismiss persistence via IConfigStore

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] `dotnet test` — All 1753 unit tests pass (+5 new)