### PR TITLE
Add spec documents for future epics

### DIFF
--- a/docs/specs/rsgo-distributions/AMS-UI-INTEGRATION.md
+++ b/docs/specs/rsgo-distributions/AMS-UI-INTEGRATION.md
@@ -1,0 +1,374 @@
+# AMS UI Integration in ReadyStackGo
+
+**Ziel:**  
+Beschreiben, wie das bestehende ams UI Framework & Design System (inkl. Web Components) in die ReadyStackGo-ams Distribution integriert wird – auf Basis der zuvor definierten Frontend-Architektur:
+
+- `@rsgo/core` → Hooks & ViewModel (Logik, API, SignalR)
+- `@rsgo/ui-ams` → React UI, die das ams Design System (Web Components) nutzt
+- `rsgo-ams` App → verwendet `@rsgo/ui-ams` + `@rsgo/core` als fertiges Frontend
+
+Diese Datei kannst du z. B. als  
+`/docs/AMS-UI-INTEGRATION.md` in dein ams-Repo oder ins RSGO-Repo legen.
+
+---
+
+## 1. Überblick
+
+### 1.1 Architektur im Frontend
+
+```text
+/packages
+  /core            # @rsgo/core
+  /ui-ams          # @rsgo/ui-ams (React + ams Design System)
+  /ams-design      # optional: Wrapper oder DS-spezifische Helper
+
+/apps
+  /rsgo-ams        # App-Host, nutzt @rsgo/core + @rsgo/ui-ams
+```
+
+- **@rsgo/core**
+  - enthält:
+    - DTO-Typen (Spiegel der C#-DTOs),
+    - API-Clients (fetch/JSON),
+    - Hooks als ViewModel (z. B. `useStacksPageViewModel()`).
+  - kennt **kein** ams Design System.
+
+- **ams UI Framework & Design System**
+  - liefert Web Components (`<ams-button>`, `<ams-card>`, `<ams-input>`, `<ams-stack-card>` etc.).
+  - wird im Browser über `customElements.define(... )` registriert.
+
+- **@rsgo/ui-ams**
+  - React UI-Paket:
+    - bootstrapped das ams Design System,
+    - nutzt kleine React-Wrapper für Web Components,
+    - kombiniert diese mit `@rsgo/core` Hooks.
+
+---
+
+## 2. Einbindung des ams Design Systems
+
+### 2.1 Registrierung der Web Components
+
+Damit React `<ams-...>`-Tags nutzen kann, muss das Design System einmalig initialisiert werden.
+
+```ts
+// ui-ams/src/setupDesignSystem.ts
+
+// Beispiel – je nach DS-Implementierung anpassen:
+import "@ams/design-system/button";
+import "@ams/design-system/card";
+import "@ams/design-system/input";
+import "@ams/design-system/stack-card";
+// ... weitere Komponenten
+
+// optional: Theme laden
+import "@ams/design-system/theme/default.css";
+```
+
+Im App-Entry:
+
+```ts
+// ui-ams/src/main.tsx
+
+import "./setupDesignSystem";
+
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { App } from "./App";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+```
+
+Damit sind alle `ams-*` Custom Elements im Browser verfügbar.
+
+---
+
+## 3. React-Wrapper für Web Components
+
+React kann Custom Elements direkt rendern, aber:
+
+- Props werden in der Regel als **Attribute** gesetzt,
+- **Properties** und **Custom Events** brauchen Wrapper-Logik.
+
+Deshalb erstellen wir **Wrapper-Komponenten**, die:
+
+- in React typisch aussehen (Props, Events),
+- intern Web Components nutzen (`<ams-button>` etc.),
+- Properties und Events korrekt behandeln.
+
+### 3.1 Einfacher Wrapper: `<ams-button>`
+
+Wenn der Button primär über Attribute gesteuert wird:
+
+```tsx
+// ui-ams/src/components/AmsButton.tsx
+
+import React from "react";
+
+export type AmsButtonVariant = "primary" | "secondary" | "danger";
+
+export interface AmsButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: AmsButtonVariant;
+}
+
+export const AmsButton: React.FC<AmsButtonProps> = ({
+  variant = "primary",
+  children,
+  ...rest
+}) => {
+  return (
+    <ams-button variant={variant} {...rest}>
+      {children}
+    </ams-button>
+  );
+};
+```
+
+Verwendung:
+
+```tsx
+<AmsButton variant="primary" onClick={handleClick}>
+  Speichern
+</AmsButton>
+```
+
+---
+
+### 3.2 Komplexerer Wrapper: `<ams-stack-card>` mit Properties & Custom Events
+
+Angenommen das Design System erwartet:
+
+- Property `data` (Objekt),
+- feuert `stackSelected` als `CustomEvent<{ id: string }>`.
+
+```tsx
+// ui-ams/src/components/AmsStackCard.tsx
+
+import React from "react";
+
+export type StackCardData = {
+  id: string;
+  name: string;
+  version: string;
+  status: string;
+};
+
+export interface AmsStackCardProps {
+  data: StackCardData;
+  onStackSelected?: (id: string) => void;
+}
+
+export const AmsStackCard: React.FC<AmsStackCardProps> = ({
+  data,
+  onStackSelected
+}) => {
+  const ref = React.useRef<any>(null);
+
+  // data als Property setzen
+  React.useEffect(() => {
+    if (ref.current) {
+      ref.current.data = data;
+    }
+  }, [data]);
+
+  // Custom Event binden
+  React.useEffect(() => {
+    const el = ref.current;
+    if (!el || !onStackSelected) return;
+
+    const handler = (e: CustomEvent<{ id: string }>) => {
+      onStackSelected(e.detail.id);
+    };
+
+    el.addEventListener("stackSelected", handler as EventListener);
+
+    return () => {
+      el.removeEventListener("stackSelected", handler as EventListener);
+    };
+  }, [onStackSelected]);
+
+  return <ams-stack-card ref={ref}></ams-stack-card>;
+};
+```
+
+Verwendung in einer Page:
+
+```tsx
+<AmsStackCard
+  data={{
+    id: s.id,
+    name: s.name,
+    version: s.version,
+    status: s.status
+  }}
+  onStackSelected={(id) => vm.installStack(id)}
+/>
+```
+
+---
+
+## 4. Kombination mit `@rsgo/core` Hooks
+
+### 4.1 Beispiel: `StacksPage` in `@rsgo/ui-ams`
+
+```tsx
+// ui-ams/src/pages/StacksPage.tsx
+
+import React from "react";
+import { useStacksPageViewModel } from "@rsgo/core";
+import { AmsButton } from "../components/AmsButton";
+import { AmsStackCard } from "../components/AmsStackCard";
+
+export const StacksPage: React.FC = () => {
+  const vm = useStacksPageViewModel();
+
+  return (
+    <div className="flex flex-col gap-4">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-primary-600">
+          ams.project Stacks
+        </h1>
+        <AmsButton onClick={vm.refresh} disabled={vm.isLoading}>
+          Neu laden
+        </AmsButton>
+      </header>
+
+      {vm.error && (
+        <div className="mb-4">
+          <ams-alert variant="error">{vm.error}</ams-alert>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+        {vm.stacks.map((s) => (
+          <AmsStackCard
+            key={s.id}
+            data={{
+              id: s.id,
+              name: s.name,
+              version: s.version,
+              status: s.status
+            }}
+            onStackSelected={(id) => {
+              if (vm.canInstall && s.status === "available") {
+                void vm.installStack(id);
+              }
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+};
+```
+
+- `useStacksPageViewModel()` kommt aus `@rsgo/core` und kapselt:
+  - API-Aufrufe (`/api/stacks/viewmodel`),
+  - Loading/Error-State,
+  - `installStack(id)` → POST ans Backend.
+- Die Page rendert ausschließlich:
+  - Layout (Grid, Header),
+  - Web Components via Wrapper (`AmsButton`, `AmsStackCard`).
+
+**Ergebnis:**
+
+- UI ist zu 100 % ams CI (Design System),
+- Logik ist 100 % in Core + Backend gekapselt.
+
+---
+
+## 5. App-Host `rsgo-ams`
+
+### 5.1 App-Komponente
+
+```tsx
+// apps/rsgo-ams/src/App.tsx
+
+import React from "react";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { StacksPage } from "@rsgo/ui-ams"; // Barrel-Export aus ui-ams
+// weitere Pages (Wizard, Environments, Deployments, ...)
+
+export const App: React.FC = () => (
+  <BrowserRouter>
+    <Routes>
+      <Route path="/stacks" element={<StacksPage />} />
+      {/* weitere ams-spezifische Routen */}
+    </Routes>
+  </BrowserRouter>
+);
+```
+
+### 5.2 Entry
+
+```tsx
+// apps/rsgo-ams/src/main.tsx
+
+import "../../ui-ams/src/setupDesignSystem"; // oder eigenes Paket
+
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { App } from "./App";
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);
+```
+
+---
+
+## 6. Typisierung & Developer Experience
+
+### 6.1 Typen für Web Components
+
+Je nach Implementierung des Design Systems:
+
+- **Stencil / Lit** können oft TypeScript-Typen generieren:
+  - ggf. als `@types/ams-design-system` Package bereitstellen.
+- Alternativ:
+  - Typen manuell in den React-Wrappern definieren (wie in `AmsButtonProps`, `AmsStackCardProps` gezeigt).
+
+### 6.2 Empfehlung
+
+- Web Components möglichst **„präsentationsorientiert“** halten:
+  - Props/Properties rein,
+  - Events raus,
+  - keine komplexe Business-Logik darin.
+- Logik bleibt im C#-Backend und in den `@rsgo/core` Hooks.
+- React-Wrapper sind dünne Adapter.
+
+---
+
+## 7. Vorteile dieses Integrationsansatzes
+
+- ✅ **Wiederverwendung** des bestehenden ams Design Systems (Web Components).
+- ✅ **Saubere Trennung**:
+  - `@rsgo/core` → Logik & Datenfluss,
+  - `@rsgo/ui-ams` → ams CI + Web Components.
+- ✅ **Flexibilität**:
+  - andere Distributionen (z. B. Generic UI) können reines React/Tailwind oder ein anderes Design System nutzen.
+- ✅ **Testbarkeit**:
+  - Hooks (`@rsgo/core`) separat testbar,
+  - Wrapper & Pages können als reine UI getestet werden (Storybook, Jest, Playwright).
+
+---
+
+## 8. Zusammenfassung
+
+- Das **ams UI Framework** (Web Components) wird im ams-Frontend (`@rsgo/ui-ams`) initialisiert.
+- Für jede relevante Web Component gibt es einen **React-Wrapper**, der:
+  - Props (inkl. komplexer Properties) an das Custom Element übergibt,
+  - Custom Events in React-Callbacks übersetzt.
+- Die Pages in `@rsgo/ui-ams` verwenden:
+  - `@rsgo/core` Hooks als ViewModels,
+  - die Wrapper-Komponenten aus dem ams Design System.
+- Die App `rsgo-ams` setzt alles zusammen und bildet das UI der ams-Distribution.
+
+Damit kannst du die ams-Edition von ReadyStackGo perfekt an das bestehende ams Design System andocken, ohne die saubere Trennung von Core/Logic und UI aufzugeben.

--- a/docs/specs/rsgo-distributions/RSGO-DISTRIBUTION-SETUP.md
+++ b/docs/specs/rsgo-distributions/RSGO-DISTRIBUTION-SETUP.md
@@ -1,0 +1,431 @@
+# ReadyStackGo Distribution Setup  
+**Core auf GitHub (OSS) & ams-Distribution in Azure DevOps (privat)**
+
+Dieses Dokument beschreibt, wie du:
+
+- **ReadyStackGo Core** als Open-Source-Projekt auf GitHub betreibst,
+- und darauf basierend eine **ams-spezifische Distribution** in Azure DevOps baust,
+- mit **zwei getrennten Docker-Images**, ohne dass der Core irgendetwas von `ams.project` wissen muss.
+
+Die Datei ist so geschrieben, dass du sie direkt als  
+`/docs/RSGO-DISTRIBUTION-SETUP.md` in dein ReadyStackGo-Repo legen kannst (oder im ams-Repo spiegeln).
+
+---
+
+## 1. Zielbild
+
+### 1.1 High-Level
+
+Wir wollen:
+
+- **Ein zentrales, generisches Produkt**:  
+  **ReadyStackGo Core** – Open Source auf GitHub.
+- **Eine angepasste, firmenspezifische Distribution**:  
+  **ReadyStackGo ams** – private Portierung in Azure DevOps.
+
+Beide nutzen **denselben Core**, aber:
+
+- **UI & Wizard & Default-Konfiguration** unterscheiden sich,
+- sie werden als **separate Docker-Images** bereitgestellt.
+
+### 1.2 Produkte
+
+- **Generic / OSS Image** (für dich & Community):
+  - z. B. `ghcr.io/wiesenwischer/readystackgo:0.5.0`
+  - Generisches UI, generischer Setup-Wizard.
+  - Voll konfigurierbar (StackSources, Registries, Environments, …).
+
+- **ams Distribution** (nur für deine Firma / Kunden):
+  - z. B. `registry.company.local/rsgo-ams:0.5.0-ams.1`
+  - Firmeneigenes Branding (Corporate Identity).
+  - ams-spezifischer Wizard:
+    - Registry-Token,
+    - ams.erp DB-Verbindung,
+    - Auswahl von ams-spezifischen Stacks.
+  - Vordefinierte StackSource & ContainerRegistry für `amssolution/*`.
+
+**Wichtig:**  
+Der **Core weiß nichts von `ams.project`** – alle ams-spezifischen Dinge liegen in der **privaten Distribution**.
+
+---
+
+## 2. Repository-Struktur
+
+### 2.1 GitHub Repo – `ReadyStackGo` (öffentlich)
+
+Enthält alle generischen, wiederverwendbaren Teile:
+
+```text
+/ReadyStackGo (GitHub)
+  /src
+    /ReadyStackGo.Core              # Domain, Application, Infrastructure
+    /ReadyStackGo.WebHost.Generic   # Generischer ASP.NET-WebHost
+    /ReadyStackGo.Ui.Generic        # Generische React/Tailwind UI
+  /docs
+    RSGO-DISTRIBUTION-SETUP.md
+    ...
+```
+
+**ReadyStackGo.Core**:
+
+- Domänenmodell:
+  - Organizations, Environments, StackSources, ContainerRegistries, StackManifests, StackInstallations, Deployments, Health, …
+- Services:
+  - StackSource-Verwaltung (Git, FileSystem, OCI, Import),
+  - Container Registry Registry,
+  - Deployment Engine (Docker API),
+  - Health Monitoring, Logging, etc.
+- Erweiterungspunkte:
+  - z. B. `ISetupWizardDefinitionProvider`, `IBootstrapper`, `IStackSource`-Implementierungen.
+
+**ReadyStackGo.WebHost.Generic**:
+
+- ASP.NET Core Host für den generischen Modus.
+- Registriert:
+  - generische Wizard-Definition,
+  - keine produktspezifischen Defaults (oder nur minimal).
+
+**ReadyStackGo.Ui.Generic**:
+
+- Generische, neutrale UI (Tailwind, React, o. ä.).
+- Voller Zugriff auf alle Konfigurationsbereiche:
+  - StackSources, Registries, Orgs, Envs, Stacks, Deployments.
+
+---
+
+### 2.2 Azure DevOps Repo – `ReadyStackGo.Ams` (privat)
+
+Enthält nur ams-spezifische Dinge:
+
+```text
+/ReadyStackGo.Ams (Azure DevOps)
+  /src
+    /ReadyStackGo.WebHost.Ams     # ASP.NET-Host für die ams-Distribution
+    /ReadyStackGo.Ui.Ams          # ams-spezifische UI (Branding & Wizard)
+  /pipelines
+    rsgo-ams-ci.yml
+    rsgo-ams-cd.yml
+```
+
+**ReadyStackGo.WebHost.Ams**:
+
+- Referenziert `ReadyStackGo.Core` als NuGet-Paket (siehe Abschnitt 3).
+- Registriert:
+  - `AmsProjectSetupWizardDefinitionProvider`,
+  - `AmsBootstrapper` (Seed von StackSources & ContainerRegistries),
+  - ggf. ams-spezifische API-Endpunkte (nur falls nötig).
+
+**ReadyStackGo.Ui.Ams**:
+
+- ams-spezifisches Branding:
+  - Logos, Farben, Typographie.
+- ams-spezifischer Setup Wizard:
+  - Schritt 1: Registry-Token für `docker.io/amssolution/*`,
+  - Schritt 2: ams.erp DB-Verbindung,
+  - Schritt 3: Auswahl ams Stacks (IdentityAccess, Infrastruktur, ams.project Core, Monitoring).
+- Evtl. eigene Übersichtsseiten für ams.project.
+
+---
+
+## 3. Kopplung: Wie kommt Ams an den Core?
+
+### 3.1 Empfehlung: Core als NuGet-Package
+
+**Ziel:**
+
+- ReadyStackGo.Core wird in GitHub gebaut und als Paket veröffentlicht.
+- ReadyStackGo.Ams verwendet diese Pakete als Dependencies.
+
+#### 3.1.1 Build & Package im GitHub-Repo
+
+CI in GitHub (z. B. GitHub Actions):
+
+1. Code bauen & testen.
+2. Version bestimmen (z. B. via GitVersion).
+3. `ReadyStackGo.Core` (und evtl. weitere libs) als NuGet-Pakete erstellen.
+4. Pakete in einen Feed pushen, z. B.:
+   - GitHub Packages,
+   - oder direkt Azure Artifacts (öffentlich oder privat).
+
+Beispiel-Package-Namen:
+
+- `ReadyStackGo.Core`
+- optional: `ReadyStackGo.Infrastructure`, `ReadyStackGo.Domain`, etc.
+
+#### 3.1.2 Nutzung in Azure DevOps
+
+Im `ReadyStackGo.Ams`-Repo:
+
+- NuGet-Feed (GitHub Packages oder Azure Artifacts) als externe Quelle einbinden.
+- In `ReadyStackGo.WebHost.Ams.csproj` (vereinfacht):
+
+```xml
+<ItemGroup>
+  <PackageReference Include="ReadyStackGo.Core" Version="0.5.0" />
+</ItemGroup>
+```
+
+Damit:
+
+- ist **klar versioniert**, auf welcher Core-Version die ams-Distribution läuft,
+- kannst du Updates bewusst steuern (0.5.0 → 0.6.0).
+
+---
+
+## 4. Wizard & Programmlogik: Erweiterung ohne ams im Core
+
+Der Core definiert nur **Abstraktionen**, die Ams-Distribution implementiert.
+
+### 4.1 Wizard Definition (im Core)
+
+```csharp
+public interface ISetupWizardDefinitionProvider
+{
+    SetupWizardDefinition GetDefinition();
+}
+
+public sealed class SetupWizardDefinition
+{
+    public string Id { get; init; }                    // z.B. "generic", "ams-project"
+    public IReadOnlyList<WizardStepDefinition> Steps { get; init; }
+}
+
+public sealed class WizardStepDefinition
+{
+    public string Id { get; init; }                    // "registry-token", "db-connection", ...
+    public string Title { get; init; }
+    public string Description { get; init; }
+    public string ComponentType { get; init; }         // UI-Komponententyp, z.B. "RegistryTokenStep"
+}
+```
+
+- Core selbst:
+  - stellt ein API zur Verfügung, z. B. `GET /api/wizard/definition`.
+  - kennt nur **Strukturen**, keine konkreten Flows.
+
+### 4.2 Generische Implementierung (im GitHub-Host)
+
+In `ReadyStackGo.WebHost.Generic`:
+
+```csharp
+public sealed class GenericSetupWizardDefinitionProvider : ISetupWizardDefinitionProvider
+{
+    public SetupWizardDefinition GetDefinition()
+        => new()
+        {
+            Id = "generic",
+            Steps =
+            [
+                new()
+                {
+                    Id = "registry",
+                    Title = "Registry konfigurieren",
+                    Description = "Legen Sie Containerregistries fest …",
+                    ComponentType = "GenericRegistrySetupStep"
+                },
+                new()
+                {
+                    Id = "stackSources",
+                    Title = "Stack Sources",
+                    Description = "Fügen Sie Stack-Quellen hinzu …",
+                    ComponentType = "GenericStackSourceSetupStep"
+                }
+            ]
+        };
+}
+```
+
+### 4.3 Ams-spezifische Implementierung (im Ams-Host)
+
+In `ReadyStackGo.WebHost.Ams`:
+
+```csharp
+public sealed class AmsProjectSetupWizardDefinitionProvider : ISetupWizardDefinitionProvider
+{
+    public SetupWizardDefinition GetDefinition()
+        => new()
+        {
+            Id = "ams-project",
+            Steps =
+            [
+                new()
+                {
+                    Id = "registry-token",
+                    Title = "Registry-Zugriff einrichten",
+                    Description = "Bitte geben Sie den bereitgestellten API-Token ein.",
+                    ComponentType = "AmsRegistryTokenStep"
+                },
+                new()
+                {
+                    Id = "db-connection",
+                    Title = "Datenbank-Verbindung",
+                    Description = "Verbindung zur ams.erp-Datenbank konfigurieren.",
+                    ComponentType = "AmsDbConnectionStep"
+                },
+                new()
+                {
+                    Id = "initial-stacks",
+                    Title = "ams.project Komponenten auswählen",
+                    Description = "Wählen Sie, welche ams.project Teile installiert werden sollen.",
+                    ComponentType = "AmsStackSelectionStep"
+                }
+            ]
+        };
+}
+```
+
+- WebHost.Ams registriert diese Implementierung im DI-Container.
+- Die UI (Ui.Ams) kennt die zugehörigen Komponenten-Namen (`AmsRegistryTokenStep` etc.) und rendert sie.
+
+**Ergebnis:**
+
+- Der **Core** weiß nur: „Es gibt einen Wizard mit Steps“.
+- Die **Konkrete Ausgestaltung** ist 100 % ams-spezifisch im Ams-Repo.
+
+---
+
+## 5. Vorkonfiguration im Ams-Host (Bootstrapper)
+
+Ams-spezifische Defaults (StackSource/Registry) liegen **nur** im Ams-Host.
+
+### 5.1 Beispiel-Bootstrapper
+
+```csharp
+public sealed class AmsBootstrapper
+{
+    private readonly IStackSourceRepository _stackSources;
+    private readonly IContainerRegistryRepository _registries;
+
+    public AmsBootstrapper(
+        IStackSourceRepository stackSources,
+        IContainerRegistryRepository registries)
+    {
+        _stackSources = stackSources;
+        _registries = registries;
+    }
+
+    public async Task InitializeAsync()
+    {
+        // 1) OCI Stack Source für amssolution
+        await _stackSources.EnsureExistsAsync(new StackSource
+        {
+            Id = "oci-amssolution",
+            Type = StackSourceType.Oci,
+            // Diese Details sind nur hier bekannt:
+            // RegistryHost = "index.docker.io",
+            // Repository  = "amssolution/rsgo-stacks",
+            // TagPattern  = "*"
+        });
+
+        // 2) Container Registry Config für amssolution/*
+        await _registries.EnsureExistsAsync(new ContainerRegistryConfig
+        {
+            Id = "amssolution-dockerhub",
+            Host = "index.docker.io",
+            Pattern = "amssolution/*",
+            Username = "amssolutionci", // Fix, Token kommt im Wizard
+            Password = null
+        });
+    }
+}
+```
+
+Dieser Bootstrapper:
+
+- wird beim ersten Start des Ams-Hosts ausgeführt,
+- legt Standard-Einträge an, falls sie noch nicht existieren.
+
+Der Core kennt:
+
+- nur `IStackSourceRepository`, `IContainerRegistryRepository`,
+- **nicht** die speziellen Werte (Host, Repository, Patterns).
+
+---
+
+## 6. Docker-Images & Deployments
+
+### 6.1 Generic Image (GitHub)
+
+Dockerfile (vereinfacht):
+
+```dockerfile
+FROM mcr.microsoft.com/dotnet/aspnet:9.0
+
+WORKDIR /app
+COPY ./publish/generic/ .    # Build-Artefakte von ReadyStackGo.WebHost.Generic + Ui.Generic
+
+ENTRYPOINT ["dotnet", "ReadyStackGo.WebHost.Generic.dll"]
+```
+
+CI-Schritte (GitHub Actions):
+
+1. Build + Test.
+2. Publish (z. B. `dotnet publish -c Release -o ./publish/generic`).
+3. Docker-Image bauen.
+4. Push zu `ghcr.io/wiesenwischer/readystackgo:<version>`.
+
+### 6.2 Ams Image (Azure DevOps)
+
+Dockerfile (vereinfacht):
+
+```dockerfile
+FROM mcr.microsoft.com/dotnet/aspnet:9.0
+
+WORKDIR /app
+COPY ./publish/ams/ .        # Build-Artefakte von ReadyStackGo.WebHost.Ams + Ui.Ams
+
+ENTRYPOINT ["dotnet", "ReadyStackGo.WebHost.Ams.dll"]
+```
+
+CI-Schritte (Azure DevOps):
+
+1. NuGet-Pakete aus GitHub/Azure Artifacts holen (ReadyStackGo.Core).
+2. Build + Test Ams-Host + Ams-UI.
+3. Publish (z. B. `dotnet publish -c Release -o ./publish/ams`).
+4. Docker-Image bauen.
+5. Push in eure interne Registry:
+   - `registry.company.local/rsgo-ams:<version>`.
+
+---
+
+## 7. Versionierung
+
+Empfehlung:
+
+- **Core-Version**:  
+  - z. B. `0.5.0`, `0.6.0`, gesteuert via GitVersion oder Release-Tags.
+- **Ams-Distribution-Version**:
+  - z. B. `0.5.0-ams.1`, `0.5.0-ams.2`, `0.6.0-ams.1`.
+
+Du kannst z. B.:
+
+- in `ReadyStackGo.Ams` im CI:
+  - die Core-Version aus den NuGet-Paketen auslesen,
+  - daraus eine zusammengesetzte Version für das Docker-Image bilden.
+
+---
+
+## 8. Zusammenfassung
+
+- **ReadyStackGo.Core** lebt als Open-Source Projekt auf GitHub.
+- **ReadyStackGo.Ams** ist eine private Distribution in Azure DevOps:
+  - sie referenziert den Core als NuGet-Paket,
+  - bringt eigene UI, Wizard-Definition und Bootstrapper mit,
+  - und erzeugt ein eigenes `rsgo-ams`-Docker-Image.
+- Der Core:
+
+  - kennt **keine** `ams.project`-Details,
+  - stellt nur generische Bausteine (StackSources, Registries, Wizard-Interfaces) bereit.
+
+- Die Ams-Distribution:
+
+  - nutzt diese Bausteine,
+  - setzt konkrete Werte (StackSource `amssolution/rsgo-stacks`, Registry `amssolution/*`),
+  - liefert ein fertiges, firmengebrandetes Produkt für Kunden.
+
+Dieses Setup hält:
+
+- **Wiederverwendbarkeit & Klarheit** im Core,
+- **Flexibilität** für weitere zukünftige Distributionen,
+- und **saubere Trennung** zwischen Open Source und proprietärer Anpassung.
+

--- a/docs/specs/rsgo-distributions/RSGO-FRONTEND-ARCH.md
+++ b/docs/specs/rsgo-distributions/RSGO-FRONTEND-ARCH.md
@@ -1,0 +1,472 @@
+# ReadyStackGo Frontend Architektur
+
+**Ziel:**  
+Klares Muster, wie das Frontend von ReadyStackGo aufgebaut ist, so dass:
+
+- **C# (.NET 9)** die komplette fachliche Logik hält (Domain + Application + „ViewModel-Backend“),
+- **TypeScript/React** nur als dünne View-Schicht fungiert,
+- und **verschiedene UIs** (Generic vs. ams) durch Austausch eines UI-Packages realisiert werden können.
+
+Diese Datei kannst du z. B. als  
+`/docs/RSGO-FRONTEND-ARCH.md` in dein GitHub-Repo legen.
+
+---
+
+## 1. High-Level Architektur
+
+### 1.1 Ziele
+
+- **Keine C#-Logik im Browser**, aber:
+  - fachliche Entscheidungen und Zustände kommen **aus dem Backend**.
+- **Frontend-Core** (TS/React) kapselt:
+  - API-Zugriff,
+  - State-Handling (inkl. Loading/Error),
+  - SignalR-Subscriptions.
+- **UI-Packages** sind:
+  - reine Views („dumme Komponenten“),
+  - austauschbar (Generic vs. ams),
+  - nutzen dieselben Core-Hooks/ViewModels.
+
+### 1.2 Struktur (Monorepo-Sicht)
+
+Empfohlenes Setup (z. B. mit pnpm / yarn workspaces):
+
+```text
+/packages
+  /core            # @rsgo/core   -> DTO-Typen, API-Clients, Hooks (ViewModel)
+  /ui-generic      # @rsgo/ui-generic -> generische UI-Komponenten & Pages
+  /ui-ams          # @rsgo/ui-ams      -> ams-spezifische UI-Komponenten & Pages
+/apps
+  /rsgo-generic    # Generic Host, nutzt core + ui-generic
+  /rsgo-ams        # Ams Host, nutzt core + ui-ams
+```
+
+---
+
+## 2. Verantwortlichkeiten
+
+### 2.1 Backend (C#/.NET 9)
+
+- **Domain & Application Layer**:
+  - „Wahrheit“ über:
+    - Organisationen, Environments,
+    - StackSources, ContainerRegistries,
+    - StackManifests, StackInstallations, Deployments,
+    - Health/Zustand, Berechtigungen etc.
+- **„ViewModel-Backend“**:
+  - stellt pro Seite **spezialisierte DTOs** zur Verfügung, z. B.:
+    - `StackListViewModelDto`,
+    - `WizardViewModelDto`,
+    - `DeploymentListViewModelDto`.
+  - Aggregiert ggf. mehrere Domänenquellen für eine UI-Ansicht.
+- **HTTP-API & SignalR**:
+  - `/api/...` → liefert DTOs, nimmt Kommandos entgegen.
+  - `/hubs/...` → pusht Events (Deployments, Health-Updates, etc.).
+
+> Wichtig: Die „Intelligenz“ sitzt im C#-Service.  
+> Das Frontend bildet diese nur ab.
+
+---
+
+### 2.2 Frontend-Core (`@rsgo/core`)
+
+**Ziel:** dünner ViewModel-Layer in TypeScript.
+
+- Definiert:
+  - **DTO-Typen** (Spiegel der C#-DTOs),
+  - **API-Client-Funktionen** (Fetch/JSON),
+  - **React Hooks** als „ViewModels“.
+
+#### 2.2.1 Beispiel: DTO-Typen & API-Funktionen
+
+```ts
+// @rsgo/core/src/api/stacks.ts
+
+export type StackListItemDto = {
+  id: string;
+  name: string;
+  version: string;
+  status: string;       // "installed" | "available" | "updating" ...
+  description?: string;
+};
+
+export type StackListViewModelDto = {
+  stacks: StackListItemDto[];
+  canInstall: boolean;
+  canUpgrade: boolean;
+};
+
+export async function fetchStackListViewModel(): Promise<StackListViewModelDto> {
+  const res = await fetch("/api/stacks/viewmodel");
+  if (!res.ok) {
+    throw new Error(`Failed to load stacks: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function installStack(id: string): Promise<void> {
+  const res = await fetch(`/api/stacks/${encodeURIComponent(id)}/install`, {
+    method: "POST"
+  });
+  if (!res.ok && res.status !== 202) {
+    throw new Error(`Failed to start install: ${res.status}`);
+  }
+}
+```
+
+#### 2.2.2 Beispiel: Hook als ViewModel
+
+```ts
+// @rsgo/core/src/hooks/useStacksPageViewModel.ts
+
+import { useEffect, useState } from "react";
+import {
+  fetchStackListViewModel,
+  installStack,
+  type StackListItemDto,
+  type StackListViewModelDto
+} from "../api/stacks";
+
+export function useStacksPageViewModel() {
+  const [stacks, setStacks] = useState<StackListItemDto[]>([]);
+  const [canInstall, setCanInstall] = useState(false);
+  const [canUpgrade, setCanUpgrade] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  async function refresh() {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const vm: StackListViewModelDto = await fetchStackListViewModel();
+      setStacks(vm.stacks);
+      setCanInstall(vm.canInstall);
+      setCanUpgrade(vm.canUpgrade);
+    } catch (e: any) {
+      setError(e.message ?? "Unknown error");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  async function install(id: string) {
+    setIsLoading(true);
+    try {
+      await installStack(id);
+      await refresh();
+    } catch (e: any) {
+      setError(e.message ?? "Install failed");
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void refresh();
+  }, []);
+
+  return {
+    stacks,
+    canInstall,
+    canUpgrade,
+    isLoading,
+    error,
+    refresh,
+    installStack: install
+  };
+}
+```
+
+> **Wichtig:**  
+> Im Core-Hook findet keine fachliche Entscheidung statt („darf der User das?“ etc.).  
+> Die Logik dazu kommt bereits aus dem C#-ViewModel-Endpoint (`CanInstall`, `CanUpgrade`, `Status` etc.).
+
+---
+
+### 2.3 UI-Pakete (`@rsgo/ui-generic`, `@rsgo/ui-ams`)
+
+**Ziel:** reine Views, kein Business-Code.
+
+Beide Pakete:
+
+- importieren **die gleichen Hooks** aus `@rsgo/core`,
+- unterscheiden sich nur in:
+  - Styling (Tailwind/Design-System),
+  - Struktur (Tabellen vs. Karten),
+  - Texten/Branding.
+
+#### 2.3.1 Generic UI – Beispiel
+
+```tsx
+// @rsgo/ui-generic/src/pages/StacksPage.tsx
+
+import React from "react";
+import { useStacksPageViewModel } from "@rsgo/core";
+
+export const StacksPage: React.FC = () => {
+  const vm = useStacksPageViewModel();
+
+  if (vm.isLoading && vm.stacks.length === 0) {
+    return <div>Stacks werden geladen…</div>;
+  }
+
+  if (vm.error) {
+    return (
+      <div>
+        <p>Fehler: {vm.error}</p>
+        <button onClick={vm.refresh}>Erneut versuchen</button>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h1>Stacks</h1>
+      <button onClick={vm.refresh} disabled={vm.isLoading}>
+        Aktualisieren
+      </button>
+
+      <ul>
+        {vm.stacks.map(s => (
+          <li key={s.id}>
+            <strong>{s.name}</strong> ({s.version}) – {s.status}
+            {vm.canInstall && s.status === "available" && (
+              <button onClick={() => vm.installStack(s.id)} disabled={vm.isLoading}>
+                Installieren
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+```
+
+#### 2.3.2 Ams UI – Beispiel
+
+```tsx
+// @rsgo/ui-ams/src/pages/StacksPage.tsx
+
+import React from "react";
+import { useStacksPageViewModel } from "@rsgo/core";
+
+export const StacksPage: React.FC = () => {
+  const vm = useStacksPageViewModel();
+
+  return (
+    <div className="flex flex-col gap-4">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold text-primary-600">
+          ams.project Stacks
+        </h1>
+        <button
+          className="btn btn-outline"
+          onClick={vm.refresh}
+          disabled={vm.isLoading}
+        >
+          Neu laden
+        </button>
+      </header>
+
+      {vm.error && (
+        <div className="alert alert-error">
+          <span>{vm.error}</span>
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+        {vm.stacks.map(s => (
+          <div key={s.id} className="card border rounded-lg p-4 shadow-sm">
+            <div className="flex justify-between items-start">
+              <div>
+                <h2 className="font-semibold">{s.name}</h2>
+                <p className="text-xs text-gray-500">Version {s.version}</p>
+              </div>
+              <span className="badge badge-outline">{s.status}</span>
+            </div>
+
+            {vm.canInstall && s.status === "available" && (
+              <button
+                className="btn btn-primary mt-3 w-full"
+                onClick={() => vm.installStack(s.id)}
+                disabled={vm.isLoading}
+              >
+                Installieren
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+```
+
+> UI-Paket unterscheiden sich nur in Darstellung – **nicht** in Logik.  
+> Die gesamte Programmlogik bleibt im C#-Backend und im Core-Hook.
+
+---
+
+## 3. Realtime / SignalR
+
+### 3.1 Backend: SignalR-Hubs
+
+Beispiel: `DeploymentHub` in C#:
+
+```csharp
+public class DeploymentHub : Hub
+{
+    // serverseitige Methoden, um Clients über Updates zu informieren
+    public async Task NotifyDeploymentUpdated(DeploymentUpdatedDto dto)
+    {
+        await Clients.All.SendAsync("DeploymentUpdated", dto);
+    }
+}
+```
+
+Domain-/Application-Services rufen `NotifyDeploymentUpdated` auf, wenn sich ein Deployment ändert.
+
+### 3.2 Frontend-Core: SignalR-Integration als Hook
+
+```ts
+// @rsgo/core/src/realtime/useDeploymentEvents.ts
+
+import { useEffect } from "react";
+import { HubConnectionBuilder } from "@microsoft/signalr";
+import { useDeploymentStore } from "./useDeploymentStore";
+
+export function useDeploymentEvents() {
+  const { updateDeployment } = useDeploymentStore();
+
+  useEffect(() => {
+    const connection = new HubConnectionBuilder()
+      .withUrl("/hubs/deployments")
+      .withAutomaticReconnect()
+      .build();
+
+    connection.on("DeploymentUpdated", payload => {
+      updateDeployment(payload);
+    });
+
+    async function start() {
+      try {
+        await connection.start();
+      } catch (err) {
+        console.error("SignalR connection failed", err);
+      }
+    }
+
+    void start();
+
+    return () => {
+      void connection.stop();
+    };
+  }, [updateDeployment]);
+}
+```
+
+### 3.3 Verwendung im ViewModel-Hook
+
+```ts
+// @rsgo/core/src/hooks/useDeploymentsPageViewModel.ts
+
+import { useDeploymentStore } from "../realtime/useDeploymentStore";
+import { useDeploymentEvents } from "../realtime/useDeploymentEvents";
+
+export function useDeploymentsPageViewModel() {
+  const { deployments, isLoading, error, refresh } = useDeploymentStore();
+
+  // aktiviert Live-Updates
+  useDeploymentEvents();
+
+  return {
+    deployments,
+    isLoading,
+    error,
+    refresh
+  };
+}
+```
+
+UI (Generic oder Ams) subscribed einfach auf `useDeploymentsPageViewModel()` und rendert Live-Änderungen.
+
+---
+
+## 4. Apps (`/apps/rsgo-generic` & `/apps/rsgo-ams`)
+
+### 4.1 Generic App
+
+```tsx
+// /apps/rsgo-generic/src/App.tsx
+
+import React from "react";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { StacksPage } from "@rsgo/ui-generic";
+// ... andere Pages
+
+export const App: React.FC = () => (
+  <BrowserRouter>
+    <Routes>
+      <Route path="/stacks" element={<StacksPage />} />
+      {/* weitere Routen */}
+    </Routes>
+  </BrowserRouter>
+);
+```
+
+### 4.2 Ams App
+
+```tsx
+// /apps/rsgo-ams/src/App.tsx
+
+import React from "react";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { StacksPage } from "@rsgo/ui-ams";
+// ... ams-spezifische Pages
+
+export const App: React.FC = () => (
+  <BrowserRouter>
+    <Routes>
+      <Route path="/stacks" element={<StacksPage />} />
+      {/* ams-spezifische Routen */}
+    </Routes>
+  </BrowserRouter>
+);
+```
+
+Beide:
+
+- verwenden dasselbe Backend (unterschiedliche Hosts/Images),
+- denselben Frontend-Core (`@rsgo/core`),
+- unterschiedliche UI-Packages.
+
+---
+
+## 5. Vorteile dieses Ansatzes
+
+- ✅ **C# bleibt der „Single Source of Truth“** für Logik & Berechtigungen.
+- ✅ **React/TS bleibt schlank** – hauptsächlich Darstellung, State, API/Wireup.
+- ✅ **Unterschiedliche UIs (Generic vs. ams)** sind leicht realisierbar:
+  - UI-Pakete tauschen, Core bleibt gleich.
+- ✅ **Wiederverwendung**:
+  - Core-Hooks können von beliebigen Distributionen genutzt werden.
+- ✅ **Testbarkeit**:
+  - C#-Logik in Unit-/Integration-Tests,
+  - TS-Hooks in einfachen Frontend-Tests,
+  - UI-Komponenten sind „dumme“ Presentational Components.
+
+---
+
+## 6. Zusammenfassung
+
+- **Backend (C#)**:
+  - liefert _ViewModel-DTOs_ über REST & SignalR.
+- **Frontend-Core (`@rsgo/core`)**:
+  - realisiert API-Clients, DTO-Typen und Hooks als dünne ViewModels.
+- **UI-Pakete (`@rsgo/ui-generic`, `@rsgo/ui-ams`)**:
+  - konsumieren diese Hooks und definieren nur Layout & Styling.
+- **Apps**:
+  - binden die passenden UI-Packages ein (Generic vs. ams) und bauen das finale SPA für das jeweilige Docker-Image.
+
+Damit ist die Trennung zwischen **Logik**, **ViewModel** und **UI** klar und du kannst ReadyStackGo langfristig sowohl als OSS-Core als auch als firmenspezifische Distribution pflegen.
+

--- a/docs/specs/rsgo-qol-improvements/OCI-STACKS-SPEC.md
+++ b/docs/specs/rsgo-qol-improvements/OCI-STACKS-SPEC.md
@@ -1,0 +1,470 @@
+# ReadyStackGo – OCI Stack Sources & Bundles
+
+Dieses Dokument fasst alles rund um **OCI-basierte Stack-Verteilung** für ReadyStackGo (RSGO) zusammen – so, dass Claude das direkt als Grundlage für Implementierung nutzen kann.
+
+Es beschreibt:
+
+- wie **OCI Stack Bundles** aussehen (Bundle-Format),
+- wie eine **`OciStackSource`** funktioniert (inkl. `Sync()`),
+- wie das Ganze mit `ImportStackSource`, Marketplace und Deployment zusammenspielt,
+- und wie Versionierung über Tags in der Registry läuft.
+
+---
+
+## 1. Überblick
+
+Ziel:
+
+- Stacks (z. B. `ams.project`) sollen als **versionierte Artefakte in einer Container-Registry** (Docker Hub, GHCR, …) veröffentlicht werden.
+- ReadyStackGo soll diese Stacks:
+  - im **Katalog** anzeigen (Marketplace / Stack-Liste),
+  - bei Bedarf **importieren** (Snapshot),
+  - und daraus Deployments erstellen.
+- Die eigentlichen **Container-Images** werden weiterhin als normale Images in der Registry verwaltet (mit Tags & Digests) – **sie werden nicht ins Bundle eingebettet**, sondern per Digest referenziert.
+
+Kernkonzepte:
+
+- **OCI Stack Bundle** – Bündel aus `stack.yaml` + `lock.json` + optionalen Metadaten.
+- **OciStackSource** – `StackSource`-Implementierung, die ein Registry-Repo durchsucht.
+- **ImportStackSource** – verwaltet lokal importierte (geschnappschusste) Stack-Manifeste.
+- **Sync()** – baut aus der Registry einen internen Stack-Katalog (welche Stacks, welche Versionen).
+
+---
+
+## 2. StackSource-Typen (Erweiterung)
+
+Bereits vorhanden (konzeptionell):
+
+- `FileSystemStackSource`
+- `GitStackSource`
+- ggf. `HttpStackSource`
+
+Neu:
+
+- `ImportStackSource`
+- `OciStackSource`
+
+### 2.1 `ImportStackSource`
+
+- Zweck: verwaltet **lokale Snapshots** von Stack-Manifesten.
+- Dient als **einheitliche Quelle** für alle importierten Stacks, egal woher sie kommen:
+  - aus Git,
+  - aus Filesystem,
+  - aus OCI (Stack-Bundle),
+  - über Upload im UI.
+
+Domänenmodell (vereinfacht):
+
+```csharp
+public sealed class ImportedStackManifest
+{
+    public Guid Id { get; init; }
+
+    public string StackId { get; init; }            // z.B. "ams-project-core"
+    public string Version { get; init; }           // z.B. "1.0.0"
+
+    public string SourceType { get; init; }        // "Git", "FileSystem", "OCI", "Upload"
+    public string? SourceReference { get; init; }  // z.B. OCI-Ref oder Git-URL
+    public DateTimeOffset ImportedAt { get; init; }
+
+    public string LocalPathOrKey { get; init; }    // Pfad oder Key zum gespeicherten Manifest
+    public string? LockDataPathOrKey { get; init; } // falls `lock.json` gespeichert wird
+}
+```
+
+**Wichtig:**
+
+- Nach dem Import arbeitet RSGO **nur noch** mit den Daten aus `ImportStackSource`.
+- Die ursprüngliche Quelle (Git/OCI/etc.) wird nur für neue Versionen / Re-Imports genutzt.
+
+---
+
+### 2.2 `OciStackSource`
+
+Neue `StackSource`-Implementierung, die eine Registry als Quelle nutzt.
+
+Konfiguration (Beispiel):
+
+```csharp
+public sealed class OciStackSourceConfig
+{
+    public string Id { get; init; }                // "oci-wiesenwischer"
+    public string RegistryHost { get; init; }      // "docker.io"
+    public string Repository { get; init; }        // "wiesenwischer/rsgo-stacks"
+    public string TagPattern { get; init; }        // "ams-project-core-*"
+    public bool IsEnabled { get; set; }
+}
+```
+
+Aufgabe:
+
+- `Sync()` verbindet sich mit der Registry,
+- listet Tags,
+- leitet daraus StackId + Version ab,
+- liest leichte Metadaten (Labels/Meta-Datei),
+- aktualisiert den **Stack-Katalog**.
+
+---
+
+## 3. OCI Stack Bundle – Format
+
+Ein **OCI Stack Bundle** ist das Artefakt, das in der Registry liegt.
+
+**Wichtig:** Es enthält:
+
+- `stack.yaml` – RSGO-Stack-Manifest,
+- `lock.json` – Liste aller benötigten Container-Images mit Digests,
+- optional `readme.md`, `meta.json`, `schema.json`.
+
+Es enthält **nicht** die eigentlichen Images (die liegen separat als normale Container-Images).
+
+### 3.1 Dateistruktur
+
+Empfohlene Struktur:
+
+```text
+/stack.yaml               # Pflicht – RSGO Stack Manifest
+/lock.json                # Pflicht – Lock-Datei mit Image-Infos
+/readme.md                # Optional – Beschreibung
+/schema.json              # Optional – JSON-Schema für stack.yaml
+/meta.json                # Optional – weitere Metadaten
+```
+
+#### `stack.yaml` (Beispiel, vereinfacht)
+
+```yaml
+apiVersion: rsgo.stack/v1
+kind: Stack
+metadata:
+  name: ams-project-core
+  version: 1.0.0
+spec:
+  services:
+    - name: ams-api
+      image: docker.io/amssolution/ams-api:1.0.0
+    - name: ams-bff
+      image: docker.io/amssolution/ams-bff:1.0.0
+  # ...
+```
+
+#### `lock.json` (Beispiel)
+
+```json
+{
+  "apiVersion": "rsgo.stack.lock/v1",
+  "stackName": "ams-project-core",
+  "stackVersion": "1.0.0",
+  "images": [
+    {
+      "name": "ams-api",
+      "image": "docker.io/amssolution/ams-api",
+      "tag": "1.0.0",
+      "digest": "sha256:abc123...",
+      "role": "api"
+    },
+    {
+      "name": "ams-bff",
+      "image": "docker.io/amssolution/ams-bff",
+      "tag": "1.0.0",
+      "digest": "sha256:def456...",
+      "role": "bff"
+    }
+  ]
+}
+```
+
+Regel:
+
+- Beim Deployment nach Möglichkeit **immer Digest aus `lock.json`** verwenden.
+- Tag ist nice-to-have / Fallback.
+
+#### `meta.json` (optional, für Marketplace)
+
+```json
+{
+  "displayName": "ams.project Core Stack",
+  "description": "Zentraler Fachstack von ams.project ...",
+  "category": "Business",
+  "tags": ["ams", "project", "nservicebus", "business"],
+  "vendor": "Wiesenwischer",
+  "contact": "support@example.com"
+}
+```
+
+---
+
+## 4. Versionierung & Tag-Konventionen
+
+**Wichtiger Punkt:**
+
+> Ein **Bundle** in der Registry repräsentiert **genau eine Version** eines Stacks.  
+> Versionen werden über **Tags** unterschieden.
+
+Typische Varianten:
+
+### Variante A – Ein Repo für alle Stacks
+
+- Repo:  
+  `docker.io/wiesenwischer/rsgo-stacks`
+
+- Tags / Artefakte:
+
+  - `ams-project-core-1.0.0`
+  - `ams-project-core-1.1.0`
+  - `ams-project-core-2.0.0`
+  - `identity-access-1.0.0`
+  - usw.
+
+**Tag-Parsing:**
+
+- `ams-project-core-1.0.0` → `StackId = "ams-project-core"`, `Version = "1.0.0"`.
+
+### Variante B – Pro Stack ein eigenes Repo
+
+- Repo: `wiesenwischer/rsgo-stack-ams-project-core`
+  - Tags:
+    - `1.0.0`
+    - `1.1.0`
+    - `2.0.0`
+
+RSGO / `OciStackSource` sollte beide Varianten unterstützen können, z. B. über Konfiguration `TagPattern`.
+
+---
+
+## 5. `OciStackSource.Sync()` – Ablauf
+
+Ziel:  
+**Genau wie bei Git/File** eine `Sync()`-Methode, die:
+
+- die Quelle neu einliest,
+- neue/aktualisierte/veraltete Stack-Versionen erkennt,
+- den internen Stack-Katalog aktualisiert.
+
+### 5.1 Pseudocode-Skizze
+
+```csharp
+public async Task SyncAsync()
+{
+    // 1. Alle Tags des Repositories holen
+    var tags = await registryClient.ListTagsAsync(config.RegistryHost, config.Repository);
+
+    // 2. Nach Pattern filtern (z.B. "ams-project-core-*")
+    var relevantTags = tags
+        .Where(t => MatchesPattern(t, config.TagPattern))
+        .ToList();
+
+    var seenKeys = new HashSet<string>();
+
+    foreach (var tag in relevantTags)
+    {
+        // 3. StackId + Version aus Tag ableiten
+        var (stackId, version) = ParseTag(tag);
+
+        // 4. Leichte Metadaten lesen (Labels oder meta.json)
+        var meta = await registryClient.ReadStackMetaAsync(
+            config.RegistryHost,
+            config.Repository,
+            tag
+        );
+
+        var catalogKey = $"{stackId}@{version}";
+        seenKeys.Add(catalogKey);
+
+        // 5. Katalogeintrag updaten
+        stackCatalog.Upsert(new StackCatalogEntryInternal
+        {
+            SourceId = config.Id,
+            StackId = stackId,
+            Version = version,
+            OciRef = $"{config.RegistryHost}/{config.Repository}:{tag}",
+            DisplayName = meta.DisplayName ?? stackId,
+            Description = meta.Description,
+            Category = meta.Category,
+            Tags = meta.Tags?.ToList() ?? new List<string>()
+        });
+    }
+
+    // 6. Veraltete Einträge aus diesem Source entfernen/markieren
+    stackCatalog.RemoveEntriesFromSourceNotIn(config.Id, seenKeys);
+}
+```
+
+### 5.2 Metadaten lesen, ohne alles zu ziehen
+
+Möglichkeiten:
+
+- **Labels** auf dem Image/Artefakt (Variante „normales Image“):
+  - `org.readystackgo.stack.name`, `org.readystackgo.stack.version`, `org.readystackgo.displayName`, `org.readystackgo.category` etc.
+- **Mini-Layer mit `meta.json`**:
+  - sehr kleiner Layer, der bei Bedarf gelesen wird.
+
+Wichtig: `Sync()` sollte **nicht** jedes Mal `stack.yaml` + `lock.json` holen, sondern nur für die Anzeige relevante Metadaten.
+
+---
+
+## 6. Import aus OCI in `ImportStackSource`
+
+Wenn ein Admin im UI einen Stack aus der OciSource (oder Marketplace) „installiert“:
+
+1. **Stack auswählen**  
+   - aus Katalog (`stackCatalog`), Eintrag hat `OciRef`.
+
+2. **`OciStackSource.Import(ociRef)` aufrufen**:
+   - `ociRef` z. B. `docker.io/wiesenwischer/rsgo-stacks:ams-project-core-1.0.0`.
+
+3. `OciStackSource`:
+
+   - PULL:
+     - lädt das Bundle (Image oder OCI-Artefakt).
+   - EXTRACT:
+     - liest `stack.yaml` und `lock.json` (+ optional `meta.json`/`readme.md`).
+   - RETURN:
+     - `StackManifestContent` (string),
+     - `LockDataContent` (string),
+     - `Meta` (optional).
+
+4. `ImportStackSource`:
+
+   - speichert `stack.yaml` unter einem lokalen Pfad/Key,
+   - speichert `lock.json` (falls vorhanden),
+   - legt `ImportedStackManifest` an:
+
+   ```csharp
+   var imported = new ImportedStackManifest
+   {
+       Id = Guid.NewGuid(),
+       StackId = stackId,
+       Version = version,
+       SourceType = "OCI",
+       SourceReference = ociRef,
+       ImportedAt = DateTimeOffset.UtcNow,
+       LocalPathOrKey = localManifestKey,
+       LockDataPathOrKey = localLockKey
+   };
+   ```
+
+5. RSGO erzeugt eine `StackInstallation` für Organisation + Environment, die auf `ImportedStackManifest` referenziert.
+
+---
+
+## 7. Deployment mit Lockfile
+
+Beim Deployment einer `StackInstallation`:
+
+1. Manifest (`stack.yaml`) aus `ImportStackSource` laden.
+2. Lock-Daten (`lock.json`) laden.
+3. Für jeden Service im Manifest:
+   - passenden `images[]`-Eintrag in `lock.json` suchen (z. B. über `name` oder `image` + `tag`).
+   - Image-Ref als `image@digest` zusammensetzen.
+
+4. Host aus `image` extrahieren:
+   - z. B. `docker.io`, `ghcr.io`.
+
+5. Passende **Container-Registry-Config** suchen:
+   - Host + Pattern (z. B. `amssolution/*`).
+   - Auth-Daten aus dieser Config verwenden.
+
+6. Images mit Digest ziehen und Container starten.
+
+**Vorteil:**
+
+- Du hast sowohl:
+  - eine robust versionierte Stackdefinition,
+  - als auch deterministische Image-Referenzen,
+- ohne Images doppelt zu speichern.
+
+---
+
+## 8. Zusammenspiel mit Marketplace
+
+Der Marketplace kann zwei Ebenen verbinden:
+
+1. **Katalog-Ebene (StackCatalogEntry)**:
+   - kommt aus:
+     - einem JSON-Katalog (StackCatalogSource) **oder**
+     - direkt aus OCI-Metadaten (`meta.json`, Labels).
+   - enthält:
+     - Name, Beschreibung, Kategorie, Tags,
+     - Hinweis auf benötigte Container-Registries,
+     - `OciRef` zum Bundle.
+
+2. **Source-Ebene (OciStackSource)**:
+   - liefert die „technische“ Sicht:
+     - welche Stacks/Versionen existieren,
+     - ihre Refs.
+
+Installations-Flow:
+
+- User klickt im Marketplace auf „Installieren“.
+- Marketplace gibt `StackId`, `Version`, `OciRef` an Backend.
+- Backend verwendet `OciStackSource.Import(ociRef)` + `ImportStackSource` wie oben beschrieben.
+
+---
+
+## 9. CI/CD – Erstellen & Veröffentlichen von Bundles
+
+Typische Pipeline:
+
+1. Code bauen, Docker-Images bauen & pushen:
+   - `docker.io/amssolution/ams-api:1.0.0`
+   - `docker.io/amssolution/ams-bff:1.0.0`
+
+2. Digests der Images ermitteln:
+   - `docker inspect` oder Registry-API.
+
+3. `stack.yaml` generieren/aktualisieren:
+   - z. B. aus Templates, Skripten etc.
+
+4. `lock.json` generieren:
+   - für jeden Service/Container:
+     - Name, Image, Tag, Digest.
+
+5. Bundle bauen:
+
+   - Variante A (normales Image mit Dateien unter `/rsgo` + Labels):
+     - Dockerfile, das `stack.yaml`, `lock.json`, `meta.json`, `readme.md` ins Image legt.
+   - Variante B (OCI-Artefakt via ORAS):
+     - TAR mit genannten Dateien.
+
+6. Bundle in die Registry pushen:
+   - `docker push docker.io/wiesenwischer/rsgo-stacks:ams-project-core-1.0.0`.
+
+7. Optional:
+   - Marketplace-Katalog aktualisieren:
+     - `StackCatalogEntry` mit `OciRef` + Metadaten.
+
+---
+
+## 10. Zusammenfassung
+
+Dieses Dokument definiert:
+
+- **OCI Stack Bundles**:
+  - Artefakte in einer Registry,
+  - enthalten `stack.yaml` + `lock.json` + optional Metadaten,
+  - **eine Version pro Bundle** (unterschiedliche Tags für Versionen).
+
+- **OciStackSource**:
+  - `Sync()`:
+    - listet Tags aus der Registry,
+    - mappt sie auf `StackId` + `Version`,
+    - hält einen internen Katalog aktuell.
+  - `Import(ociRef)`:
+    - zieht ein Bundle,
+    - extrahiert `stack.yaml` + `lock.json`,
+    - gibt diese an `ImportStackSource` weiter.
+
+- **ImportStackSource**:
+  - verwaltet lokale, versionierte Snapshots von Stack-Manifesten,
+  - ist Basis für `StackInstallation`.
+
+- **Deployment**:
+  - nutzt Manifest + Lockfile,
+  - zieht Images über Container-Registry-Config (Host + Pattern + Auth),
+  - verwendet Digests für reproduzierbare Deployments.
+
+Damit ist der komplette Weg abgedeckt:
+
+> CI/CD → OCI-Stack-Bundle → OciStackSource.Sync() → Marketplace/Katalog → ImportStackSource → Deployment
+
+Diese Datei kannst du als `OCI-STACKS-SPEC.md` in dein `/docs`-Verzeichnis legen und Claude damit sowohl Backend- als auch Pipeline-Implementierung starten lassen.

--- a/docs/specs/rsgo-qol-improvements/REGISTRY-WIZARD-UX.md
+++ b/docs/specs/rsgo-qol-improvements/REGISTRY-WIZARD-UX.md
@@ -1,0 +1,252 @@
+# ReadyStackGo – Container-Registry-Wizard (UX & Flow)
+
+## 1. Ziel dieses Dokuments
+
+Dieses Dokument beschreibt, **wie** die Konfiguration der Container-Registries im
+ReadyStackGo-Setup-Wizard umgesetzt werden soll – speziell unter der Randbedingung:
+
+- Es gibt einen **festen Stepper oben** (Schritte mit Nummer + Titel),
+- **jeder Schritt ist eine eigene Seite**,
+- **keine Dialoge/Modals** im Wizard für die Authentifizierung.
+
+Fokus:  
+Wie binden wir die **Container-Registry-Authentifizierung** so ein, dass sie:
+
+- zum bestehenden Wizard / Stepper passt,
+- mehrere Registries (auch mit Patterns wie `amssolution/*`) unterstützt,
+- für den Benutzer übersichtlich und verständlich bleibt.
+
+---
+
+## 2. Ausgangslage
+
+ReadyStackGo hat bereits:
+
+- eine **Container-Registry-Registry**  
+  → hier werden Einträge für Container-Registries gepflegt (z. B. Docker Hub, GHCR, private Registries).  
+  Jeder Eintrag kann:
+  - einen `Host` haben (z. B. `docker.io`, `ghcr.io`),
+  - ein oder mehrere **Patterns** (z. B. `amssolution/*`),
+  - Authentifizierungs-Daten (Basic, Token, etc.).
+
+- eine **Manifest-Registry-Registry**  
+  → hier werden Quellen für Stack-Manifeste gepflegt (Git-Repos, etc.).
+
+Stacks enthalten Images wie:
+
+- `amssolution/ams-api:0.5.0` (implizit `docker.io`)
+- `docker.io/amssolution/ams-worker:0.5.0`
+- `ghcr.io/wiesenwischer/ams-project-api:0.5.0`
+
+Du kannst in einer Container-Registry-Konfiguration Patterns hinterlegen, z. B.:
+
+- `amssolution/*`  
+- `wiesenwischer/*`
+
+Damit kannst du z. B. **zwei verschiedene private Docker-Hub-Accounts** verwenden, obwohl der Host gleich ist (`docker.io`).
+
+---
+
+## 3. Grundentscheidung: Ein fester Wizard-Step statt Dialoge
+
+### 3.1 Stepper-Design
+
+Der Wizard hat einen **festen Stepper** mit Schritten wie z. B.:
+
+1. Admin & TLS  
+2. Organisationen & Environments  
+3. Stack-/Manifest-Quellen  
+4. Container-Registries  
+5. Zusammenfassung  
+
+Wichtige Design-Entscheidung:
+
+> **Es soll keinen separaten Dialog für die Registry-Auth geben**,  
+> weil das:
+> - den Stepper visuell „bricht“,
+> - den Flow komplizierter macht (Wizard-State + Dialog-State),
+> - die UX verschlechtert (man sieht immer nur eine Registry, verliert Überblick).
+
+Stattdessen:
+
+- Es gibt **genau einen Wizard-Step „Container-Registries“** (z. B. Schritt 4).
+- Auf dieser Seite werden **alle relevanten Registry-Bereiche** als **Cards**/Sektionen dargestellt.
+- Die Authentifizierungsfelder werden **inline** in diesen Cards konfiguriert.
+
+---
+
+## 4. Ablauf im Wizard
+
+### 4.1 Vorheriger Schritt: Manifest-Quellen wählen
+
+In einem vorherigen Step (z. B. Schritt 3):
+
+- Der Benutzer wählt, welche Manifest-Registries (Git-Repos etc.) er nutzen möchte.
+- ReadyStackGo:
+  - lädt die Manifeste aus diesen Quellen,
+  - analysiert alle `image:`-Einträge,
+  - extrahiert dabei:
+    - `Host` (z. B. `docker.io`, `ghcr.io`),
+    - `Path` (z. B. `amssolution/ams-api`).
+
+Auf Basis dieser Informationen bildet RSGO **Registry-Bereiche**, z. B.:
+
+- Host `docker.io`, Namespace `amssolution` → Vorschlags-Pattern: `amssolution/*`
+- Host `ghcr.io`, Namespace `wiesenwischer` → Vorschlags-Pattern: `wiesenwischer/*`
+- Host `docker.io`, Namespace `library` → Vorschlags-Pattern: `library/*` (Public Images)
+
+Diese Registry-Bereiche bilden später die Cards auf der Seite „Container-Registries“.
+
+---
+
+### 4.2 Schritt „Container-Registries“ (ein fester Step)
+
+Oben:
+
+> **Schritt 4 von 5 – Container-Registries**  
+> ReadyStackGo hat anhand der ausgewählten Stacks die folgenden Registry-Bereiche erkannt.  
+> Bitte hinterlege ggf. Zugangsdaten für private Registries.
+
+#### 4.2.1 Darstellung als Cards
+
+Die Seite zeigt **eine Card pro Registry-Bereich**, z. B.:
+
+**Card 1:**
+
+- Titel: `docker.io – amssolution/*`
+- Zusatzinfo:
+  - „Verwendet in: amssolution/ams-api, amssolution/ams-worker, …“
+- Status:
+  - z. B. „Noch nicht konfiguriert“ oder „Wird als public verwendet“
+
+Felder innerhalb der Card:
+
+- **Anzeigename**  
+  z. B. `Docker Hub – amssolution`
+- **Patterns** (Liste):
+  - `amssolution/*` (Textfeld, editierbar)
+  - Button: „+ weiteres Pattern hinzufügen“
+- **Authentifizierung**:
+  - Radiobuttons:
+    - `● Authentifizierung erforderlich`
+    - `○ Ohne Authentifizierung (Public Images)`
+  - Wenn „Authentifizierung erforderlich“:
+    - Auth-Typ: `Basic` / `Token`
+    - Username
+    - Passwort / Token
+    - optional: Button „Verbindung testen“
+
+**Card 2:**
+
+- Titel: `ghcr.io – wiesenwischer/*`
+- etc. (gleiche Struktur)
+
+**Card 3:**
+
+- Titel: `docker.io – library/*`
+- Default:
+  - Radiobutton „Ohne Authentifizierung“ vorausgewählt
+  - Hinweis: „Wird nur für Public Images wie `redis`, `postgres` verwendet“
+
+Cards können optional collapsible sein (auf-/zuklappbar), um bei vielen Registries die Seite übersichtlich zu halten.
+
+#### 4.2.2 Buttons am Seitenende
+
+Am Ende der Seite:
+
+- `Zurück` (zum vorherigen Step)
+- `Weiter` (zum nächsten Step)
+
+Beim Klick auf `Weiter`:
+
+1. Validierung aller Cards:
+   - Falls „Authentifizierung erforderlich“ gewählt ist:
+     - Pflichtfelder (z. B. Username, Token) müssen befüllt sein.
+2. Speichern:
+   - Für jede Card wird/werden `ContainerRegistryConfig`-Eintrag/Einträge erzeugt bzw. aktualisiert:
+     - `Host`
+     - `Patterns`
+     - `AuthMode`
+     - `Credentials`
+3. Weiterleitung zum nächsten Wizard-Step (z. B. Zusammenfassung).
+
+---
+
+## 5. Matching-Logik (Host + Pattern) bleibt unverändert
+
+Der technische Matching-Mechanismus ist unabhängig vom Wizard-UX-Design und sieht so aus:
+
+1. Ein Stack-Manifest enthält ein Image, z. B.:
+   - `amssolution/ams-api:0.5.0` (→ Host `docker.io`, Path `amssolution/ams-api`)
+   - `docker.io/amssolution/ams-api:0.5.0`
+   - `ghcr.io/wiesenwischer/ams-project-api:0.5.0`
+
+2. RSGO parst:
+   - `host` (explizit, oder default `docker.io`),
+   - `path` (alles nach Host, vor `:` → z. B. `amssolution/ams-api`).
+
+3. RSGO sucht passende `ContainerRegistryConfig`:
+   - `Host == parsedHost`
+   - `Patterns` matchen den `path` (z. B. `amssolution/*`).
+
+4. Falls mehrere Patterns passen:
+   - der **spezifischste Pattern** gewinnt (z. B. längster String, weniger Wildcards etc.).
+
+5. Falls **keine** Registry-Konfiguration passt:
+   - je nach Modus:
+     - Entwicklung/Einfach: anonymen Pull versuchen, Warnung loggen,
+     - Produktion/Streng: Fehler „Keine passende Registry konfiguriert“.
+
+Der Wizard-Step „Container-Registries“ ist damit einfach ein Komfort-Frontend, um diese `ContainerRegistryConfig`-Einträge zu erstellen.
+
+---
+
+## 6. Warum kein Dialog für Auth-Eingabe?
+
+### 6.1 UX-Gründe
+
+- Der Stepper oben würde weiterhin „Schritt 4“ anzeigen, während ein Dialog offen ist.
+- Der Benutzer verliert leichter den Überblick:
+  - „Wo bin ich jetzt? Wizard-Schritt oder Dialog?“
+- Die Auth-Konfiguration ist kein „Nebenbei-Feature“, sondern ein **zentrales Setup-Thema**:
+  - Sie gehört in einen **vollwertigen Wizard-Schritt**,
+  - nicht in ein zusätzliches Popup.
+
+### 6.2 Technische Gründe
+
+- Ein **einziger Form-Step** ist deutlich simpler:
+  - nur eine Validierung,
+  - nur ein „Weiter“-Handling.
+- Keine Doppelzustände:
+  - kein „Wizard aktiv + Dialog aktiv“-Chaos,
+  - keine Sonderfälle:
+    - „Was passiert, wenn ich im Dialog auf Cancel klicke, aber im Wizard auf Zurück?“.
+
+### 6.3 Übersicht für den Admin
+
+- Mit Cards auf einer Seite sieht der Admin **alle Registry-Bereiche auf einen Blick**:
+  - welche privaten Namespaces es gibt (`amssolution/*`, `wiesenwischer/*`, …),
+  - welche davon Auth brauchen,
+  - welche anonym laufen können (`library/*`).
+- Das ist deutlich transparenter, als Registry für Registry in einem Dialog-Kontext durchzuklicken.
+
+---
+
+## 7. Zusammenfassung der Design-Entscheidung
+
+**Beschlossene Linie für ReadyStackGo:**
+
+- Es gibt **einen festen Wizard-Step „Container-Registries“**.
+- Auf dieser Seite:
+  - zeigt RSGO alle aus den Manifesten erkannten Registry-Bereiche,
+  - jeder Bereich wird als **Card** mit:
+    - Host,
+    - vorgegebenem Pattern (z. B. `amssolution/*`),
+    - Beispielen,
+    - Auth-Einstellungen
+    dargestellt.
+  - Der Benutzer konfiguriert alle benötigten Registries **inline**.
+- Es gibt **keine separaten Dialoge** für die Auth-Eingabe im Wizard.
+- Die bereits vorhandene **Host+Pattern-Matching-Logik** wird exakt weiterverwendet – der Wizard ist nur die komfortable Oberfläche dafür.
+
+Dieses Dokument kann direkt als Referenz in `/docs/REGISTRY-WIZARD-UX.md` im ReadyStackGo-Repository verwendet werden.

--- a/docs/specs/rsgo-qol-improvements/STACK-MARKETPLACE.md
+++ b/docs/specs/rsgo-qol-improvements/STACK-MARKETPLACE.md
@@ -1,0 +1,429 @@
+# ReadyStackGo – Stack Marketplace Specification
+
+## 1. Ziel & Überblick
+
+Dieses Dokument beschreibt den **Stack Marketplace** für ReadyStackGo (RSGO).
+
+Der Marketplace ist eine **UX-Schicht über den bestehenden Mechanismen**:
+
+- Manifest-Quellen (Stack Sources / Manifest Registries)
+- Container-Registries
+
+Ziel:
+
+- Administratoren können **Stacks wie in einem App-Store entdecken**, Details ansehen und pro Organisation/Environment installieren.
+- Technisch bleiben Manifeste, Stack Sources und Container-Registries weiterhin die Grundlage – der Marketplace referenziert diese nur.
+
+Use Cases:
+
+- Offizielle Stacks bereitstellen (z. B. `ams.project`, IdentityAccess, Monitoring, Demo).
+- Interne Stacks für einzelne Kunden/Organisationen verfügbar machen.
+- Zukünftig optionale 3rd-Party-Stacks integrieren.
+
+---
+
+## 2. Begriffe & Domänenmodell
+
+### 2.1 Bereits existierende Konzepte (RSGO)
+
+- **Manifest Source / Stack Source**  
+  Quelle für Stack-Manifeste (z. B. Git-Repo, HTTP, lokaler Pfad).  
+  In den Settings: „Stack Sources“.
+
+- **Container Registry Config**  
+  Beschreibung einer Container-Registry inkl. Host, Patterns (z. B. `amssolution/*`) und Auth-Daten.  
+  In den Settings: „Container Registries“.
+
+- **Stack Manifest**  
+  RSGO-spezifisches Manifest, das beschreibt:
+  - Services, Migrations, Volumes etc.
+  - Parameter, Secrets,
+  - Policies (Start-Reihenfolge, Dependencies, …).
+
+- **Stack Installation** (bereits geplant/teils vorhanden)  
+  „Konkreter Stack“ installiert für eine Organisation + Environment:
+  - welches Manifest,
+  - welche Version,
+  - Status (Running, Stopped, Failed, Upgrading),
+  - Healthinformationen etc.
+
+### 2.2 Neue Konzepte für den Marketplace
+
+#### 2.2.1 StackCatalogSource
+
+Repräsentiert eine **Quelle** für Marketplace-Einträge.
+
+Beispiele:
+
+- Eingebauter JSON-Katalog aus der RSGO-Distribution
+- JSON-Datei in einem Git-Repo (Organisation erstellt eigenen Katalog)
+- HTTP-Endpunkt, der Katalogeinträge liefert (für später evtl. „öffentlichen“ Marketplace)
+
+Eigenschaften (Domänenmodell):
+
+```csharp
+public sealed class StackCatalogSource
+{
+    public string Id { get; init; }              // interne ID (z. B. "rsgo-official")
+    public string Name { get; init; }            // Anzeigename ("ReadyStackGo Official Stacks")
+    public string Type { get; init; }            // "embedded", "git-json", "http-json", ...
+    public string? Location { get; init; }       // URL, Pfad, Repo-URL je nach Type
+    public bool IsEnabled { get; set; }
+
+    // Optional: scope / visibility
+    public string Scope { get; init; }           // z. B. "System", "Org:<OrgId>"
+}
+```
+
+#### 2.2.2 StackCatalogEntry
+
+Repräsentiert **einen Eintrag** im Marketplace („ein installierbarer Stack“).
+
+Eigenschaften:
+
+```csharp
+public sealed class StackCatalogEntry
+{
+    public string Id { get; init; }                  // Katalog-weiter eindeutiger Schlüssel
+    public string SourceId { get; init; }            // Referenz auf StackCatalogSource.Id
+
+    public string Name { get; init; }                // z. B. "ams.project Core Stack"
+    public string Slug { get; init; }                // URL-freundlich (z. B. "ams-project-core")
+
+    public string? ShortDescription { get; init; }   // Kurzbeschreibung für Kachel
+    public string? LongDescription { get; init; }    // Detailbeschreibung für Detailseite (Markdown?)
+
+    public string Category { get; init; }            // z. B. "Business", "Infrastructure", "Monitoring", "Demo"
+    public IReadOnlyList<string> Tags { get; init; } // z. B. ["ams", "nservicebus", "project", "identity"]
+
+    public string? LogoUrl { get; init; }            // Icon/Logo für UI
+    public string? BannerUrl { get; init; }          // Optionales Banner (Detailseite)
+
+    // Verweis auf das eigentliche Stack-Manifest
+    public string ManifestSourceId { get; init; }    // ID der Manifest-Quelle
+    public string ManifestPath { get; init; }        // Pfad/Key zum Manifest innerhalb der Quelle
+
+    // Optionale Hinweise zu benötigten Container-Registries
+    public IReadOnlyList<RequiredRegistryHint> RequiredRegistries { get; init; }
+
+    // Anforderungen / Hinweise
+    public IReadOnlyList<string> Requirements { get; init; }   // "Requires ams.erp database connection", ...
+
+    // Versionierung (optional, erste Ausbaustufe kann mit einfachem String arbeiten)
+    public string? Version { get; init; }             // z. B. "0.5.0"
+    public string? MinRsgoVersion { get; init; }      // z. B. "0.3.0"
+    public string? MaxRsgoVersion { get; init; }      // optional
+
+    // Mögliche Flags für UX
+    public bool IsFeatured { get; init; }             // "auf der ersten Seite hervorheben"
+    public bool IsDeprecated { get; init; }           // "nicht mehr empfehlen"
+}
+
+public sealed class RequiredRegistryHint
+{
+    public string Host { get; init; }                 // z. B. "docker.io", "ghcr.io"
+    public IReadOnlyList<string> Patterns { get; init; } // z. B. ["amssolution/*", "wiesenwischer/*"]
+    public bool AuthRequired { get; init; }           // Hinweis, ob Auth sehr wahrscheinlich ist
+    public string? Description { get; init; }         // Hinweistext für UI
+}
+```
+
+---
+
+## 3. Katalogformat (JSON) – Beispiel
+
+Ein `StackCatalogSource` kann z. B. auf eine JSON-Datei zeigen, die eine Liste von `StackCatalogEntry` beschreibt.
+
+Beispiel `rsgo-official-catalog.json`:
+
+```json
+{
+  "version": 1,
+  "entries": [
+    {
+      "id": "ams-project-core",
+      "name": "ams.project Core Stack",
+      "slug": "ams-project-core",
+      "shortDescription": "Zentraler Fach-Stack von ams.project (API, BFF, Worker, WebFrontends).",
+      "longDescription": "Dieser Stack enthält die Kernkomponenten von ams.project ...",
+      "category": "Business",
+      "tags": ["ams", "project", "nservicebus", "business"],
+
+      "logoUrl": "https://example.com/logos/ams-project.png",
+      "bannerUrl": null,
+
+      "manifestSourceId": "ams-manifests-git",
+      "manifestPath": "stacks/ams/ams-project-core.yaml",
+
+      "requiredRegistries": [
+        {
+          "host": "docker.io",
+          "patterns": ["amssolution/*"],
+          "authRequired": true,
+          "description": "Private Docker-Hub-Images im Namespace 'amssolution'."
+        },
+        {
+          "host": "docker.io",
+          "patterns": ["library/*"],
+          "authRequired": false,
+          "description": "Public Base-Images (redis, postgres, ...)."
+        }
+      ],
+
+      "requirements": [
+        "Requires ams.erp database connection",
+        "Requires NServiceBus transport configuration",
+        "Recommended: separate 'IdentityAccess' stack installed first"
+      ],
+
+      "version": "0.5.0",
+      "minRsgoVersion": "0.3.0",
+      "maxRsgoVersion": null,
+      "isFeatured": true,
+      "isDeprecated": false
+    }
+  ]
+}
+```
+
+---
+
+## 4. UI & UX – Marketplace-Ansichten
+
+### 4.1 Hauptnavigation
+
+Im UI gibt es für Administratoren einen Bereich, z. B.:
+
+- **Stacks**
+  - Tab „Installiert“ (installierte Stack-Instanzen)
+  - Tab „Marketplace“ (Katalog aller verfügbaren Stacks)
+
+Die bestehenden Settings-Kacheln bleiben erhalten:
+
+- **Settings → Stack Sources** (Manifest sources)
+- **Settings → Container Registries** (Image-Quellen)
+
+Der Marketplace ist eine **Arbeitsansicht**, keine Settings-Seite.
+
+### 4.2 Marketplace-Übersicht („Kacheln“)
+
+Auf der Seite „Stacks → Marketplace“:
+
+- **Suchfeld**:
+  - Suche nach Name, Tags, Kategorie.
+- **Filter**:
+  - Kategorie (Business, Infrastructure, Monitoring, Demo, …)
+  - Quelle (Offizielle Stacks, Organisationseigene, 3rd Party)
+  - Status (Installiert, Nicht installiert, Update verfügbar – optional später)
+
+- **Kacheln pro StackCatalogEntry**:
+
+  Anzeige z. B.:
+
+  - Logo/Icon
+  - Name
+  - Kurzbeschreibung
+  - Kategorie-Label
+  - Tags (kleine Chips)
+  - Status:
+    - „Nicht installiert“
+    - „Installiert (Org X, Env Y)“
+    - „Update verfügbar“ (falls später Versionierung implementiert wird)
+  - Buttons:
+    - `Details anzeigen`
+    - optional Direkt-Button `Installieren` (öffnet Install-Flow).
+
+### 4.3 Detail-Ansicht eines Stacks
+
+Beim Klick auf `Details anzeigen`:
+
+- Banner/Logo.
+- Name, Kategorie, Tags.
+- Info „Bereitgestellt von: Wiesenwischer / Official / Third-Party XYZ“.
+- Langbeschreibung (Markdown gerendert).
+- Technischer Abschnitt:
+  - „Besteht aus: API, BFF, Worker, Web-Frontend, Migrations-Container, Monitoring-Container …“
+  - Verweis auf das Manifest: `ManifestSourceId + ManifestPath` (Link „Manifest anzeigen“).
+
+- **Registries-Abschnitt**:
+  - Auflistung von `requiredRegistries`:
+    - z. B. `docker.io – amssolution/*` (Status: Registry konfiguriert / nicht konfiguriert)
+  - Bei fehlender Registry:
+    - CTA: „Container-Registry konfigurieren“ (Link auf Settings → Container Registries mit Filter).
+
+- Button:
+  - `Installieren` oder `Für Organisation installieren`.
+
+---
+
+## 5. Installation eines Stacks aus dem Marketplace
+
+### 5.1 Auswahl von Organisation & Environment
+
+Beim Klick auf `Installieren`:
+
+- Seite oder Modal:
+
+  - **Organisation** wählen.
+  - **Environment** wählen (`Dev`, `Test`, `Prod`, …).
+  - Optional: „Stackinstanz-Name“ (falls mehrere Instanzen pro Org erlaubt sind).
+
+- Backend erzeugt eine neue `StackInstallation`:
+
+```csharp
+public sealed class StackInstallation
+{
+    public Guid Id { get; init; }
+
+    public string OrgId { get; init; }
+    public string EnvironmentId { get; init; }
+
+    public string CatalogEntryId { get; init; }       // Referenz auf StackCatalogEntry
+    public string ManifestSourceId { get; init; }
+    public string ManifestPath { get; init; }
+
+    public string? InstalledVersion { get; set; }     // aus CatalogEntry.Version
+    public StackInstallationStatus Status { get; set; }
+    public DateTimeOffset CreatedAt { get; init; }
+    public DateTimeOffset? LastUpdatedAt { get; set; }
+}
+```
+
+### 5.2 Übergang in den bestehenden Deployment-Flow
+
+Danach läuft der bekannte Deployment-Flow:
+
+1. **Parameter & Secrets**:
+   - Ermittlung aus Manifest.
+   - Eingabemaske (inkl. `.env`-Import, falls vorhanden).
+
+2. **Registry-Check anhand `requiredRegistries`**:
+   - Für jede `RequiredRegistryHint`:
+     - Prüfen, ob eine passende `ContainerRegistryConfig` existiert.
+   - Wenn `AuthRequired == true` und keine passende Config:
+     - Installation blockieren mit klarer Meldung:
+       - „Für diesen Stack wird eine Registry für `docker.io/amssolution/*` benötigt. Bitte konfigurieren Sie eine entsprechende Registry.“
+   - Wenn `AuthRequired == false` und keine passende Config:
+     - anonym versuchen, aber Warnung loggen.
+
+3. **Deployment-Plan erstellen und ausführen**:
+   - Analog zu manueller Manifest-Installation:
+     - Migrations-Container als Jobs,
+     - Services mit Restart-Policies,
+     - Health/Status-Überwachung.
+
+4. **Status aktualisieren**:
+   - `StackInstallation.Status` je nach Ergebnis (`Deploying`, `Running`, `Failed`, …).
+
+---
+
+## 6. Zusammenspiel mit Stack Sources & Container Registries
+
+### 6.1 Stack Sources
+
+- `StackCatalogEntry.ManifestSourceId` muss auf eine existierende Manifest-Quelle zeigen.
+- Beim Laden eines Katalogs:
+  - Wenn die Manifest-Quelle nicht existiert:
+    - Option A: Warnung, dass dieser Katalog-Eintrag (noch) nicht installierbar ist.
+    - Option B: automatisches Anlegen der Manifest-Quelle anhand von Metadaten der `StackCatalogSource`.
+
+Damit bleiben:
+
+- Stack Sources = **technische Konfiguration der Manifestquellen**,
+- Marketplace = **UX-Schicht, die diese Quellen konsumiert**.
+
+### 6.2 Container Registries
+
+- `RequiredRegistryHint` sind nur „Hints“, keine harte Kopplung.
+- Der Deployment-Prozess nutzt weiterhin das bestehende Matching:
+  - Host + Pattern → passende `ContainerRegistryConfig`.
+- Der Marketplace nutzt Hints nur für:
+  - Vorwarnungen in der UI,
+  - „Fehlende Registry“-Hinweise,
+  - bessere Diagnose bei fehlgeschlagenem Deployment.
+
+---
+
+## 7. Security & RBAC
+
+### 7.1 Rollen & Rechte
+
+Empfehlung:
+
+- **SystemOwner / OrgAdmin**:
+  - Marketplace sehen,
+  - Stacks installieren/deinstallieren,
+  - eigene `StackCatalogSource`s anlegen (org-bezogen).
+
+- **Operator**:
+  - Installierte Stacks sehen,
+  - Start/Stop/Restart im Rahmen seiner Rechte,
+  - optional: Marketplace lesen, aber nicht installieren.
+
+- **Read-Only / Beobachter**:
+  - nur installierte Stacks einsehen,
+  - Marketplace ggf. ausgeblendet.
+
+### 7.2 Sichtbarkeit von Catalog Sources
+
+- `StackCatalogSource.Scope`:
+  - `System` → für alle Organisationen sichtbar.
+  - `Org:<OrgId>` → nur für spezifische Organisation.
+
+Der Marketplace filtert die sichtbaren `StackCatalogEntry` anhand des Scopes und der aktuellen Benutzer-/Org-Kontexte.
+
+---
+
+## 8. Roadmap-Vorschlag für die Implementierung
+
+### Phase 1 – Interner Marketplace
+
+- Eine eingebaute `StackCatalogSource`:
+  - Typ `embedded` oder `git-json` (z. B. eigenes Repo mit `stack-catalog.json`).
+- Ziel:
+  - Erste Version mit:
+    - ams.project-Core-Stack,
+    - IdentityAccess-Stack,
+    - Monitoring-Stack,
+    - ggf. Demo-Stack.
+- Kein Schreibzugriff (nur Lesen), kein Upload/Publishing.
+
+### Phase 2 – Organisationseigene Kataloge
+
+- Zusätzliche `StackCatalogSource`-Types:
+  - `git-json`:
+    - Jede Organisation kann in ihren Settings ein Repo hinterlegen, in dem ein Katalog liegt.
+- Der Marketplace zeigt:
+  - Offizielle Stacks,
+  - plus Org-spezifische Stacks für die aktuelle Organisation.
+
+### Phase 3 – Erweiterter Marketplace
+
+- Optionale, zentrale HTTP-basierte Katalog-API (z. B. „RSGO Hub“).
+- Features:
+  - automatische Updates von Katalogeinträgen,
+  - optional: Abhängigkeiten, Kompatibilitätsmatrix, Supportinfos.
+
+---
+
+## 9. Zusammenfassung
+
+Der geplante **Stack Marketplace** für ReadyStackGo:
+
+- Ergänzt dein bestehendes Konzept von:
+  - Stack Sources (Manifeste),
+  - Container Registries (Images),
+  - Stack Installations (konkrete Deployments).
+- Führt zwei neue Kerntypen ein:
+  - `StackCatalogSource` – Quelle für Marketplace-Einträge,
+  - `StackCatalogEntry` – „App Store“-Eintrag für einen Stack.
+- Bietet Administratoren:
+  - eine übersichtliche „App Store“-ähnliche Oberfläche,
+  - Detailansichten je Stack,
+  - direkten Install-Flow für Organisation & Environment.
+- Bleibt strikt kompatibel mit:
+  - deinem Manifest-Format,
+  - deiner Registry-/Pattern-Logik,
+  - deinem Deployment-/Health-Modell.
+
+Diese Spezifikation kann als `STACK-MARKETPLACE.md` im `/docs`-Verzeichnis deines ReadyStackGo-Repositories abgelegt und als Grundlage für die Implementierung in Backend (.NET 9/FastEndpoints) und Frontend (React + Tailwind/TailAdmin) verwendet werden.


### PR DESCRIPTION
Add specification documents that were created during planning but not yet committed:

- **rsgo-distributions/**: AMS UI Integration, Distribution Setup, Frontend Architecture
- **rsgo-qol-improvements/**: OCI Stacks, Registry Wizard UX, Stack Marketplace