### PR TITLE
Fix SPA fallback for URLs with dots

### DIFF
--- a/src/ReadyStackGo.Api/Program.cs
+++ b/src/ReadyStackGo.Api/Program.cs
@@ -145,6 +145,26 @@ public class Program
         var reverseProxyConfig = await ConfigureReverseProxyAsync(app);
 
         // Configure the HTTP request pipeline
+
+        // SPA fallback middleware: catches 404s for non-API routes that contain dots
+        // (e.g. /catalog/source:product:1.0.0). MapFallback uses {*path:nonfile} which
+        // skips these paths, so this middleware serves index.html as a last resort.
+        var webRootPath = app.Environment.WebRootPath;
+        app.Use(async (context, next) =>
+        {
+            await next();
+            if (context.Response.StatusCode == 404 &&
+                !context.Response.HasStarted &&
+                !context.Request.Path.StartsWithSegments("/api") &&
+                !context.Request.Path.StartsWithSegments("/hubs"))
+            {
+                context.Response.StatusCode = 200;
+                context.Response.ContentType = "text/html";
+                await context.Response.SendFileAsync(
+                    Path.Combine(webRootPath, "index.html"));
+            }
+        });
+
         if (app.Environment.IsDevelopment())
         {
             app.UseCors("DevCorsPolicy");
@@ -189,11 +209,13 @@ public class Program
         app.MapHub<UpdateHub>("/hubs/update");
 
         // SPA fallback: serve index.html for non-API, non-file routes
-        // This must come after static files middleware so that actual files are served first
+        // MapFallback uses {*path:nonfile} which skips paths with dots (e.g. version
+        // numbers in product IDs like "source:product:1.0.0"). The additional middleware
+        // below catches those dotted paths that MapFallback misses.
         app.MapFallback(async context =>
         {
-            // Only serve SPA for non-API routes
-            if (!context.Request.Path.StartsWithSegments("/api"))
+            if (!context.Request.Path.StartsWithSegments("/api") &&
+                !context.Request.Path.StartsWithSegments("/hubs"))
             {
                 context.Response.ContentType = "text/html";
                 await context.Response.SendFileAsync(

--- a/src/ReadyStackGo.WebUi/src/pages/Deployments/DeployProduct.tsx
+++ b/src/ReadyStackGo.WebUi/src/pages/Deployments/DeployProduct.tsx
@@ -915,26 +915,11 @@ export default function DeployProduct() {
               <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
                 Used as a prefix for all stack deployments. Stack names are derived automatically.
               </p>
-              {/* Preview of derived stack names */}
+              {/* Derived stack names hint */}
               {product && deploymentName.trim() && (
-                <div className="mt-3 p-3 rounded-lg bg-gray-50 dark:bg-gray-800/50">
-                  <p className="text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">
-                    Derived Stack Names
-                  </p>
-                  <div className="space-y-1">
-                    {product.stacks.map((stack) => (
-                      <div key={stack.id} className="flex items-center gap-2 text-xs">
-                        <span className="text-gray-400 dark:text-gray-500">{stack.name}</span>
-                        <svg className="w-3 h-3 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14 5l7 7m0 0l-7 7m7-7H3" />
-                        </svg>
-                        <code className="px-1.5 py-0.5 rounded bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 font-mono">
-                          {toKebabCase(`${deploymentName}-${stack.name}`)}
-                        </code>
-                      </div>
-                    ))}
-                  </div>
-                </div>
+                <p className="mt-1.5 text-xs text-gray-400 dark:text-gray-500">
+                  Stacks: {product.stacks.map((stack) => toKebabCase(`${deploymentName}-${stack.name}`)).join(', ')}
+                </p>
               )}
             </div>
 


### PR DESCRIPTION
## Summary
- Fix 404 on page refresh for SPA routes containing dots (e.g. `/deploy-product/source%3Aproduct%3A1.0.0`)
- Root cause: `MapFallback` uses `{*path:nonfile}` which skips paths with dots, treating them as file requests
- Add early middleware that catches 404s for non-API/non-hub routes and serves `index.html`
- Simplify derived stack names preview in DeployProduct to a subtle single-line hint

## Test plan
- [ ] Navigate to a product deploy page, refresh the browser — should load instead of 404
- [ ] Verify `/api/nonexistent` still returns 404 (not index.html)
- [ ] Verify static files (JS, CSS) still load correctly