### PR TITLE
Add container management improvements with 3 views and remove action

### DIFF
--- a/docs/Plans/PLAN-container-management.md
+++ b/docs/Plans/PLAN-container-management.md
@@ -1,0 +1,204 @@
+# Phase: Container Management Improvements
+
+## Ziel
+
+Die Container-Seite um Delete-Aktion, Stack/Product-Zuordnung und verschiedene Ansichten (List, Stack, Product) erweitern. Verwaiste Container (RSGO-Labels aber kein Deployment) werden erkannt und markiert. Externe Container ohne RSGO-Labels erscheinen als "Unmanaged" Gruppe.
+
+## Analyse
+
+### Bestehende Architektur
+
+| Komponente | Pfad | Relevanz |
+|---|---|---|
+| `IDockerService` | `Application/Services/IDockerService.cs` | `RemoveContainerAsync()` bereits vorhanden |
+| `DockerService` | `Infrastructure.Docker/DockerService.cs:265` | Remove-Implementierung existiert (force + non-force) |
+| `StopContainerCommand` | `Application/UseCases/Containers/StopContainer/` | Pattern-Vorlage für RemoveContainer |
+| `StopContainerEndpoint` | `Api/Endpoints/Containers/StopContainerEndpoint.cs` | Pattern-Vorlage für Endpoint |
+| `ContainerDto` | `Application/UseCases/Containers/ContainerDto.cs` | Enthält bereits `Labels` Dictionary |
+| `IDeploymentRepository` | `Domain/Deployment/Deployments/IDeploymentRepository.cs` | `GetByStackName()` für Orphan-Erkennung |
+| `IProductCache` | `Application/Services/IProductCache.cs` | `GetStack(stackId)` für Product-Zuordnung |
+| `StackId` | `Domain/StackManagement/Stacks/StackId.cs` | `TryParse()` zum Parsen von Deployment.StackId |
+| `StackDefinition` | `Domain/StackManagement/Stacks/StackDefinition.cs` | `ProductName`, `ProductDisplayName` |
+| `Containers.tsx` | `WebUi/src/pages/Monitoring/Containers.tsx` | Hauptdatei für UI-Umbau |
+| `containers.ts` | `WebUi/src/api/containers.ts` | API-Client, aktuell: list, start, stop |
+| `VolumeDetail.tsx` | `WebUi/src/pages/Monitoring/VolumeDetail.tsx` | Pattern-Vorlage für Delete-Confirmation |
+
+### Container-Labels (gesetzt bei Deployment)
+
+```
+rsgo.stack       = <stackName>        → Stack-Zuordnung
+rsgo.context     = <serviceName>      → Service innerhalb des Stacks
+rsgo.environment = <environmentId>    → Environment-Zuordnung
+rsgo.lifecycle   = service | init     → Container-Typ
+```
+
+### Bestehende API-Endpoints
+
+| Method | Route | Permission | Status |
+|--------|-------|-----------|--------|
+| GET | `/api/containers?environment=...` | Deployments.Read | Existiert |
+| POST | `/api/containers/{id}/start?environment=...` | Deployments.Update | Existiert |
+| POST | `/api/containers/{id}/stop?environment=...` | Deployments.Update | Existiert |
+| DELETE | `/api/containers/{id}?environment=...&force=...` | Deployments.Delete | **NEU** |
+| GET | `/api/containers/context?environment=...` | Deployments.Read | **NEU** |
+
+### Container-zu-Product Mapping
+
+```
+Container (Docker)
+  └─ Label: rsgo.stack = "wordpress"
+      └─ Deployment (SQLite, GetByStackName)
+          └─ StackId = "builtin:wordpress:5.9:wordpress"
+              └─ StackId.TryParse() → StackId Record
+                  └─ IProductCache.GetStack(stackId)
+                      └─ StackDefinition.ProductName / ProductDisplayName
+```
+
+### Orphan-Erkennung
+
+Ein Container gilt als **orphaned** wenn:
+1. Er ein `rsgo.stack` Label hat (wurde von RSGO deployed)
+2. Kein aktives Deployment (Status != Removed) für diesen Stack-Namen existiert
+
+Container **ohne** `rsgo.stack` Label sind **nicht orphaned** — sie sind "unmanaged" (extern, z.B. Portainer, Traefik).
+
+## Features / Schritte
+
+- [ ] **Feature 1: RemoveContainer Backend** — Use Case + Endpoint
+  - Neue Dateien:
+    - `Application/UseCases/Containers/RemoveContainer/RemoveContainerCommand.cs`
+    - `Application/UseCases/Containers/RemoveContainer/RemoveContainerHandler.cs`
+    - `Api/Endpoints/Containers/RemoveContainerEndpoint.cs`
+  - Pattern-Vorlage: `StopContainer*` (1:1 Kopie mit Anpassungen)
+  - Handler: Safety-Check (running container ohne force → Fehler), dann `_dockerService.RemoveContainerAsync()`
+  - Endpoint: `DELETE /api/containers/{id}`, Permission `Deployments.Delete`
+  - Abhängig von: –
+
+- [ ] **Feature 2: GetContainerContext Backend** — Use Case + Endpoint
+  - Neue Dateien:
+    - `Application/UseCases/Containers/GetContainerContext/GetContainerContextQuery.cs`
+    - `Application/UseCases/Containers/GetContainerContext/GetContainerContextHandler.cs`
+    - `Api/Endpoints/Containers/GetContainerContextEndpoint.cs`
+  - DTOs:
+    - `StackContextInfo { StackName, DeploymentExists, DeploymentId?, ProductName?, ProductDisplayName? }`
+    - `GetContainerContextResult { Stacks: Dictionary<string, StackContextInfo> }`
+  - Handler-Logik:
+    1. `ListContainersAsync()` → unique `rsgo.stack` Labels extrahieren
+    2. Pro Stack: `GetByStackName()` → Deployment vorhanden?
+    3. Falls Deployment: `StackId.TryParse(deployment.StackId)` → `_productCache.GetStack()` → ProductName
+  - Dependencies: `IDockerService`, `IDeploymentRepository`, `IProductCache`
+  - Abhängig von: –
+
+- [ ] **Feature 3: Backend-Tests**
+  - `RemoveContainerHandlerTests` (5 Tests):
+    - `StoppedContainer_ReturnsSuccess`
+    - `RunningContainer_WithoutForce_ReturnsError`
+    - `RunningContainer_WithForce_ReturnsSuccess`
+    - `NonExistentContainer_ReturnsError`
+    - `DockerServiceThrows_ReturnsError`
+  - `GetContainerContextHandlerTests` (6 Tests):
+    - `AllStacksHaveDeployments_AllContextsPopulated`
+    - `ContainersWithoutLabels_NotIncluded`
+    - `StackWithoutDeployment_DeploymentExistsFalse`
+    - `StackWithDeployment_ProductInfoResolved`
+    - `StackWithDeployment_ProductNotInCache_ProductNameNull`
+    - `DockerServiceThrows_ReturnsError`
+  - Abhängig von: Feature 1, Feature 2
+
+- [ ] **Feature 4: Frontend — API-Client + Containers.tsx**
+  - `api/containers.ts` erweitern:
+    - `remove(environmentId, id, force)` via `apiDelete`
+    - `getContext(environmentId)` → `ContainerContextResult`
+    - Neue TypeScript-Interfaces: `StackContextInfo`, `ContainerContextResult`
+  - `Containers.tsx` komplett überarbeiten:
+    - **Action Buttons**: Icon-only (Play/Stop/Trash) in subtlem Grau statt rotem/grünem Hintergrund
+    - **Remove Confirmation**: Inline "Remove?" + ✓/✗ (VolumeDetail-Pattern)
+    - **View Toggle**: List / Stacks / Products — Umschaltung im Header
+    - **List View**: Tabelle mit Stack + Product Spalten, orphaned Badge
+    - **Stack View**: Gruppierung nach `rsgo.stack`, Unmanaged-Gruppe am Ende
+    - **Product View**: Gruppierung nach Product, Stacks darunter, Unmanaged am Ende
+  - Abhängig von: Feature 1, Feature 2
+
+- [ ] **Phase abschließen** — Build, Tests, PR
+
+## View-Konzept
+
+### View Toggle (Header)
+
+Drei Buttons im Header-Bereich: `[≡ List] [▦ Stacks] [⊞ Products]`
+Aktiver Button hervorgehoben. State in `useState`, kein localStorage nötig.
+
+### List View (Default)
+
+Flache Tabelle, Grid `sm:grid-cols-10`:
+
+| Name (2) | Stack (2) | Product (2) | Image (2, hidden mobile) | Status (1) | Actions (1) |
+|-----------|-----------|-------------|--------------------------|------------|-------------|
+| wp-app | wordpress ↗ | WordPress | wordpress:6.4 | ● healthy | ▶ ■ 🗑 |
+| wp-db | wordpress ↗ | WordPress | mysql:8 | ● healthy | ▶ ■ 🗑 |
+| redis | redis-test ⚠ orphaned | – | redis:7 | ● running | ▶ ■ 🗑 |
+| portainer | – | – | portainer/portainer | ● running | ▶ ■ 🗑 |
+
+- Stack-Spalte: Link zu `/deployments/{stackName}` wenn Deployment existiert, amber "orphaned" Badge wenn nicht, "–" ohne Label
+- Product-Spalte: `productDisplayName` aus Context, "–" wenn nicht zuordbar
+- Actions: Icon-Buttons `p-1.5 rounded text-gray-500 hover:bg-gray-100`
+
+### Stack View (Gruppiert)
+
+```
+┌─ wordpress ──────────────────── Running (2 containers) ───┐
+│  wp-app     | wordpress:6.4 | healthy  | 8080:80 | ▶ ■ 🗑 │
+│  wp-db      | mysql:8       | healthy  | –       | ▶ ■ 🗑 │
+└───────────────────────────────────────────────────────────┘
+
+┌─ redis-test ────────────── ⚠ Orphaned (1 container) ─────┐
+│  redis       | redis:7     | running  | 6379    | ▶ ■ 🗑 │
+└───────────────────────────────────────────────────────────┘
+
+┌─ Unmanaged ──────────────────── 2 containers ────────────┐
+│  portainer  | portainer/.. | running  | 9443    | ▶ ■ 🗑 │
+│  traefik    | traefik:v3   | running  | 80      | ▶ ■ 🗑 │
+└───────────────────────────────────────────────────────────┘
+```
+
+Gruppen-Header: Stack-Name (Link wenn Deployment existiert), Status-Badge, Container-Count.
+
+### Product View (Gruppiert nach Produkt)
+
+```
+┌─ WordPress ──────────────────────────────────────────────┐
+│  ┌ wordpress (v6.4) ── Running ────────────────────────┐ │
+│  │  wp-app  | healthy | 8080:80 | ▶ ■ 🗑              │ │
+│  │  wp-db   | healthy | –       | ▶ ■ 🗑              │ │
+│  └─────────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────┘
+
+┌─ Unknown Product ────────────────────────────────────────┐
+│  ┌ redis-test ── ⚠ Orphaned ──────────────────────────┐ │
+│  │  redis | running | 6379 | ▶ ■ 🗑                   │ │
+│  └─────────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────┘
+
+┌─ Unmanaged ──────────────────────────────────────────────┐
+│  portainer | running | 9443 | ▶ ■ 🗑                     │
+│  traefik   | running | 80   | ▶ ■ 🗑                     │
+└──────────────────────────────────────────────────────────┘
+```
+
+Orphaned Stacks → "Unknown Product" Gruppe. Unmanaged → eigene Gruppe am Ende.
+
+## Test-Strategie
+
+- **Unit Tests**: RemoveContainerHandler (Safety-Check, Force-Flag, Fehlerfälle) + GetContainerContextHandler (Label-Parsing, Deployment-Lookup, Product-Cache, Fehlerfälle)
+- **E2E Tests**: Später per `document-feature` Skill
+- **Manuell**: Docker-Container starten, Container-Seite prüfen, alle 3 Views durchklicken, Remove testen
+
+## Entscheidungen
+
+| Entscheidung | Optionen | Gewählt | Begründung |
+|---|---|---|---|
+| Remove Permission | Deployments.Update, Deployments.Delete | Deployments.Delete | Destruktive Aktion, konsistent mit RemoveVolume/RemoveDeployment |
+| Orphan-Erkennung | Separater Endpoint, In ListContainers, Frontend-only | Separater Context-Endpoint | ListContainers bleibt schnell (Docker-only), Context-Daten parallel geladen |
+| Externe Container | Ausblenden, Als "orphaned" zeigen, Als "Unmanaged" | Unmanaged-Gruppe | Nicht von RSGO verwaltet = nicht verwaist, eigene Kategorie |
+| Action Buttons | Farbige Text-Buttons, Icon-Buttons grau | Icon-Buttons grau | Weniger visuelles Rauschen, konsistenter mit modernen UIs |
+| Ansichten | Nur List, List+Stack, Alle drei | Alle drei (List+Stack+Product) | Maximale Flexibilität bei der Container-Übersicht |

--- a/src/ReadyStackGo.Api/Endpoints/Containers/GetContainerContextEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Containers/GetContainerContextEndpoint.cs
@@ -1,0 +1,56 @@
+using FastEndpoints;
+using MediatR;
+using ReadyStackGo.Api.Authorization;
+using ReadyStackGo.Application.UseCases.Containers.GetContainerContext;
+
+namespace ReadyStackGo.API.Endpoints.Containers;
+
+public class GetContainerContextRequest
+{
+    [QueryParam]
+    public string Environment { get; set; } = null!;
+
+    /// <summary>
+    /// Environment ID for RBAC scope check (alias for Environment).
+    /// </summary>
+    public string? EnvironmentId => Environment;
+}
+
+/// <summary>
+/// Returns stack/product context for containers. Requires Deployments.Read permission.
+/// Accessible by: SystemAdmin, OrganizationOwner, Operator, Viewer (scoped).
+/// </summary>
+[RequirePermission("Deployments", "Read")]
+public class GetContainerContextEndpoint : Endpoint<GetContainerContextRequest, GetContainerContextResult>
+{
+    private readonly IMediator _mediator;
+
+    public GetContainerContextEndpoint(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Get("/api/containers/context");
+        PreProcessor<RbacPreProcessor<GetContainerContextRequest>>();
+        Description(b => b.WithTags("Containers"));
+    }
+
+    public override async Task HandleAsync(GetContainerContextRequest req, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(req.Environment))
+        {
+            ThrowError("Environment is required");
+        }
+
+        var result = await _mediator.Send(new GetContainerContextQuery(req.Environment), ct);
+
+        if (!result.Success)
+        {
+            ThrowError(result.ErrorMessage ?? "Failed to get container context");
+        }
+
+        Response = result;
+    }
+}

--- a/src/ReadyStackGo.Api/Endpoints/Containers/RemoveContainerEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Containers/RemoveContainerEndpoint.cs
@@ -1,0 +1,59 @@
+using FastEndpoints;
+using MediatR;
+using ReadyStackGo.Api.Authorization;
+using ReadyStackGo.Application.UseCases.Containers.RemoveContainer;
+
+namespace ReadyStackGo.API.Endpoints.Containers;
+
+public class RemoveContainerRequest
+{
+    [QueryParam]
+    public string Environment { get; set; } = null!;
+
+    [QueryParam]
+    public bool Force { get; set; }
+
+    /// <summary>
+    /// Environment ID for RBAC scope check (alias for Environment).
+    /// </summary>
+    public string? EnvironmentId => Environment;
+}
+
+/// <summary>
+/// Removes a container. Requires Deployments.Delete permission.
+/// Accessible by: SystemAdmin, OrganizationOwner, Operator (scoped).
+/// </summary>
+[RequirePermission("Deployments", "Delete")]
+public class RemoveContainerEndpoint : Endpoint<RemoveContainerRequest, EmptyResponse>
+{
+    private readonly IMediator _mediator;
+
+    public RemoveContainerEndpoint(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Delete("/api/containers/{id}");
+        PreProcessor<RbacPreProcessor<RemoveContainerRequest>>();
+        Description(b => b.WithTags("Containers"));
+    }
+
+    public override async Task HandleAsync(RemoveContainerRequest req, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(req.Environment))
+        {
+            ThrowError("Environment is required");
+        }
+
+        var id = Route<string>("id")!;
+
+        var result = await _mediator.Send(new RemoveContainerCommand(req.Environment, id, req.Force), ct);
+
+        if (!result.Success)
+        {
+            ThrowError(result.ErrorMessage ?? "Failed to remove container");
+        }
+    }
+}

--- a/src/ReadyStackGo.Application/UseCases/Containers/GetContainerContext/GetContainerContextHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Containers/GetContainerContext/GetContainerContextHandler.cs
@@ -1,0 +1,73 @@
+using MediatR;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Domain.Deployment.Deployments;
+using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.StackManagement.Stacks;
+
+namespace ReadyStackGo.Application.UseCases.Containers.GetContainerContext;
+
+public class GetContainerContextHandler : IRequestHandler<GetContainerContextQuery, GetContainerContextResult>
+{
+    private readonly IDockerService _dockerService;
+    private readonly IDeploymentRepository _deploymentRepository;
+    private readonly IProductCache _productCache;
+
+    public GetContainerContextHandler(
+        IDockerService dockerService,
+        IDeploymentRepository deploymentRepository,
+        IProductCache productCache)
+    {
+        _dockerService = dockerService;
+        _deploymentRepository = deploymentRepository;
+        _productCache = productCache;
+    }
+
+    public async Task<GetContainerContextResult> Handle(GetContainerContextQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (!Guid.TryParse(request.EnvironmentId, out var envGuid))
+                return GetContainerContextResult.Failed("Invalid environment ID format.");
+
+            var environmentId = new EnvironmentId(envGuid);
+
+            var containers = await _dockerService.ListContainersAsync(request.EnvironmentId, cancellationToken);
+
+            var stackNames = containers
+                .Where(c => c.Labels.ContainsKey("rsgo.stack"))
+                .Select(c => c.Labels["rsgo.stack"])
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+            var stacks = new Dictionary<string, StackContextInfo>();
+
+            foreach (var stackName in stackNames)
+            {
+                var deployment = _deploymentRepository.GetByStackName(environmentId, stackName);
+
+                string? productName = null;
+                string? productDisplayName = null;
+
+                if (deployment != null && StackId.TryParse(deployment.StackId, out var parsedStackId))
+                {
+                    var stackDef = _productCache.GetStack(parsedStackId!.Value);
+                    productName = stackDef?.ProductName;
+                    productDisplayName = stackDef?.ProductDisplayName;
+                }
+
+                stacks[stackName] = new StackContextInfo(
+                    stackName,
+                    deployment != null,
+                    deployment?.Id.ToString(),
+                    productName,
+                    productDisplayName);
+            }
+
+            return new GetContainerContextResult(true, stacks);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return GetContainerContextResult.Failed(ex.Message);
+        }
+    }
+}

--- a/src/ReadyStackGo.Application/UseCases/Containers/GetContainerContext/GetContainerContextQuery.cs
+++ b/src/ReadyStackGo.Application/UseCases/Containers/GetContainerContext/GetContainerContextQuery.cs
@@ -1,0 +1,21 @@
+using MediatR;
+
+namespace ReadyStackGo.Application.UseCases.Containers.GetContainerContext;
+
+public record GetContainerContextQuery(string EnvironmentId) : IRequest<GetContainerContextResult>;
+
+public record StackContextInfo(
+    string StackName,
+    bool DeploymentExists,
+    string? DeploymentId = null,
+    string? ProductName = null,
+    string? ProductDisplayName = null);
+
+public record GetContainerContextResult(
+    bool Success,
+    IReadOnlyDictionary<string, StackContextInfo> Stacks,
+    string? ErrorMessage = null)
+{
+    public static GetContainerContextResult Failed(string message) =>
+        new(false, new Dictionary<string, StackContextInfo>(), message);
+}

--- a/src/ReadyStackGo.Application/UseCases/Containers/RemoveContainer/RemoveContainerCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Containers/RemoveContainer/RemoveContainerCommand.cs
@@ -1,0 +1,7 @@
+using MediatR;
+
+namespace ReadyStackGo.Application.UseCases.Containers.RemoveContainer;
+
+public record RemoveContainerCommand(string EnvironmentId, string ContainerId, bool Force = false) : IRequest<RemoveContainerResult>;
+
+public record RemoveContainerResult(bool Success, string? ErrorMessage = null);

--- a/src/ReadyStackGo.Application/UseCases/Containers/RemoveContainer/RemoveContainerHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Containers/RemoveContainer/RemoveContainerHandler.cs
@@ -1,0 +1,39 @@
+using MediatR;
+using ReadyStackGo.Application.Services;
+
+namespace ReadyStackGo.Application.UseCases.Containers.RemoveContainer;
+
+public class RemoveContainerHandler : IRequestHandler<RemoveContainerCommand, RemoveContainerResult>
+{
+    private readonly IDockerService _dockerService;
+
+    public RemoveContainerHandler(IDockerService dockerService)
+    {
+        _dockerService = dockerService;
+    }
+
+    public async Task<RemoveContainerResult> Handle(RemoveContainerCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (!request.Force)
+            {
+                var containers = await _dockerService.ListContainersAsync(request.EnvironmentId, cancellationToken);
+                var container = containers.FirstOrDefault(c => c.Id == request.ContainerId);
+
+                if (container == null)
+                    return new RemoveContainerResult(false, "Container not found.");
+
+                if (container.State.Equals("running", StringComparison.OrdinalIgnoreCase))
+                    return new RemoveContainerResult(false, "Cannot remove a running container. Stop it first or use force.");
+            }
+
+            await _dockerService.RemoveContainerAsync(request.EnvironmentId, request.ContainerId, request.Force, cancellationToken);
+            return new RemoveContainerResult(true);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return new RemoveContainerResult(false, ex.Message);
+        }
+    }
+}

--- a/src/ReadyStackGo.WebUi/src/api/containers.ts
+++ b/src/ReadyStackGo.WebUi/src/api/containers.ts
@@ -1,4 +1,4 @@
-import { apiGet, apiPost } from './client';
+import { apiGet, apiPost, apiDelete } from './client';
 
 export interface Container {
   id: string;
@@ -19,9 +19,27 @@ export interface Port {
   type: string;
 }
 
+export interface StackContextInfo {
+  stackName: string;
+  deploymentExists: boolean;
+  deploymentId?: string;
+  productName?: string;
+  productDisplayName?: string;
+}
+
+export interface ContainerContextResult {
+  success: boolean;
+  stacks: Record<string, StackContextInfo>;
+  errorMessage?: string;
+}
+
 export const containerApi = {
   async list(environmentId: string): Promise<Container[]> {
     return apiGet<Container[]>(`/api/containers?environment=${encodeURIComponent(environmentId)}`);
+  },
+
+  async getContext(environmentId: string): Promise<ContainerContextResult> {
+    return apiGet<ContainerContextResult>(`/api/containers/context?environment=${encodeURIComponent(environmentId)}`);
   },
 
   async start(environmentId: string, id: string): Promise<void> {
@@ -30,5 +48,9 @@ export const containerApi = {
 
   async stop(environmentId: string, id: string): Promise<void> {
     return apiPost(`/api/containers/${id}/stop?environment=${encodeURIComponent(environmentId)}`);
+  },
+
+  async remove(environmentId: string, id: string, force: boolean = false): Promise<void> {
+    return apiDelete(`/api/containers/${id}?environment=${encodeURIComponent(environmentId)}&force=${force}`);
   },
 };

--- a/src/ReadyStackGo.WebUi/src/pages/Monitoring/Containers.tsx
+++ b/src/ReadyStackGo.WebUi/src/pages/Monitoring/Containers.tsx
@@ -1,17 +1,27 @@
-import { useEffect, useState, useCallback } from "react";
-import { containerApi, type Container } from "../../api/containers";
+import { useEffect, useState, useCallback, useMemo } from "react";
+import {
+  containerApi,
+  type Container,
+  type StackContextInfo,
+} from "../../api/containers";
 import { useEnvironment } from "../../context/EnvironmentContext";
+
+type ViewMode = "list" | "stacks" | "products";
 
 export default function Containers() {
   const [containers, setContainers] = useState<Container[]>([]);
+  const [context, setContext] = useState<Record<string, StackContextInfo>>({});
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
+  const [removeConfirm, setRemoveConfirm] = useState<string | null>(null);
+  const [viewMode, setViewMode] = useState<ViewMode>("list");
   const { activeEnvironment } = useEnvironment();
 
   const loadContainers = useCallback(async () => {
     if (!activeEnvironment) {
       setContainers([]);
+      setContext({});
       setLoading(false);
       return;
     }
@@ -19,10 +29,16 @@ export default function Containers() {
     try {
       setLoading(true);
       setError(null);
-      const data = await containerApi.list(activeEnvironment.id);
+      const [data, ctx] = await Promise.all([
+        containerApi.list(activeEnvironment.id),
+        containerApi.getContext(activeEnvironment.id),
+      ]);
       setContainers(data);
+      setContext(ctx.success ? ctx.stacks : {});
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load containers");
+      setError(
+        err instanceof Error ? err.message : "Failed to load containers"
+      );
     } finally {
       setLoading(false);
     }
@@ -34,13 +50,14 @@ export default function Containers() {
 
   const handleStart = async (id: string) => {
     if (!activeEnvironment) return;
-
     try {
       setActionLoading(id);
       await containerApi.start(activeEnvironment.id, id);
       await loadContainers();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to start container");
+      setError(
+        err instanceof Error ? err.message : "Failed to start container"
+      );
     } finally {
       setActionLoading(null);
     }
@@ -48,77 +65,768 @@ export default function Containers() {
 
   const handleStop = async (id: string) => {
     if (!activeEnvironment) return;
-
     try {
       setActionLoading(id);
       await containerApi.stop(activeEnvironment.id, id);
       await loadContainers();
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to stop container");
+      setError(
+        err instanceof Error ? err.message : "Failed to stop container"
+      );
     } finally {
       setActionLoading(null);
     }
   };
 
-  /**
-   * Get combined status badge (like Portainer).
-   * Shows "healthy" instead of "running" when health check passes.
-   */
-  const getCombinedStatusBadge = (state: string, healthStatus: string | undefined) => {
-    // If health check exists, use it as primary status (like Portainer)
-    if (healthStatus && healthStatus !== "none") {
-      switch (healthStatus.toLowerCase()) {
-        case "healthy":
-          return (
-            <span className="inline-flex rounded-full px-3 py-1 text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
-              healthy
-            </span>
-          );
-        case "unhealthy":
-          return (
-            <span className="inline-flex rounded-full px-3 py-1 text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200">
-              unhealthy
-            </span>
-          );
-        case "starting":
-          return (
-            <span className="inline-flex rounded-full px-3 py-1 text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200">
-              starting
-            </span>
-          );
+  const handleRemove = async (id: string, force: boolean) => {
+    if (!activeEnvironment) return;
+    try {
+      setActionLoading(id);
+      setRemoveConfirm(null);
+      await containerApi.remove(activeEnvironment.id, id, force);
+      await loadContainers();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to remove container"
+      );
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const getStackName = (c: Container) => c.labels?.["rsgo.stack"];
+
+  const getContextInfo = useCallback(
+    (stackName: string | undefined) => {
+      if (!stackName) return undefined;
+      const key = Object.keys(context).find(
+        (k) => k.toLowerCase() === stackName.toLowerCase()
+      );
+      return key ? context[key] : undefined;
+    },
+    [context]
+  );
+
+  // Grouped data for Stack/Product views
+  const groupedByStack = useMemo(() => {
+    const managed: Record<
+      string,
+      { containers: Container[]; context?: StackContextInfo }
+    > = {};
+    const unmanaged: Container[] = [];
+
+    for (const c of containers) {
+      const stackName = getStackName(c);
+      if (stackName) {
+        if (!managed[stackName]) {
+          managed[stackName] = {
+            containers: [],
+            context: getContextInfo(stackName),
+          };
+        }
+        managed[stackName].containers.push(c);
+      } else {
+        unmanaged.push(c);
       }
     }
+    return { managed, unmanaged };
+  }, [containers, getContextInfo]);
 
-    // Fall back to container state
-    const stateLower = state.toLowerCase();
-    switch (stateLower) {
-      case "running":
+  const groupedByProduct = useMemo(() => {
+    const products: Record<
+      string,
+      {
+        displayName: string;
+        stacks: Record<
+          string,
+          { containers: Container[]; context?: StackContextInfo }
+        >;
+      }
+    > = {};
+    const unknownProduct: Record<
+      string,
+      { containers: Container[]; context?: StackContextInfo }
+    > = {};
+    const unmanaged: Container[] = [];
+
+    for (const c of containers) {
+      const stackName = getStackName(c);
+      if (!stackName) {
+        unmanaged.push(c);
+        continue;
+      }
+      const ctx = getContextInfo(stackName);
+      const productKey = ctx?.productName ?? null;
+      const productDisplay = ctx?.productDisplayName ?? null;
+
+      if (productKey && productDisplay) {
+        if (!products[productKey]) {
+          products[productKey] = { displayName: productDisplay, stacks: {} };
+        }
+        if (!products[productKey].stacks[stackName]) {
+          products[productKey].stacks[stackName] = {
+            containers: [],
+            context: ctx,
+          };
+        }
+        products[productKey].stacks[stackName].containers.push(c);
+      } else {
+        if (!unknownProduct[stackName]) {
+          unknownProduct[stackName] = { containers: [], context: ctx };
+        }
+        unknownProduct[stackName].containers.push(c);
+      }
+    }
+    return { products, unknownProduct, unmanaged };
+  }, [containers, getContextInfo]);
+
+  // --- Reusable sub-components ---
+
+  const StatusBadge = ({
+    state,
+    healthStatus,
+  }: {
+    state: string;
+    healthStatus?: string;
+  }) => {
+    if (healthStatus && healthStatus !== "none") {
+      const h = healthStatus.toLowerCase();
+      if (h === "healthy")
         return (
-          <span className="inline-flex rounded-full px-3 py-1 text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
-            running
+          <span className="inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200">
+            healthy
           </span>
         );
-      case "exited":
-      case "dead":
+      if (h === "unhealthy")
         return (
-          <span className="inline-flex rounded-full px-3 py-1 text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200">
-            {stateLower}
+          <span className="inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200">
+            unhealthy
           </span>
         );
-      case "paused":
-      case "restarting":
+      if (h === "starting")
         return (
-          <span className="inline-flex rounded-full px-3 py-1 text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200">
-            {stateLower}
-          </span>
-        );
-      default:
-        return (
-          <span className="inline-flex rounded-full px-3 py-1 text-xs font-medium bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300">
-            {state}
+          <span className="inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200">
+            starting
           </span>
         );
     }
+    const s = state.toLowerCase();
+    const colors =
+      s === "running"
+        ? "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200"
+        : s === "exited" || s === "dead"
+          ? "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200"
+          : s === "paused" || s === "restarting"
+            ? "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200"
+            : "bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300";
+    return (
+      <span
+        className={`inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium ${colors}`}
+      >
+        {s}
+      </span>
+    );
+  };
+
+  const OrphanedBadge = () => (
+    <span className="inline-flex rounded-full px-2.5 py-0.5 text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200">
+      orphaned
+    </span>
+  );
+
+  const PortDisplay = ({ c }: { c: Container }) => (
+    <span className="text-sm text-gray-700 dark:text-gray-300">
+      {c.ports[0] ? `${c.ports[0].publicPort}:${c.ports[0].privatePort}` : "-"}
+    </span>
+  );
+
+  const ActionButtons = ({ c }: { c: Container }) => {
+    const isRunning = c.state.toLowerCase() === "running";
+    const isLoading = actionLoading === c.id;
+    const isConfirming = removeConfirm === c.id;
+
+    if (isConfirming) {
+      return (
+        <div className="flex items-center gap-1.5">
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {isRunning ? "Force remove?" : "Remove?"}
+          </span>
+          <button
+            onClick={() => handleRemove(c.id, isRunning)}
+            disabled={isLoading}
+            className="p-1 rounded text-green-600 hover:bg-green-100 dark:text-green-400 dark:hover:bg-green-900 disabled:opacity-50"
+            title="Confirm"
+          >
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+          </button>
+          <button
+            onClick={() => setRemoveConfirm(null)}
+            className="p-1 rounded text-red-600 hover:bg-red-100 dark:text-red-400 dark:hover:bg-red-900"
+            title="Cancel"
+          >
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex items-center gap-1">
+        {isRunning ? (
+          <button
+            onClick={() => handleStop(c.id)}
+            disabled={isLoading}
+            className="p-1.5 rounded text-gray-500 hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700 disabled:opacity-50"
+            title="Stop"
+          >
+            {isLoading ? (
+              <Spinner />
+            ) : (
+              <svg
+                className="w-4 h-4"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <rect x="6" y="6" width="12" height="12" rx="1" />
+              </svg>
+            )}
+          </button>
+        ) : (
+          <button
+            onClick={() => handleStart(c.id)}
+            disabled={isLoading}
+            className="p-1.5 rounded text-gray-500 hover:text-gray-900 hover:bg-gray-100 dark:text-gray-400 dark:hover:text-white dark:hover:bg-gray-700 disabled:opacity-50"
+            title="Start"
+          >
+            {isLoading ? (
+              <Spinner />
+            ) : (
+              <svg
+                className="w-4 h-4"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path d="M8 5v14l11-7z" />
+              </svg>
+            )}
+          </button>
+        )}
+        <button
+          onClick={() => setRemoveConfirm(c.id)}
+          disabled={isLoading}
+          className="p-1.5 rounded text-gray-500 hover:text-red-600 hover:bg-red-50 dark:text-gray-400 dark:hover:text-red-400 dark:hover:bg-red-900/30 disabled:opacity-50"
+          title="Remove"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+            />
+          </svg>
+        </button>
+      </div>
+    );
+  };
+
+  const Spinner = () => (
+    <svg className="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="4"
+      />
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+      />
+    </svg>
+  );
+
+  // --- View Toggle ---
+  const listIcon = (
+    <svg
+      className="w-4 h-4"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M4 6h16M4 12h16M4 18h16"
+      />
+    </svg>
+  );
+  const stackIcon = (
+    <svg
+      className="w-4 h-4"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+      />
+    </svg>
+  );
+  const productIcon = (
+    <svg
+      className="w-4 h-4"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
+      />
+    </svg>
+  );
+
+  const ViewToggle = () => (
+    <div className="inline-flex rounded-lg border border-gray-200 dark:border-gray-700 p-0.5">
+      {(
+        [
+          { key: "list", label: "List", icon: listIcon },
+          { key: "stacks", label: "Stacks", icon: stackIcon },
+          { key: "products", label: "Products", icon: productIcon },
+        ] as const
+      ).map(({ key, label, icon }) => (
+        <button
+          key={key}
+          onClick={() => setViewMode(key)}
+          className={`inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md transition-colors ${
+            viewMode === key
+              ? "bg-gray-100 text-gray-900 dark:bg-gray-700 dark:text-white"
+              : "text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+          }`}
+        >
+          {icon}
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+
+  // --- Container Row (for list view with stack+product columns) ---
+  const ContainerRow = ({
+    c,
+    showStack,
+    showProduct,
+  }: {
+    c: Container;
+    showStack?: boolean;
+    showProduct?: boolean;
+  }) => {
+    const stackName = getStackName(c);
+    const ctx = getContextInfo(stackName);
+    const isOrphaned = stackName && ctx && !ctx.deploymentExists;
+
+    return (
+      <div className="grid grid-cols-6 border-t border-gray-200 dark:border-gray-700 px-4 py-3 sm:grid-cols-12 md:px-6 items-center">
+        <div
+          className={`${showStack || showProduct ? "col-span-2" : "col-span-3"} flex items-center min-w-0`}
+        >
+          <p className="text-sm text-gray-900 dark:text-white truncate">
+            {c.name}
+          </p>
+        </div>
+        {showStack && (
+          <div className="col-span-2 hidden sm:flex items-center gap-1.5 min-w-0">
+            <span className="text-sm text-gray-700 dark:text-gray-300 truncate">
+              {stackName || "-"}
+            </span>
+            {isOrphaned && <OrphanedBadge />}
+          </div>
+        )}
+        {showProduct && (
+          <div className="col-span-2 hidden sm:flex items-center min-w-0">
+            <span className="text-sm text-gray-700 dark:text-gray-300 truncate">
+              {ctx?.productDisplayName || "-"}
+            </span>
+          </div>
+        )}
+        <div className="col-span-2 hidden sm:flex items-center min-w-0">
+          <p className="text-sm text-gray-700 dark:text-gray-300 truncate">
+            {c.image}
+          </p>
+        </div>
+        <div className="col-span-1 flex items-center">
+          <StatusBadge state={c.state} healthStatus={c.healthStatus} />
+        </div>
+        <div className="col-span-1 flex items-center">
+          <PortDisplay c={c} />
+        </div>
+        <div className="col-span-2 flex items-center justify-end">
+          <ActionButtons c={c} />
+        </div>
+      </div>
+    );
+  };
+
+  // --- List Header ---
+  const ListHeader = ({
+    showStack,
+    showProduct,
+  }: {
+    showStack?: boolean;
+    showProduct?: boolean;
+  }) => (
+    <div className="grid grid-cols-6 px-4 py-3 sm:grid-cols-12 md:px-6 bg-gray-50 dark:bg-gray-800/50">
+      <div
+        className={`${showStack || showProduct ? "col-span-2" : "col-span-3"} flex items-center`}
+      >
+        <p className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
+          Name
+        </p>
+      </div>
+      {showStack && (
+        <div className="col-span-2 hidden sm:flex items-center">
+          <p className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
+            Stack
+          </p>
+        </div>
+      )}
+      {showProduct && (
+        <div className="col-span-2 hidden sm:flex items-center">
+          <p className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
+            Product
+          </p>
+        </div>
+      )}
+      <div className="col-span-2 hidden sm:flex items-center">
+        <p className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
+          Image
+        </p>
+      </div>
+      <div className="col-span-1 flex items-center">
+        <p className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
+          Status
+        </p>
+      </div>
+      <div className="col-span-1 flex items-center">
+        <p className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
+          Port
+        </p>
+      </div>
+      <div className="col-span-2 flex items-center justify-end">
+        <p className="text-xs font-medium uppercase text-gray-500 dark:text-gray-400">
+          Actions
+        </p>
+      </div>
+    </div>
+  );
+
+  // --- Stack Group Header ---
+  const StackGroupHeader = ({
+    title,
+    containers: groupContainers,
+    ctx,
+    isUnmanaged,
+  }: {
+    title: string;
+    containers: Container[];
+    ctx?: StackContextInfo;
+    isUnmanaged?: boolean;
+  }) => {
+    const runningCount = groupContainers.filter(
+      (c) => c.state.toLowerCase() === "running"
+    ).length;
+    const total = groupContainers.length;
+    const isOrphaned = ctx && !ctx.deploymentExists;
+
+    return (
+      <div className="flex items-center justify-between px-4 py-3 md:px-6 bg-gray-50 dark:bg-gray-800/50">
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+            {isUnmanaged ? "Unmanaged" : title}
+          </h3>
+          {isOrphaned && <OrphanedBadge />}
+        </div>
+        <span className="text-xs text-gray-500 dark:text-gray-400">
+          {runningCount === total
+            ? `${total} running`
+            : `${runningCount}/${total} running`}
+        </span>
+      </div>
+    );
+  };
+
+  // --- Compact header for containers within stack/product groups ---
+  const CompactHeader = () => (
+    <div className="grid grid-cols-6 px-4 py-2 sm:grid-cols-12 md:px-6 border-t border-gray-100 dark:border-gray-800">
+      <div className="col-span-3 flex items-center">
+        <p className="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">
+          Name
+        </p>
+      </div>
+      <div className="col-span-2 hidden sm:flex items-center">
+        <p className="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">
+          Image
+        </p>
+      </div>
+      <div className="col-span-1 flex items-center">
+        <p className="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">
+          Status
+        </p>
+      </div>
+      <div className="col-span-1 flex items-center">
+        <p className="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">
+          Port
+        </p>
+      </div>
+      <div className="col-span-2 hidden sm:flex" />
+      <div className="col-span-2 flex items-center justify-end">
+        <p className="text-xs font-medium uppercase text-gray-400 dark:text-gray-500">
+          Actions
+        </p>
+      </div>
+    </div>
+  );
+
+  // --- Compact Container Row (no stack/product columns) ---
+  const CompactContainerRow = ({ c }: { c: Container }) => (
+    <div className="grid grid-cols-6 border-t border-gray-100 dark:border-gray-800 px-4 py-2.5 sm:grid-cols-12 md:px-6 items-center">
+      <div className="col-span-3 flex items-center min-w-0">
+        <p className="text-sm text-gray-900 dark:text-white truncate">
+          {c.name}
+        </p>
+      </div>
+      <div className="col-span-2 hidden sm:flex items-center min-w-0">
+        <p className="text-sm text-gray-700 dark:text-gray-300 truncate">
+          {c.image}
+        </p>
+      </div>
+      <div className="col-span-1 flex items-center">
+        <StatusBadge state={c.state} healthStatus={c.healthStatus} />
+      </div>
+      <div className="col-span-1 flex items-center">
+        <PortDisplay c={c} />
+      </div>
+      <div className="col-span-2 hidden sm:flex" />
+      <div className="col-span-2 flex items-center justify-end">
+        <ActionButtons c={c} />
+      </div>
+    </div>
+  );
+
+  // --- Empty / Loading states ---
+  const EmptyState = () => (
+    <div className="px-4 py-8 md:px-6">
+      <p className="text-center text-sm text-gray-500 dark:text-gray-400">
+        No containers found. Make sure Docker is running.
+      </p>
+    </div>
+  );
+
+  const LoadingState = () => (
+    <div className="px-4 py-8 md:px-6">
+      <p className="text-center text-sm text-gray-500 dark:text-gray-400">
+        Loading containers...
+      </p>
+    </div>
+  );
+
+  // =========== VIEWS ===========
+
+  const ListView = () => (
+    <div className="rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03] overflow-hidden">
+      <ListHeader showStack showProduct />
+      {loading ? (
+        <LoadingState />
+      ) : containers.length === 0 ? (
+        <EmptyState />
+      ) : (
+        containers.map((c) => (
+          <ContainerRow key={c.id} c={c} showStack showProduct />
+        ))
+      )}
+    </div>
+  );
+
+  const StackView = () => {
+    const { managed, unmanaged } = groupedByStack;
+    const stackNames = Object.keys(managed).sort();
+
+    return (
+      <div className="space-y-4">
+        {loading ? (
+          <div className="rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03] overflow-hidden">
+            <LoadingState />
+          </div>
+        ) : containers.length === 0 ? (
+          <div className="rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03] overflow-hidden">
+            <EmptyState />
+          </div>
+        ) : (
+          <>
+            {stackNames.map((name) => (
+              <div
+                key={name}
+                className="rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03] overflow-hidden"
+              >
+                <StackGroupHeader
+                  title={name}
+                  containers={managed[name].containers}
+                  ctx={managed[name].context}
+                />
+                <CompactHeader />
+                {managed[name].containers.map((c) => (
+                  <CompactContainerRow key={c.id} c={c} />
+                ))}
+              </div>
+            ))}
+            {unmanaged.length > 0 && (
+              <div className="rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03] overflow-hidden">
+                <StackGroupHeader
+                  title="Unmanaged"
+                  containers={unmanaged}
+                  isUnmanaged
+                />
+                <CompactHeader />
+                {unmanaged.map((c) => (
+                  <CompactContainerRow key={c.id} c={c} />
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    );
+  };
+
+  const ProductView = () => {
+    const { products, unknownProduct, unmanaged } = groupedByProduct;
+    const productKeys = Object.keys(products).sort();
+    const unknownStacks = Object.keys(unknownProduct).sort();
+
+    return (
+      <div className="space-y-6">
+        {loading ? (
+          <div className="rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03] overflow-hidden">
+            <LoadingState />
+          </div>
+        ) : containers.length === 0 ? (
+          <div className="rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03] overflow-hidden">
+            <EmptyState />
+          </div>
+        ) : (
+          <>
+            {productKeys.map((productKey) => {
+              const product = products[productKey];
+              const stackNames = Object.keys(product.stacks).sort();
+              return (
+                <div
+                  key={productKey}
+                  className="rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03] overflow-hidden"
+                >
+                  <div className="px-4 py-3 md:px-6 bg-gray-100 dark:bg-gray-800">
+                    <h3 className="text-sm font-bold text-gray-900 dark:text-white">
+                      {product.displayName}
+                    </h3>
+                  </div>
+                  {stackNames.map((stackName) => {
+                    const stack = product.stacks[stackName];
+                    return (
+                      <div key={stackName}>
+                        <StackGroupHeader
+                          title={stackName}
+                          containers={stack.containers}
+                          ctx={stack.context}
+                        />
+                        <CompactHeader />
+                        {stack.containers.map((c) => (
+                          <CompactContainerRow key={c.id} c={c} />
+                        ))}
+                      </div>
+                    );
+                  })}
+                </div>
+              );
+            })}
+            {unknownStacks.length > 0 && (
+              <div className="rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03] overflow-hidden">
+                <div className="px-4 py-3 md:px-6 bg-gray-100 dark:bg-gray-800">
+                  <h3 className="text-sm font-bold text-gray-900 dark:text-white">
+                    Unknown Product
+                  </h3>
+                </div>
+                {unknownStacks.map((stackName) => {
+                  const stack = unknownProduct[stackName];
+                  return (
+                    <div key={stackName}>
+                      <StackGroupHeader
+                        title={stackName}
+                        containers={stack.containers}
+                        ctx={stack.context}
+                      />
+                      <CompactHeader />
+                      {stack.containers.map((c) => (
+                        <CompactContainerRow key={c.id} c={c} />
+                      ))}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+            {unmanaged.length > 0 && (
+              <div className="rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03] overflow-hidden">
+                <div className="px-4 py-3 md:px-6 bg-gray-100 dark:bg-gray-800">
+                  <h3 className="text-sm font-bold text-gray-900 dark:text-white">
+                    Unmanaged
+                  </h3>
+                </div>
+                <CompactHeader />
+                {unmanaged.map((c) => (
+                  <CompactContainerRow key={c.id} c={c} />
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    );
   };
 
   return (
@@ -127,15 +835,28 @@ export default function Containers() {
         <h2 className="text-2xl font-bold text-gray-900 dark:text-white">
           Container Management
         </h2>
-        <button
-          onClick={loadContainers}
-          className="inline-flex items-center justify-center gap-2 rounded-md bg-gray-100 px-6 py-3 text-center font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
-        >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-          </svg>
-          Refresh
-        </button>
+        <div className="flex items-center gap-3">
+          <ViewToggle />
+          <button
+            onClick={loadContainers}
+            className="inline-flex items-center justify-center gap-2 rounded-md bg-gray-100 px-6 py-3 text-center font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+              />
+            </svg>
+            Refresh
+          </button>
+        </div>
       </div>
 
       {error && (
@@ -144,94 +865,9 @@ export default function Containers() {
         </div>
       )}
 
-      <div className="flex flex-col gap-10">
-        <div className="rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03]">
-          <div className="px-4 py-6 md:px-6 xl:px-7.5">
-            <h4 className="text-xl font-semibold text-black dark:text-white">
-              All Containers
-            </h4>
-          </div>
-
-          <div className="grid grid-cols-6 border-t border-stroke px-4 py-4.5 dark:border-strokedark sm:grid-cols-8 md:px-6 2xl:px-7.5">
-            <div className="col-span-3 flex items-center">
-              <p className="font-medium text-gray-900 dark:text-gray-200">Container Name</p>
-            </div>
-            <div className="col-span-2 hidden items-center sm:flex">
-              <p className="font-medium text-gray-900 dark:text-gray-200">Image</p>
-            </div>
-            <div className="col-span-1 flex items-center">
-              <p className="font-medium text-gray-900 dark:text-gray-200">Status</p>
-            </div>
-            <div className="col-span-1 flex items-center">
-              <p className="font-medium text-gray-900 dark:text-gray-200">Port</p>
-            </div>
-            <div className="col-span-1 flex items-center">
-              <p className="font-medium text-gray-900 dark:text-gray-200">Actions</p>
-            </div>
-          </div>
-
-          {loading ? (
-            <div className="border-t border-stroke px-4 py-4.5 dark:border-strokedark md:px-6 2xl:px-7.5">
-              <p className="text-center text-sm text-gray-600 dark:text-gray-400">
-                Loading containers...
-              </p>
-            </div>
-          ) : containers.length === 0 ? (
-            <div className="border-t border-stroke px-4 py-4.5 dark:border-strokedark md:px-6 2xl:px-7.5">
-              <p className="text-center text-sm text-gray-600 dark:text-gray-400">
-                No containers found. Make sure Docker is running.
-              </p>
-            </div>
-          ) : (
-            containers.map((container) => (
-              <div
-                key={container.id}
-                className="grid grid-cols-6 border-t border-stroke px-4 py-4.5 dark:border-strokedark sm:grid-cols-8 md:px-6 2xl:px-7.5"
-              >
-                <div className="col-span-3 flex items-center">
-                  <p className="text-sm text-black dark:text-white">
-                    {container.name}
-                  </p>
-                </div>
-                <div className="col-span-2 hidden items-center sm:flex">
-                  <p className="text-sm text-black dark:text-white">
-                    {container.image}
-                  </p>
-                </div>
-                <div className="col-span-1 flex items-center">
-                  {getCombinedStatusBadge(container.state, container.healthStatus)}
-                </div>
-                <div className="col-span-1 flex items-center">
-                  <p className="text-sm text-black dark:text-white">
-                    {container.ports[0]
-                      ? `${container.ports[0].publicPort}:${container.ports[0].privatePort}`
-                      : "-"}
-                  </p>
-                </div>
-                <div className="col-span-1 flex items-center gap-2">
-                  {container.state.toLowerCase() === "running" ? (
-                    <button
-                      onClick={() => handleStop(container.id)}
-                      disabled={actionLoading === container.id}
-                      className="rounded bg-red-500 px-3 py-1 text-xs font-medium text-white hover:bg-red-600 disabled:opacity-50"
-                    >
-                      {actionLoading === container.id ? "..." : "Stop"}
-                    </button>
-                  ) : (
-                    <button
-                      onClick={() => handleStart(container.id)}
-                      disabled={actionLoading === container.id}
-                      className="rounded bg-green-500 px-3 py-1 text-xs font-medium text-white hover:bg-green-600 disabled:opacity-50"
-                    >
-                      {actionLoading === container.id ? "..." : "Start"}
-                    </button>
-                  )}
-                </div>
-              </div>
-            ))
-          )}
-        </div>
-      </div>
+      {viewMode === "list" && <ListView />}
+      {viewMode === "stacks" && <StackView />}
+      {viewMode === "products" && <ProductView />}
     </div>
   );
 }

--- a/tests/ReadyStackGo.UnitTests/Application/Containers/GetContainerContextHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Containers/GetContainerContextHandlerTests.cs
@@ -1,0 +1,251 @@
+using FluentAssertions;
+using Moq;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Application.UseCases.Containers;
+using ReadyStackGo.Application.UseCases.Containers.GetContainerContext;
+using ReadyStackGo.Domain.Deployment.Deployments;
+using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.Deployment;
+using ReadyStackGo.Domain.StackManagement.Stacks;
+
+namespace ReadyStackGo.UnitTests.Application.Containers;
+
+public class GetContainerContextHandlerTests
+{
+    private readonly Mock<IDockerService> _dockerServiceMock;
+    private readonly Mock<IDeploymentRepository> _deploymentRepositoryMock;
+    private readonly Mock<IProductCache> _productCacheMock;
+    private readonly GetContainerContextHandler _handler;
+
+    private static readonly Guid EnvGuid = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    private static readonly string EnvId = EnvGuid.ToString();
+    private static readonly EnvironmentId EnvironmentId = new(EnvGuid);
+
+    public GetContainerContextHandlerTests()
+    {
+        _dockerServiceMock = new Mock<IDockerService>();
+        _deploymentRepositoryMock = new Mock<IDeploymentRepository>();
+        _productCacheMock = new Mock<IProductCache>();
+        _handler = new GetContainerContextHandler(
+            _dockerServiceMock.Object,
+            _deploymentRepositoryMock.Object,
+            _productCacheMock.Object);
+    }
+
+    private static ContainerDto MakeContainer(string id, string name, Dictionary<string, string>? labels = null) =>
+        new() { Id = id, Name = name, Image = "test:latest", State = "running", Status = "Up 2 hours", Labels = labels ?? new() };
+
+    private static Deployment MakeDeployment(string stackName, string stackId)
+    {
+        return Deployment.StartInstallation(
+            new DeploymentId(Guid.NewGuid()),
+            EnvironmentId,
+            stackId,
+            stackName,
+            $"project-{stackName}",
+            UserId.Create());
+    }
+
+    [Fact]
+    public async Task Handle_AllStacksHaveDeployments_AllContextsPopulated()
+    {
+        var containers = new[]
+        {
+            MakeContainer("c1", "wp-app", new() { ["rsgo.stack"] = "wordpress" }),
+            MakeContainer("c2", "wp-db", new() { ["rsgo.stack"] = "wordpress" }),
+            MakeContainer("c3", "redis-1", new() { ["rsgo.stack"] = "redis" }),
+        };
+        _dockerServiceMock
+            .Setup(s => s.ListContainersAsync(EnvId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(containers);
+
+        var wpDeployment = MakeDeployment("wordpress", "source1:wordpress-product:wordpress");
+        var redisDeployment = MakeDeployment("redis", "source1:redis-product:redis");
+        _deploymentRepositoryMock
+            .Setup(r => r.GetByStackName(EnvironmentId, "wordpress")).Returns(wpDeployment);
+        _deploymentRepositoryMock
+            .Setup(r => r.GetByStackName(EnvironmentId, "redis")).Returns(redisDeployment);
+
+        var wpStack = new StackDefinition("source1", "wordpress", ProductId.FromName("wordpress-product"),
+            productName: "WordPress", productDisplayName: "WordPress CMS");
+        var redisStack = new StackDefinition("source1", "redis", ProductId.FromName("redis-product"),
+            productName: "Redis", productDisplayName: "Redis Cache");
+        _productCacheMock.Setup(c => c.GetStack("source1:wordpress-product:wordpress")).Returns(wpStack);
+        _productCacheMock.Setup(c => c.GetStack("source1:redis-product:redis")).Returns(redisStack);
+
+        var result = await _handler.Handle(new GetContainerContextQuery(EnvId), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Stacks.Should().HaveCount(2);
+        result.Stacks["wordpress"].DeploymentExists.Should().BeTrue();
+        result.Stacks["wordpress"].ProductDisplayName.Should().Be("WordPress CMS");
+        result.Stacks["redis"].DeploymentExists.Should().BeTrue();
+        result.Stacks["redis"].ProductDisplayName.Should().Be("Redis Cache");
+    }
+
+    [Fact]
+    public async Task Handle_ContainersWithoutLabels_NotIncludedInStacks()
+    {
+        var containers = new[]
+        {
+            MakeContainer("c1", "wp-app", new() { ["rsgo.stack"] = "wordpress" }),
+            MakeContainer("c2", "portainer", new() { ["other.label"] = "value" }),
+            MakeContainer("c3", "traefik"),
+        };
+        _dockerServiceMock
+            .Setup(s => s.ListContainersAsync(EnvId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(containers);
+
+        _deploymentRepositoryMock
+            .Setup(r => r.GetByStackName(EnvironmentId, "wordpress"))
+            .Returns(MakeDeployment("wordpress", "src:wp:wordpress"));
+        _productCacheMock
+            .Setup(c => c.GetStack(It.IsAny<string>()))
+            .Returns((StackDefinition?)null);
+
+        var result = await _handler.Handle(new GetContainerContextQuery(EnvId), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Stacks.Should().HaveCount(1);
+        result.Stacks.Should().ContainKey("wordpress");
+    }
+
+    [Fact]
+    public async Task Handle_StackWithoutDeployment_DeploymentExistsFalse()
+    {
+        var containers = new[]
+        {
+            MakeContainer("c1", "orphan-app", new() { ["rsgo.stack"] = "orphan-stack" }),
+        };
+        _dockerServiceMock
+            .Setup(s => s.ListContainersAsync(EnvId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(containers);
+
+        _deploymentRepositoryMock
+            .Setup(r => r.GetByStackName(EnvironmentId, "orphan-stack"))
+            .Returns((Deployment?)null);
+
+        var result = await _handler.Handle(new GetContainerContextQuery(EnvId), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Stacks["orphan-stack"].DeploymentExists.Should().BeFalse();
+        result.Stacks["orphan-stack"].DeploymentId.Should().BeNull();
+        result.Stacks["orphan-stack"].ProductName.Should().BeNull();
+        result.Stacks["orphan-stack"].ProductDisplayName.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_StackWithDeployment_ProductInfoResolved()
+    {
+        var containers = new[]
+        {
+            MakeContainer("c1", "app", new() { ["rsgo.stack"] = "mystack" }),
+        };
+        _dockerServiceMock
+            .Setup(s => s.ListContainersAsync(EnvId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(containers);
+
+        var deployment = MakeDeployment("mystack", "local:myproduct:mystack");
+        _deploymentRepositoryMock
+            .Setup(r => r.GetByStackName(EnvironmentId, "mystack")).Returns(deployment);
+
+        var stackDef = new StackDefinition("local", "mystack", ProductId.FromName("myproduct"),
+            productName: "MyProduct", productDisplayName: "My Product Display");
+        _productCacheMock.Setup(c => c.GetStack("local:myproduct:mystack")).Returns(stackDef);
+
+        var result = await _handler.Handle(new GetContainerContextQuery(EnvId), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Stacks["mystack"].DeploymentExists.Should().BeTrue();
+        result.Stacks["mystack"].ProductName.Should().Be("MyProduct");
+        result.Stacks["mystack"].ProductDisplayName.Should().Be("My Product Display");
+        result.Stacks["mystack"].DeploymentId.Should().Be(deployment.Id.ToString());
+    }
+
+    [Fact]
+    public async Task Handle_StackWithDeployment_ProductNotInCache_ProductNameNull()
+    {
+        var containers = new[]
+        {
+            MakeContainer("c1", "app", new() { ["rsgo.stack"] = "mystack" }),
+        };
+        _dockerServiceMock
+            .Setup(s => s.ListContainersAsync(EnvId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(containers);
+
+        var deployment = MakeDeployment("mystack", "local:myproduct:mystack");
+        _deploymentRepositoryMock
+            .Setup(r => r.GetByStackName(EnvironmentId, "mystack")).Returns(deployment);
+
+        _productCacheMock.Setup(c => c.GetStack("local:myproduct:mystack")).Returns((StackDefinition?)null);
+
+        var result = await _handler.Handle(new GetContainerContextQuery(EnvId), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Stacks["mystack"].DeploymentExists.Should().BeTrue();
+        result.Stacks["mystack"].ProductName.Should().BeNull();
+        result.Stacks["mystack"].ProductDisplayName.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_DockerServiceThrows_ReturnsError()
+    {
+        _dockerServiceMock
+            .Setup(s => s.ListContainersAsync(EnvId, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Docker not available"));
+
+        var result = await _handler.Handle(new GetContainerContextQuery(EnvId), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Docker not available");
+    }
+
+    [Theory]
+    [InlineData("not-a-guid")]
+    [InlineData("")]
+    [InlineData("12345")]
+    public async Task Handle_InvalidEnvironmentId_ReturnsError(string invalidEnvId)
+    {
+        var result = await _handler.Handle(new GetContainerContextQuery(invalidEnvId), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Invalid environment ID");
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateStackLabels_DeduplicatedCorrectly()
+    {
+        var containers = new[]
+        {
+            MakeContainer("c1", "wp-app", new() { ["rsgo.stack"] = "wordpress" }),
+            MakeContainer("c2", "wp-db", new() { ["rsgo.stack"] = "wordpress" }),
+            MakeContainer("c3", "wp-cache", new() { ["rsgo.stack"] = "WordPress" }),
+        };
+        _dockerServiceMock
+            .Setup(s => s.ListContainersAsync(EnvId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(containers);
+
+        _deploymentRepositoryMock
+            .Setup(r => r.GetByStackName(EnvironmentId, It.IsAny<string>()))
+            .Returns((Deployment?)null);
+
+        var result = await _handler.Handle(new GetContainerContextQuery(EnvId), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        // "wordpress" and "WordPress" should be deduplicated (case-insensitive)
+        result.Stacks.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Handle_NoContainers_ReturnsEmptyStacks()
+    {
+        _dockerServiceMock
+            .Setup(s => s.ListContainersAsync(EnvId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ContainerDto>());
+
+        var result = await _handler.Handle(new GetContainerContextQuery(EnvId), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Stacks.Should().BeEmpty();
+    }
+}

--- a/tests/ReadyStackGo.UnitTests/Application/Containers/RemoveContainerHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Containers/RemoveContainerHandlerTests.cs
@@ -1,0 +1,116 @@
+using FluentAssertions;
+using Moq;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Application.UseCases.Containers;
+using ReadyStackGo.Application.UseCases.Containers.RemoveContainer;
+
+namespace ReadyStackGo.UnitTests.Application.Containers;
+
+public class RemoveContainerHandlerTests
+{
+    private readonly Mock<IDockerService> _dockerServiceMock;
+    private readonly RemoveContainerHandler _handler;
+
+    public RemoveContainerHandlerTests()
+    {
+        _dockerServiceMock = new Mock<IDockerService>();
+        _handler = new RemoveContainerHandler(_dockerServiceMock.Object);
+    }
+
+    private static ContainerDto MakeContainer(string id, string name, string state = "exited") =>
+        new() { Id = id, Name = name, Image = "test:latest", State = state, Status = $"Exited (0)" };
+
+    [Fact]
+    public async Task Handle_StoppedContainer_ReturnsSuccess()
+    {
+        _dockerServiceMock
+            .Setup(s => s.ListContainersAsync("env-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { MakeContainer("c1", "app", "exited") });
+
+        var result = await _handler.Handle(
+            new RemoveContainerCommand("env-1", "c1"), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _dockerServiceMock.Verify(
+            s => s.RemoveContainerAsync("env-1", "c1", false, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_RunningContainer_WithoutForce_ReturnsError()
+    {
+        _dockerServiceMock
+            .Setup(s => s.ListContainersAsync("env-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { MakeContainer("c1", "app", "running") });
+
+        var result = await _handler.Handle(
+            new RemoveContainerCommand("env-1", "c1"), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("running");
+        _dockerServiceMock.Verify(
+            s => s.RemoveContainerAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_RunningContainer_WithForce_ReturnsSuccess()
+    {
+        var result = await _handler.Handle(
+            new RemoveContainerCommand("env-1", "c1", Force: true), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _dockerServiceMock.Verify(
+            s => s.RemoveContainerAsync("env-1", "c1", true, It.IsAny<CancellationToken>()), Times.Once);
+        // Force skips the container list check entirely
+        _dockerServiceMock.Verify(
+            s => s.ListContainersAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_NonExistentContainer_ReturnsError()
+    {
+        _dockerServiceMock
+            .Setup(s => s.ListContainersAsync("env-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { MakeContainer("other", "other-app") });
+
+        var result = await _handler.Handle(
+            new RemoveContainerCommand("env-1", "c1"), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("not found");
+    }
+
+    [Fact]
+    public async Task Handle_DockerServiceThrows_ReturnsError()
+    {
+        _dockerServiceMock
+            .Setup(s => s.ListContainersAsync("env-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { MakeContainer("c1", "app", "exited") });
+        _dockerServiceMock
+            .Setup(s => s.RemoveContainerAsync("env-1", "c1", false, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Docker daemon error"));
+
+        var result = await _handler.Handle(
+            new RemoveContainerCommand("env-1", "c1"), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("Docker daemon error");
+    }
+
+    [Theory]
+    [InlineData("Running")]
+    [InlineData("RUNNING")]
+    [InlineData("running")]
+    public async Task Handle_RunningStateIsCaseInsensitive(string state)
+    {
+        _dockerServiceMock
+            .Setup(s => s.ListContainersAsync("env-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { MakeContainer("c1", "app", state) });
+
+        var result = await _handler.Handle(
+            new RemoveContainerCommand("env-1", "c1"), CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("running");
+    }
+}


### PR DESCRIPTION
## Summary

- Add **RemoveContainer** use case with `DELETE /api/containers/{id}` endpoint, supporting force-remove for running containers
- Add **GetContainerContext** endpoint (`GET /api/containers/context`) providing stack-to-product enrichment data
- Redesign Container Management page with **three switchable views**: List, Stack, and Product
- Replace solid red/green Start/Stop buttons with **subtle icon buttons** (play, stop, trash)
- Add **inline remove confirmation** with force-remove warning for running containers
- Show **Stack** and **Product** columns in list view with **orphaned badge** for containers with rsgo labels but no deployment
- Group containers by stack or product in grouped views, with **Unmanaged** group for external containers
- 19 new unit tests covering RemoveContainerHandler and GetContainerContextHandler

## Test plan

- [ ] `dotnet build` passes with 0 errors, 0 warnings (excluding pre-existing)
- [ ] All 1886 unit tests pass
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] List view shows Name, Stack, Product, Image, Status, Port, Actions columns
- [ ] Stack view groups containers by rsgo.stack label with running count
- [ ] Product view groups stacks under product names
- [ ] Containers without rsgo labels appear in "Unmanaged" group
- [ ] Orphaned containers (rsgo label, no deployment) show amber "orphaned" badge
- [ ] Start/Stop icons work correctly, show spinner during action
- [ ] Remove shows inline confirmation; running containers get "Force remove?" prompt
- [ ] View toggle (List/Stacks/Products) switches between views