### PR TITLE
Add inline health check entry expansion in dashboard

### DIFF
--- a/src/ReadyStackGo.WebUi/src/api/health.ts
+++ b/src/ReadyStackGo.WebUi/src/api/health.ts
@@ -35,6 +35,18 @@ export interface ServiceHealthDto {
   containerName: string | null;
   reason: string | null;
   restartCount: number;
+  healthCheckEntries?: HealthCheckEntryDto[];
+  responseTimeMs?: number;
+}
+
+export interface HealthCheckEntryDto {
+  name: string;
+  status: string;
+  description?: string;
+  durationMs?: number;
+  data?: Record<string, string>;
+  tags?: string[];
+  exception?: string;
 }
 
 export interface BusHealthDto {

--- a/src/ReadyStackGo.WebUi/src/components/health/HealthCheckEntryRow.tsx
+++ b/src/ReadyStackGo.WebUi/src/components/health/HealthCheckEntryRow.tsx
@@ -1,0 +1,113 @@
+import { useState } from 'react';
+import { type HealthCheckEntryDto, getHealthStatusPresentation } from '../../api/health';
+
+interface HealthCheckEntryRowProps {
+  entry: HealthCheckEntryDto;
+}
+
+export default function HealthCheckEntryRow({ entry }: HealthCheckEntryRowProps) {
+  const [showData, setShowData] = useState(false);
+  const presentation = getHealthStatusPresentation(entry.status);
+  const hasData = entry.data && Object.keys(entry.data).length > 0;
+  const hasExtra = hasData || entry.exception;
+
+  return (
+    <div className="py-2 px-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <span
+            className={`h-1.5 w-1.5 rounded-full ${
+              entry.status.toLowerCase() === 'healthy'
+                ? 'bg-green-500'
+                : entry.status.toLowerCase() === 'degraded'
+                ? 'bg-yellow-500'
+                : entry.status.toLowerCase() === 'unhealthy'
+                ? 'bg-red-500'
+                : 'bg-gray-400'
+            }`}
+          />
+          <span className="text-xs font-medium text-gray-700 dark:text-gray-300">
+            {entry.name}
+          </span>
+          {entry.tags && entry.tags.length > 0 && (
+            <div className="flex gap-1">
+              {entry.tags.map((tag) => (
+                <span
+                  key={tag}
+                  className="inline-flex items-center rounded px-1 py-0.5 text-[10px] font-medium bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+        <div className="flex items-center gap-3">
+          {entry.durationMs != null && (
+            <span className="text-[10px] text-gray-400 dark:text-gray-500 tabular-nums">
+              {entry.durationMs < 1
+                ? '<1ms'
+                : entry.durationMs < 1000
+                ? `${Math.round(entry.durationMs)}ms`
+                : `${(entry.durationMs / 1000).toFixed(1)}s`}
+            </span>
+          )}
+          <span
+            className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium ${presentation.bgColor} ${presentation.textColor}`}
+          >
+            {presentation.label}
+          </span>
+          {hasExtra && (
+            <button
+              onClick={() => setShowData(!showData)}
+              className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+            >
+              <svg
+                className={`w-3.5 h-3.5 transition-transform ${showData ? 'rotate-180' : ''}`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {entry.description && (
+        <p className="mt-1 ml-3.5 text-[11px] text-gray-500 dark:text-gray-400">
+          {entry.description}
+        </p>
+      )}
+
+      {showData && (
+        <div className="mt-2 ml-3.5 space-y-2">
+          {hasData && (
+            <div className="rounded bg-gray-50 dark:bg-gray-800/50 p-2">
+              <table className="w-full text-[11px]">
+                <tbody>
+                  {Object.entries(entry.data!).map(([key, value]) => (
+                    <tr key={key}>
+                      <td className="pr-3 py-0.5 font-medium text-gray-500 dark:text-gray-400 whitespace-nowrap align-top">
+                        {key}
+                      </td>
+                      <td className="py-0.5 text-gray-700 dark:text-gray-300 break-all">
+                        {value}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+          {entry.exception && (
+            <pre className="rounded bg-red-50 dark:bg-red-900/20 p-2 text-[11px] text-red-700 dark:text-red-400 overflow-x-auto whitespace-pre-wrap">
+              {entry.exception}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ReadyStackGo.WebUi/src/components/health/HealthServiceRow.tsx
+++ b/src/ReadyStackGo.WebUi/src/components/health/HealthServiceRow.tsx
@@ -1,49 +1,83 @@
+import { useState } from 'react';
 import { type ServiceHealthDto, getHealthStatusPresentation } from '../../api/health';
+import HealthCheckEntryRow from './HealthCheckEntryRow';
 
 interface HealthServiceRowProps {
   service: ServiceHealthDto;
 }
 
 export default function HealthServiceRow({ service }: HealthServiceRowProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
   const presentation = getHealthStatusPresentation(service.status);
+  const hasEntries = service.healthCheckEntries && service.healthCheckEntries.length > 0;
 
   return (
-    <div className="flex items-center justify-between py-2 px-3 border-b border-gray-100 dark:border-gray-800 last:border-0 hover:bg-gray-50 dark:hover:bg-gray-800/30 transition-colors">
-      <div className="flex items-center gap-3">
-        <span
-          className={`h-2 w-2 rounded-full ${
-            service.status.toLowerCase() === 'healthy'
-              ? 'bg-green-500'
-              : service.status.toLowerCase() === 'degraded'
-              ? 'bg-yellow-500'
-              : service.status.toLowerCase() === 'unhealthy'
-              ? 'bg-red-500'
-              : 'bg-gray-400'
-          }`}
-        />
-        <div>
-          <span className="text-sm font-medium text-gray-900 dark:text-white">
-            {service.name}
-          </span>
-          {service.containerName && (
-            <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">
-              ({service.containerName})
+    <div className="border-b border-gray-100 dark:border-gray-800 last:border-0">
+      <div
+        className={`flex items-center justify-between py-2 px-3 hover:bg-gray-50 dark:hover:bg-gray-800/30 transition-colors ${hasEntries ? 'cursor-pointer' : ''}`}
+        onClick={hasEntries ? () => setIsExpanded(!isExpanded) : undefined}
+      >
+        <div className="flex items-center gap-3">
+          <span
+            className={`h-2 w-2 rounded-full ${
+              service.status.toLowerCase() === 'healthy'
+                ? 'bg-green-500'
+                : service.status.toLowerCase() === 'degraded'
+                ? 'bg-yellow-500'
+                : service.status.toLowerCase() === 'unhealthy'
+                ? 'bg-red-500'
+                : 'bg-gray-400'
+            }`}
+          />
+          <div>
+            <span className="text-sm font-medium text-gray-900 dark:text-white">
+              {service.name}
             </span>
+            {service.containerName && (
+              <span className="ml-2 text-xs text-gray-500 dark:text-gray-400">
+                ({service.containerName})
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-4">
+          {service.responseTimeMs != null && (
+            <span className="text-xs text-gray-400 dark:text-gray-500 tabular-nums">
+              {service.responseTimeMs}ms
+            </span>
+          )}
+          {service.restartCount > 0 && (
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              {service.restartCount} restart{service.restartCount !== 1 ? 's' : ''}
+            </span>
+          )}
+          <span
+            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${presentation.bgColor} ${presentation.textColor}`}
+          >
+            {presentation.label}
+          </span>
+          {hasEntries && (
+            <svg
+              className={`w-4 h-4 text-gray-400 transition-transform ${isExpanded ? 'rotate-180' : ''}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+            </svg>
           )}
         </div>
       </div>
-      <div className="flex items-center gap-4">
-        {service.restartCount > 0 && (
-          <span className="text-xs text-gray-500 dark:text-gray-400">
-            {service.restartCount} restart{service.restartCount !== 1 ? 's' : ''}
-          </span>
-        )}
-        <span
-          className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${presentation.bgColor} ${presentation.textColor}`}
-        >
-          {presentation.label}
-        </span>
-      </div>
+
+      {isExpanded && hasEntries && (
+        <div className="ml-5 border-l-2 border-gray-200 dark:border-gray-700 bg-gray-50/50 dark:bg-gray-800/20">
+          <div className="divide-y divide-gray-100 dark:divide-gray-800">
+            {service.healthCheckEntries!.map((entry) => (
+              <HealthCheckEntryRow key={entry.name} entry={entry} />
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add `HealthCheckEntryDto` TypeScript interface matching backend DTO
- Extend `ServiceHealthDto` with `healthCheckEntries` and `responseTimeMs`
- Make `HealthServiceRow` expandable when health check entries are present (click to expand)
- New `HealthCheckEntryRow` component showing: status dot, name, tags, duration, status badge, description, data table (collapsible), exception (collapsible, red code block)
- Display response time on the service row

## Test plan
- [ ] TypeScript type check passes (`npx tsc --noEmit`)
- [ ] Expand a service row with health check entries → entries displayed
- [ ] Service rows without entries remain non-expandable
- [ ] Entry data table and exception toggleable via chevron
- [ ] Tags displayed as small badges
- [ ] Duration formatted correctly (<1ms, ms, seconds)