### PR TITLE
Add HealthCheckEntry value object and extend ServiceHealth

### DIFF
--- a/src/ReadyStackGo.Domain/Deployment/Health/HealthCheckEntry.cs
+++ b/src/ReadyStackGo.Domain/Deployment/Health/HealthCheckEntry.cs
@@ -1,0 +1,86 @@
+namespace ReadyStackGo.Domain.Deployment.Health;
+
+using ReadyStackGo.Domain.SharedKernel;
+
+/// <summary>
+/// A single health check entry from an ASP.NET Core HealthReport.
+/// Represents an individual check (e.g., "database", "redis", "disk") with its result.
+/// </summary>
+public sealed class HealthCheckEntry : ValueObject
+{
+    /// <summary>
+    /// Name of the health check (e.g., "database", "redis", "disk").
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Health status of this check.
+    /// </summary>
+    public HealthStatus Status { get; }
+
+    /// <summary>
+    /// Optional description from the health check result.
+    /// </summary>
+    public string? Description { get; }
+
+    /// <summary>
+    /// Duration of the health check in milliseconds.
+    /// </summary>
+    public double? DurationMs { get; }
+
+    /// <summary>
+    /// Additional key-value data reported by the health check.
+    /// </summary>
+    public IReadOnlyDictionary<string, string>? Data { get; }
+
+    /// <summary>
+    /// Tags associated with the health check.
+    /// </summary>
+    public IReadOnlyList<string>? Tags { get; }
+
+    /// <summary>
+    /// Exception message if the health check threw an exception.
+    /// </summary>
+    public string? Exception { get; }
+
+    private HealthCheckEntry(
+        string name,
+        HealthStatus status,
+        string? description,
+        double? durationMs,
+        IReadOnlyDictionary<string, string>? data,
+        IReadOnlyList<string>? tags,
+        string? exception)
+    {
+        SelfAssertArgumentNotEmpty(name, "Health check entry name cannot be empty.");
+
+        Name = name;
+        Status = status;
+        Description = description;
+        DurationMs = durationMs;
+        Data = data;
+        Tags = tags;
+        Exception = exception;
+    }
+
+    public static HealthCheckEntry Create(
+        string name,
+        HealthStatus status,
+        string? description = null,
+        double? durationMs = null,
+        IReadOnlyDictionary<string, string>? data = null,
+        IReadOnlyList<string>? tags = null,
+        string? exception = null)
+    {
+        return new HealthCheckEntry(name, status, description, durationMs, data, tags, exception);
+    }
+
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return Name;
+        yield return Status;
+        yield return Description;
+        yield return DurationMs;
+        yield return Exception;
+    }
+}

--- a/src/ReadyStackGo.Domain/Deployment/Health/ServiceHealth.cs
+++ b/src/ReadyStackGo.Domain/Deployment/Health/ServiceHealth.cs
@@ -38,13 +38,27 @@ public sealed class ServiceHealth : ValueObject
     /// </summary>
     public int? RestartCount { get; }
 
+    /// <summary>
+    /// Parsed health check entries from the HTTP health endpoint response.
+    /// Only populated when the service exposes an ASP.NET Core HealthReport.
+    /// </summary>
+    public IReadOnlyList<HealthCheckEntry>? HealthCheckEntries { get; }
+
+    /// <summary>
+    /// Response time of the HTTP health check in milliseconds.
+    /// Only populated when the service was checked via HTTP health endpoint.
+    /// </summary>
+    public int? ResponseTimeMs { get; }
+
     private ServiceHealth(
         string name,
         HealthStatus status,
         string? containerId,
         string? containerName,
         string? reason,
-        int? restartCount)
+        int? restartCount,
+        IReadOnlyList<HealthCheckEntry>? healthCheckEntries = null,
+        int? responseTimeMs = null)
     {
         SelfAssertArgumentNotEmpty(name, "Service name cannot be empty.");
 
@@ -54,6 +68,8 @@ public sealed class ServiceHealth : ValueObject
         ContainerName = containerName;
         Reason = reason;
         RestartCount = restartCount;
+        HealthCheckEntries = healthCheckEntries;
+        ResponseTimeMs = responseTimeMs;
     }
 
     public static ServiceHealth Create(
@@ -62,9 +78,11 @@ public sealed class ServiceHealth : ValueObject
         string? containerId = null,
         string? containerName = null,
         string? reason = null,
-        int? restartCount = null)
+        int? restartCount = null,
+        IReadOnlyList<HealthCheckEntry>? healthCheckEntries = null,
+        int? responseTimeMs = null)
     {
-        return new ServiceHealth(name, status, containerId, containerName, reason, restartCount);
+        return new ServiceHealth(name, status, containerId, containerName, reason, restartCount, healthCheckEntries, responseTimeMs);
     }
 
     public static ServiceHealth Healthy(string name, string? containerId = null, string? containerName = null)
@@ -95,5 +113,6 @@ public sealed class ServiceHealth : ValueObject
         yield return ContainerName;
         yield return Reason;
         yield return RestartCount;
+        yield return ResponseTimeMs;
     }
 }


### PR DESCRIPTION
## Summary
- New `HealthCheckEntry` value object in Domain layer capturing full ASP.NET Core HealthReport entry data (name, status, description, durationMs, data dictionary, tags, exception)
- Extend `ServiceHealth` with `HealthCheckEntries: IReadOnlyList<HealthCheckEntry>?` and `ResponseTimeMs: int?`
- Extended `ServiceHealth.Create()` factory method with optional `healthCheckEntries` and `responseTimeMs` parameters

## Test plan
- [ ] Verify build succeeds with 0 errors
- [ ] Unit tests for HealthCheckEntry value object (added in Feature 8 PR)
- [ ] Verify existing health monitoring works unchanged (new fields are optional)