### PR TITLE
Fix webhook deployments losing variables and add variable override support

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/Hooks/RedeployEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Hooks/RedeployEndpoint.cs
@@ -38,7 +38,7 @@ public class RedeployEndpoint : Endpoint<RedeployStackRequest, RedeployStackResp
         }
 
         var response = await _mediator.Send(
-            new RedeployStackCommand(req.StackName, environmentId!), ct);
+            new RedeployStackCommand(req.StackName, environmentId!, req.Variables), ct);
 
         if (!response.Success)
         {


### PR DESCRIPTION
## Summary
- **DeployViaHookHandler**: When redeploying an existing stack via `/api/hooks/deploy`, stored deployment variables are now used as the base with webhook-provided variables as overrides (previously only webhook variables were used, causing empty env vars)
- **RedeployStackHandler**: Added optional `Variables` field to `/api/hooks/redeploy` request, enabling pipelines to override specific variables during redeploy while preserving all stored values
- Added 10 new unit tests covering all variable merge scenarios (stored-only, webhook-only, override, additive, empty)

## Test plan
- [x] All 1805 unit tests pass
- [x] 0 errors, 0 warnings
- [ ] CI Build & Test check