### PR TITLE
Add product deployments section to deployments overview

### DIFF
--- a/docs/Plans/PLAN-deployments-overview-product-info.md
+++ b/docs/Plans/PLAN-deployments-overview-product-info.md
@@ -18,9 +18,8 @@ Die Deployments-Übersicht zeigt aktuell nur einzelne Stack-Deployments. Product
 - `Deployments.tsx` zeigt nur Stack-Deployments via `listDeployments()`
 - Keine Product-Deployment-Integration in der Overview
 
-**Bereits implementiert (in dieser Session):**
+**Bereits implementiert (PR #151):**
 - Product-Level `DeploymentName` Refactoring — Single DeploymentName statt per-Stack Names
-- Backend, Frontend, Tests sind bereits fertig — noch nicht committed
 
 ### Betroffene Bounded Contexts
 - **Domain**: Keine Änderungen
@@ -33,34 +32,28 @@ Die Deployments-Übersicht zeigt aktuell nur einzelne Stack-Deployments. Product
 
 Reihenfolge basierend auf Abhängigkeiten:
 
-- [ ] **Feature 1: Product-Level DeploymentName** – Bereits implementiert in dieser Session
-  - Betroffene Dateien: Domain, Application, API, EF Core, Frontend, Tests (alle bereits geändert)
+- [x] **Feature 1: Product-Level DeploymentName** – Implemented in PR #151
+  - Betroffene Dateien: Domain, Application, API, EF Core, Frontend, Tests
   - Abhängig von: -
 
-- [ ] **Feature 2: Frontend API Funktion `listProductDeployments()`** – Neue Funktion + TypeScript Interface
+- [x] **Feature 2: Frontend API Funktion `listProductDeployments()`** – Neue Funktion + TypeScript Interface
   - Betroffene Dateien:
     - `src/ReadyStackGo.WebUi/src/api/deployments.ts` — `listProductDeployments()` Funktion + `ListProductDeploymentsResponse`, `ProductDeploymentSummaryDto` Interfaces
-  - Pattern-Vorlage: `listDeployments()` in gleicher Datei (Zeile 134-136)
   - Abhängig von: -
 
-- [ ] **Feature 3: Product Deployments Sektion in Deployments.tsx** – Neue Sektion oberhalb der Stack-Liste
+- [x] **Feature 3: Product Deployments Sektion in Deployments.tsx** – Neue Sektion oberhalb der Stack-Liste
   - Betroffene Dateien:
     - `src/ReadyStackGo.WebUi/src/pages/Deployments/Deployments.tsx` — Product Deployment Cards rendern
-  - Layout:
-    - "Product Deployments" Überschrift (analog zu "Deployed Stacks")
-    - Product Cards mit: ProductDisplayName, Version-Badge, Status-Badge, DeploymentName (mono), Stack-Fortschritt (3/5 stacks), Aktionen
-    - Status-Farben: Running=Grün, Deploying/Upgrading=Brand, Failed=Rot, PartiallyRunning=Gelb
-    - Aktionen: "Details" → `/catalog/{productId}`, "Upgrade" (wenn `canUpgrade`), "Remove" (wenn `canRemove`)
-    - Empty State: "No product deployments" mit Link zum Catalog
-  - Pattern-Vorlage: `DeploymentRow` Komponente in gleicher Datei
+  - Layout: ProductDisplayName, Version-Badge, Status-Badge, DeploymentName (mono), Stack-Fortschritt, Aktionen
+  - Status-Farben: Running=Grün, Deploying/Upgrading=Brand, Failed=Rot, PartiallyRunning=Gelb
+  - Aktionen: "Details" → `/catalog/{groupId}`, "Upgrade" (canUpgrade), "Remove" (canRemove)
+  - Sektion nur sichtbar wenn mindestens 1 Product Deployment existiert
   - Abhängig von: Feature 2
 
-- [ ] **Feature 4: Seitenüberschrift anpassen** – Text von "deployed stacks" auf "deployments" generalisieren
-  - Betroffene Dateien:
-    - `src/ReadyStackGo.WebUi/src/pages/Deployments/Deployments.tsx` — Subtitle-Text anpassen
+- [x] **Feature 4: Seitenüberschrift anpassen** – Subtitle von "deployed stacks" auf "deployments" generalisiert
   - Abhängig von: Feature 3
 
-- [ ] **Phase abschließen** – Build, Tests, Commit, PR gegen main
+- [x] **Phase abschließen** – Build, Tests, Commit, PR gegen main
 
 ## Test-Strategie
 - **Unit Tests**: Keine neuen Backend-Tests nötig (API existiert bereits)

--- a/docs/Reference/Roadmap.md
+++ b/docs/Reference/Roadmap.md
@@ -210,7 +210,7 @@ Release version numbers are assigned when an Epic ships, not during planning.
   - Product Deployment E2E Tests with Multi-Stack Test Product
   - Step-by-Step Documentation with Screenshots (DE/EN)
 
-- **v0.28** – Deployments Overview with Product Info
+- **v0.28** – Deployments Overview with Product Info (2026-02-25)
   - Product Deployments Section in Deployments Overview (Above Stack Deployments)
   - Product Deployment Cards (Name, Version, Status, Stack Progress, Actions)
   - Frontend `listProductDeployments()` API Function (Missing in v0.27)

--- a/src/ReadyStackGo.WebUi/src/api/deployments.ts
+++ b/src/ReadyStackGo.WebUi/src/api/deployments.ts
@@ -135,6 +135,37 @@ export async function listDeployments(environmentId: string): Promise<ListDeploy
   return apiGet<ListDeploymentsResponse>(`/api/environments/${environmentId}/deployments`);
 }
 
+// ============================================================================
+// List Product Deployments API
+// ============================================================================
+
+export interface ProductDeploymentSummaryDto {
+  productDeploymentId: string;
+  productGroupId: string;
+  productName: string;
+  productDisplayName: string;
+  productVersion: string;
+  deploymentName: string;
+  status: string;
+  createdAt: string;
+  completedAt?: string;
+  errorMessage?: string;
+  totalStacks: number;
+  completedStacks: number;
+  failedStacks: number;
+  canUpgrade: boolean;
+  canRemove: boolean;
+}
+
+export interface ListProductDeploymentsResponse {
+  success: boolean;
+  productDeployments: ProductDeploymentSummaryDto[];
+}
+
+export async function listProductDeployments(environmentId: string): Promise<ListProductDeploymentsResponse> {
+  return apiGet<ListProductDeploymentsResponse>(`/api/environments/${environmentId}/product-deployments`);
+}
+
 export async function getDeployment(environmentId: string, deploymentId: string): Promise<GetDeploymentResponse> {
   return apiGet<GetDeploymentResponse>(`/api/environments/${environmentId}/deployments/${deploymentId}`);
 }

--- a/src/ReadyStackGo.WebUi/src/pages/Deployments/Deployments.tsx
+++ b/src/ReadyStackGo.WebUi/src/pages/Deployments/Deployments.tsx
@@ -1,6 +1,11 @@
 import { useEffect, useState, useCallback } from "react";
 import { Link } from "react-router";
-import { listDeployments, type DeploymentSummary } from "../../api/deployments";
+import {
+  listDeployments,
+  listProductDeployments,
+  type DeploymentSummary,
+  type ProductDeploymentSummaryDto,
+} from "../../api/deployments";
 import { useEnvironment } from "../../context/EnvironmentContext";
 import { useHealthHub } from "../../hooks/useHealthHub";
 import {
@@ -12,6 +17,7 @@ import {
 export default function Deployments() {
   const { activeEnvironment } = useEnvironment();
   const [deployments, setDeployments] = useState<DeploymentSummary[]>([]);
+  const [productDeployments, setProductDeployments] = useState<ProductDeploymentSummaryDto[]>([]);
   const [healthData, setHealthData] = useState<Map<string, StackHealthSummaryDto>>(new Map());
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -48,6 +54,7 @@ export default function Deployments() {
   const loadDeployments = useCallback(async () => {
     if (!activeEnvironment) {
       setDeployments([]);
+      setProductDeployments([]);
       setLoading(false);
       return;
     }
@@ -55,11 +62,17 @@ export default function Deployments() {
     try {
       setLoading(true);
       setError(null);
-      const response = await listDeployments(activeEnvironment.id);
-      if (response.success) {
-        setDeployments(response.deployments);
+      const [stackResponse, productResponse] = await Promise.all([
+        listDeployments(activeEnvironment.id),
+        listProductDeployments(activeEnvironment.id),
+      ]);
+      if (stackResponse.success) {
+        setDeployments(stackResponse.deployments);
       } else {
         setError("Failed to load deployments");
+      }
+      if (productResponse.success) {
+        setProductDeployments(productResponse.productDeployments);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load deployments");
@@ -104,6 +117,8 @@ export default function Deployments() {
     }
   };
 
+  const hasNoDeployments = !loading && activeEnvironment && deployments.length === 0 && productDeployments.length === 0;
+
   return (
     <div className="mx-auto max-w-screen-2xl p-4 md:p-6 2xl:p-10">
       <div className="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -112,7 +127,7 @@ export default function Deployments() {
             Deployments
           </h2>
           <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-            Monitor and manage deployed stacks {activeEnvironment && `in ${activeEnvironment.name}`}
+            Monitor and manage deployments {activeEnvironment && `in ${activeEnvironment.name}`}
           </p>
         </div>
         <div className="flex items-center gap-4">
@@ -143,61 +158,185 @@ export default function Deployments() {
         </div>
       )}
 
-      <div className="rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03]">
-        <div className="px-4 py-6 md:px-6 xl:px-7.5">
-          <h4 className="text-xl font-semibold text-black dark:text-white">
-            Deployed Stacks
-          </h4>
+      {loading ? (
+        <div className="rounded-2xl border border-gray-200 bg-white px-4 py-8 dark:border-gray-800 dark:bg-white/[0.03]">
+          <p className="text-center text-sm text-gray-600 dark:text-gray-400">
+            Loading deployments...
+          </p>
+        </div>
+      ) : !activeEnvironment ? (
+        <div className="rounded-2xl border border-gray-200 bg-white px-4 py-8 dark:border-gray-800 dark:bg-white/[0.03]">
+          <p className="text-center text-sm text-gray-600 dark:text-gray-400">
+            Select an environment to view deployments.
+          </p>
+        </div>
+      ) : hasNoDeployments ? (
+        <div className="rounded-2xl border border-gray-200 bg-white px-4 py-8 dark:border-gray-800 dark:bg-white/[0.03]">
+          <div className="text-center">
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+              No deployments in this environment.
+            </p>
+            <Link
+              to="/catalog"
+              className="inline-flex items-center gap-2 text-brand-600 hover:text-brand-700 dark:text-brand-400"
+            >
+              Browse Catalog
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </Link>
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-6">
+          {/* Product Deployments Section */}
+          {productDeployments.length > 0 && (
+            <div className="rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03]">
+              <div className="px-4 py-6 md:px-6 xl:px-7.5">
+                <h4 className="text-xl font-semibold text-black dark:text-white">
+                  Product Deployments
+                </h4>
+              </div>
+              <div className="border-t border-stroke dark:border-strokedark">
+                {productDeployments.map((pd) => (
+                  <ProductDeploymentRow
+                    key={pd.productDeploymentId}
+                    deployment={pd}
+                    formatDate={formatDate}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Stack Deployments Section */}
+          {deployments.length > 0 && (
+            <div className="rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03]">
+              <div className="px-4 py-6 md:px-6 xl:px-7.5">
+                <h4 className="text-xl font-semibold text-black dark:text-white">
+                  Deployed Stacks
+                </h4>
+              </div>
+              <div className="border-t border-stroke dark:border-strokedark">
+                {deployments.map((deployment) => {
+                  const health = healthData.get(deployment.deploymentId || '');
+                  return (
+                    <DeploymentRow
+                      key={deployment.deploymentId || deployment.stackName}
+                      deployment={deployment}
+                      health={health}
+                      formatDate={formatDate}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Product Deployment Row
+// ============================================================================
+
+function getProductStatusPresentation(status: string) {
+  switch (status) {
+    case 'Running':
+      return { label: 'Running', bgColor: 'bg-green-100 dark:bg-green-900/30', textColor: 'text-green-800 dark:text-green-300' };
+    case 'Deploying':
+    case 'Upgrading':
+      return { label: status, bgColor: 'bg-brand-100 dark:bg-brand-900/30', textColor: 'text-brand-800 dark:text-brand-300' };
+    case 'Failed':
+      return { label: 'Failed', bgColor: 'bg-red-100 dark:bg-red-900/30', textColor: 'text-red-800 dark:text-red-300' };
+    case 'PartiallyRunning':
+      return { label: 'Partially Running', bgColor: 'bg-yellow-100 dark:bg-yellow-900/30', textColor: 'text-yellow-800 dark:text-yellow-300' };
+    case 'Removing':
+      return { label: 'Removing', bgColor: 'bg-gray-100 dark:bg-gray-700', textColor: 'text-gray-700 dark:text-gray-300' };
+    default:
+      return { label: status, bgColor: 'bg-gray-100 dark:bg-gray-700', textColor: 'text-gray-700 dark:text-gray-300' };
+  }
+}
+
+interface ProductDeploymentRowProps {
+  deployment: ProductDeploymentSummaryDto;
+  formatDate: (date: string) => string;
+}
+
+function ProductDeploymentRow({ deployment, formatDate }: ProductDeploymentRowProps) {
+  const status = getProductStatusPresentation(deployment.status);
+
+  return (
+    <div className="px-4 py-4 md:px-6 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors">
+      <div className="flex items-center justify-between gap-4">
+        {/* Product Info */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-3">
+            <h5 className="font-semibold text-gray-900 dark:text-white truncate">
+              {deployment.productDisplayName}
+            </h5>
+            <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+              v{deployment.productVersion}
+            </span>
+            <span className={`inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium ${status.bgColor} ${status.textColor}`}>
+              {status.label}
+            </span>
+          </div>
+          <div className="mt-1 flex items-center gap-4 text-sm text-gray-500 dark:text-gray-400">
+            <span className="font-mono text-xs">{deployment.deploymentName}</span>
+            <span>•</span>
+            <span>{deployment.completedStacks}/{deployment.totalStacks} stacks</span>
+            {deployment.failedStacks > 0 && (
+              <>
+                <span>•</span>
+                <span className="text-red-600 dark:text-red-400">{deployment.failedStacks} failed</span>
+              </>
+            )}
+            <span>•</span>
+            <span>Deployed {formatDate(deployment.createdAt)}</span>
+          </div>
+          {deployment.errorMessage && (
+            <p className="mt-1 text-xs text-red-600 dark:text-red-400">
+              {deployment.errorMessage}
+            </p>
+          )}
         </div>
 
-        {loading ? (
-          <div className="border-t border-stroke px-4 py-8 dark:border-strokedark">
-            <p className="text-center text-sm text-gray-600 dark:text-gray-400">
-              Loading deployments...
-            </p>
-          </div>
-        ) : !activeEnvironment ? (
-          <div className="border-t border-stroke px-4 py-8 dark:border-strokedark">
-            <p className="text-center text-sm text-gray-600 dark:text-gray-400">
-              Select an environment to view deployments.
-            </p>
-          </div>
-        ) : deployments.length === 0 ? (
-          <div className="border-t border-stroke px-4 py-8 dark:border-strokedark">
-            <div className="text-center">
-              <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
-                No deployments in this environment.
-              </p>
-              <Link
-                to="/catalog"
-                className="inline-flex items-center gap-2 text-brand-600 hover:text-brand-700 dark:text-brand-400"
-              >
-                Browse Stack Catalog
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                </svg>
-              </Link>
-            </div>
-          </div>
-        ) : (
-          <div className="border-t border-stroke dark:border-strokedark">
-            {deployments.map((deployment) => {
-              const health = healthData.get(deployment.deploymentId || '');
-              return (
-                <DeploymentRow
-                  key={deployment.deploymentId || deployment.stackName}
-                  deployment={deployment}
-                  health={health}
-                  formatDate={formatDate}
-                />
-              );
-            })}
-          </div>
-        )}
+        {/* Actions */}
+        <div className="flex items-center gap-2">
+          <Link
+            to={`/catalog/${encodeURIComponent(deployment.productGroupId)}`}
+            className="inline-flex items-center justify-center rounded bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+          >
+            Details
+          </Link>
+          {deployment.canUpgrade && (
+            <Link
+              to={`/upgrade-product/${deployment.productDeploymentId}`}
+              className="inline-flex items-center justify-center rounded bg-brand-100 px-3 py-1.5 text-sm font-medium text-brand-700 hover:bg-brand-200 dark:bg-brand-900/30 dark:text-brand-400 dark:hover:bg-brand-900/50"
+            >
+              Upgrade
+            </Link>
+          )}
+          {deployment.canRemove && (
+            <Link
+              to={`/remove-product/${deployment.productDeploymentId}`}
+              className="inline-flex items-center justify-center rounded bg-red-100 px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-200 dark:bg-red-900/30 dark:text-red-400 dark:hover:bg-red-900/50"
+            >
+              Remove
+            </Link>
+          )}
+        </div>
       </div>
     </div>
   );
 }
+
+// ============================================================================
+// Stack Deployment Row
+// ============================================================================
 
 interface DeploymentRowProps {
   deployment: DeploymentSummary;


### PR DESCRIPTION
## Summary
- Add `listProductDeployments()` API function + `ProductDeploymentSummaryDto` TypeScript interface
- Add "Product Deployments" section above "Deployed Stacks" in the deployments overview
- Product cards show display name, version badge, status badge, deployment name, stack progress, and actions (Details/Upgrade/Remove)
- Status colors: Running=Green, Deploying/Upgrading=Brand, Failed=Red, PartiallyRunning=Yellow
- Section only visible when product deployments exist
- Update subtitle from "deployed stacks" to "deployments"
- Mark v0.28 as released in roadmap

## Test plan
- [ ] Deploy a product, verify it appears in the Product Deployments section
- [ ] Verify status badges show correct colors for Running/Failed states
- [ ] Verify Upgrade/Remove buttons only appear when canUpgrade/canRemove is true
- [ ] Verify Details link navigates to `/catalog/{groupId}`
- [ ] Verify empty state shows when no deployments exist at all
- [ ] Verify stack deployments still display correctly below products