### PR TITLE
Add ams.project stacks to source registry catalog

### DIFF
--- a/src/ReadyStackGo.Infrastructure/Services/StackSources/source-registry.json
+++ b/src/ReadyStackGo.Infrastructure/Services/StackSources/source-registry.json
@@ -24,5 +24,17 @@
     "tags": ["community", "official", "curated"],
     "featured": true,
     "stackCount": 1
+  },
+  {
+    "id": "rsgo-ams-project-stacks",
+    "name": "ams.project Stacks",
+    "description": "Enterprise project management stacks by ams.Solution AG (ams.project, ams.identityaccess)",
+    "type": "git-repository",
+    "gitUrl": "https://github.com/Wiesenwischer/rsgo-ams-project-stacks.git",
+    "gitBranch": "main",
+    "category": "vendor",
+    "tags": ["enterprise", "vendor", "ams"],
+    "featured": false,
+    "stackCount": 2
   }
 ]

--- a/tests/ReadyStackGo.UnitTests/Services/SourceRegistryServiceTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Services/SourceRegistryServiceTests.cs
@@ -88,6 +88,32 @@ public class SourceRegistryServiceTests
     }
 
     [Fact]
+    public void GetAll_ContainsAmsProjectStacksEntry()
+    {
+        var service = CreateService();
+
+        var entries = service.GetAll();
+
+        entries.Should().Contain(e => e.Id == "rsgo-ams-project-stacks");
+    }
+
+    [Fact]
+    public void GetAll_AmsProjectStacksHasCorrectData()
+    {
+        var service = CreateService();
+
+        var entry = service.GetAll().First(e => e.Id == "rsgo-ams-project-stacks");
+
+        entry.Name.Should().Be("ams.project Stacks");
+        entry.GitUrl.Should().Contain("github.com/Wiesenwischer/rsgo-ams-project-stacks");
+        entry.GitBranch.Should().Be("main");
+        entry.Category.Should().Be("vendor");
+        entry.Featured.Should().BeFalse();
+        entry.Tags.Should().Contain("vendor");
+        entry.Tags.Should().Contain("ams");
+    }
+
+    [Fact]
     public void GetAll_AllGitUrlsAreValidUris()
     {
         var service = CreateService();


### PR DESCRIPTION
## Summary
- Created new GitHub repo [rsgo-ams-project-stacks](https://github.com/Wiesenwischer/rsgo-ams-project-stacks) with stack definitions for ams.project (v3.1.0-pre) and ams.identityaccess (v3.1.0-pre) by ams.Solution AG
- Added the repo as a `vendor` category catalog source in `source-registry.json` (not featured, opt-in via wizard or Settings > Stack Sources > From Catalog)
- Added unit tests for the new registry entry

## Test plan
- [ ] `dotnet build` passes with 0 errors
- [ ] `SourceRegistryServiceTests` all pass (13 tests including 2 new)
- [ ] Wizard shows ams.project stacks as selectable source
- [ ] Settings > Stack Sources > Add > From Catalog lists ams.project stacks