### PR TITLE
Add service health detail API endpoint

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/Health/GetServiceHealthEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Health/GetServiceHealthEndpoint.cs
@@ -1,0 +1,55 @@
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using ReadyStackGo.Api.Authorization;
+using ReadyStackGo.Application.UseCases.Health.GetServiceHealth;
+
+namespace ReadyStackGo.API.Endpoints.Health;
+
+/// <summary>
+/// GET /api/health/{environmentId}/deployments/{deploymentId}/services/{serviceName}
+/// Get detailed health information for a specific service within a deployment.
+/// Returns full health check entries when available.
+/// </summary>
+[RequirePermission("Health", "Read")]
+public class GetServiceHealthEndpoint : Endpoint<GetServiceHealthRequest, GetServiceHealthResponse>
+{
+    private readonly IMediator _mediator;
+
+    public GetServiceHealthEndpoint(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Get("/api/health/{environmentId}/deployments/{deploymentId}/services/{serviceName}");
+        PreProcessor<RbacPreProcessor<GetServiceHealthRequest>>();
+    }
+
+    public override async Task HandleAsync(GetServiceHealthRequest req, CancellationToken ct)
+    {
+        var query = new GetServiceHealthQuery(
+            req.EnvironmentId,
+            req.DeploymentId,
+            req.ServiceName,
+            req.ForceRefresh);
+
+        var response = await _mediator.Send(query, ct);
+
+        if (!response.Success)
+        {
+            ThrowError(response.Message ?? "Service health data not available", StatusCodes.Status404NotFound);
+        }
+
+        Response = response;
+    }
+}
+
+public class GetServiceHealthRequest
+{
+    public string EnvironmentId { get; set; } = string.Empty;
+    public string DeploymentId { get; set; } = string.Empty;
+    public string ServiceName { get; set; } = string.Empty;
+    public bool ForceRefresh { get; set; }
+}

--- a/src/ReadyStackGo.Application/UseCases/Health/GetServiceHealth/GetServiceHealthHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Health/GetServiceHealth/GetServiceHealthHandler.cs
@@ -1,0 +1,142 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Domain.Deployment.Deployments;
+using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.Deployment.Health;
+using DomainHealthCheckConfig = ReadyStackGo.Domain.Deployment.RuntimeConfig.ServiceHealthCheckConfig;
+using AppHealthCheckConfig = ReadyStackGo.Application.Services.ServiceHealthCheckConfig;
+
+namespace ReadyStackGo.Application.UseCases.Health.GetServiceHealth;
+
+/// <summary>
+/// Handler for GetServiceHealthQuery.
+/// Returns health data for a single service with full health check entries.
+/// </summary>
+public class GetServiceHealthHandler : IRequestHandler<GetServiceHealthQuery, GetServiceHealthResponse>
+{
+    private readonly IHealthMonitoringService _healthMonitoringService;
+    private readonly IDeploymentRepository _deploymentRepository;
+    private readonly IEnvironmentRepository _environmentRepository;
+    private readonly ILogger<GetServiceHealthHandler> _logger;
+
+    private static readonly TimeSpan StaleThreshold = TimeSpan.FromMinutes(5);
+
+    public GetServiceHealthHandler(
+        IHealthMonitoringService healthMonitoringService,
+        IDeploymentRepository deploymentRepository,
+        IEnvironmentRepository environmentRepository,
+        ILogger<GetServiceHealthHandler> logger)
+    {
+        _healthMonitoringService = healthMonitoringService;
+        _deploymentRepository = deploymentRepository;
+        _environmentRepository = environmentRepository;
+        _logger = logger;
+    }
+
+    public async Task<GetServiceHealthResponse> Handle(
+        GetServiceHealthQuery request,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogDebug(
+            "Getting service health for {ServiceName} in deployment {DeploymentId}",
+            request.ServiceName, request.DeploymentId);
+
+        if (!Guid.TryParse(request.DeploymentId, out var deploymentGuid))
+            return GetServiceHealthResponse.Failure("Invalid deployment ID format");
+
+        if (!Guid.TryParse(request.EnvironmentId, out var environmentGuid))
+            return GetServiceHealthResponse.Failure("Invalid environment ID format");
+
+        var deploymentId = DeploymentId.FromGuid(deploymentGuid);
+        var environmentId = EnvironmentId.FromGuid(environmentGuid);
+
+        var deployment = _deploymentRepository.Get(deploymentId);
+        if (deployment == null)
+            return GetServiceHealthResponse.Failure($"Deployment {request.DeploymentId} not found");
+
+        var environment = _environmentRepository.Get(environmentId);
+        if (environment == null)
+            return GetServiceHealthResponse.Failure($"Environment {request.EnvironmentId} not found");
+
+        // Get latest snapshot (or capture fresh one if stale/forced)
+        var snapshot = await _healthMonitoringService.GetLatestHealthSnapshotAsync(
+            deploymentId, cancellationToken);
+
+        bool needsRefresh = request.ForceRefresh ||
+            snapshot == null ||
+            (DateTime.UtcNow - snapshot.CapturedAtUtc > StaleThreshold);
+
+        if (needsRefresh)
+        {
+            var serviceHealthConfigs = MapHealthCheckConfigs(deployment.HealthCheckConfigs);
+
+            snapshot = await _healthMonitoringService.CaptureHealthSnapshotAsync(
+                environment.OrganizationId,
+                environmentId,
+                deploymentId,
+                deployment.StackName,
+                deployment.StackVersion,
+                serviceHealthConfigs,
+                cancellationToken);
+        }
+
+        // Find the specific service in the snapshot
+        var service = snapshot!.Self.Services
+            .FirstOrDefault(s => string.Equals(s.Name, request.ServiceName, StringComparison.OrdinalIgnoreCase));
+
+        if (service == null)
+            return GetServiceHealthResponse.Failure($"Service '{request.ServiceName}' not found in deployment");
+
+        // Map to DTO using the shared mapper logic
+        var dto = HealthSnapshotMapper.MapServiceToDto(service);
+
+        return GetServiceHealthResponse.Ok(dto, snapshot.StackName, snapshot.CapturedAtUtc);
+    }
+
+    private static IReadOnlyDictionary<string, AppHealthCheckConfig>? MapHealthCheckConfigs(
+        IReadOnlyCollection<DomainHealthCheckConfig>? domainConfigs)
+    {
+        if (domainConfigs == null || domainConfigs.Count == 0)
+            return null;
+
+        var result = new Dictionary<string, AppHealthCheckConfig>();
+
+        foreach (var config in domainConfigs)
+        {
+            var timeoutSeconds = 5;
+            if (!string.IsNullOrEmpty(config.Timeout) && TimeSpan.TryParse(config.Timeout, out var timeout))
+                timeoutSeconds = (int)timeout.TotalSeconds;
+
+            result[config.ServiceName] = new AppHealthCheckConfig
+            {
+                Type = config.Type,
+                Path = config.Path ?? "/hc",
+                Port = config.Port,
+                TimeoutSeconds = timeoutSeconds,
+                UseHttps = config.Https,
+                ExpectedStatusCodes = config.ExpectedStatusCodes ?? new[] { 200 }
+            };
+        }
+
+        return result.Count > 0 ? result : null;
+    }
+}
+
+/// <summary>
+/// Response for getting service health detail.
+/// </summary>
+public class GetServiceHealthResponse
+{
+    public bool Success { get; set; }
+    public string? Message { get; set; }
+    public ServiceHealthDto? Data { get; set; }
+    public string? StackName { get; set; }
+    public DateTime? CapturedAtUtc { get; set; }
+
+    public static GetServiceHealthResponse Ok(ServiceHealthDto data, string stackName, DateTime capturedAtUtc) =>
+        new() { Success = true, Data = data, StackName = stackName, CapturedAtUtc = capturedAtUtc };
+
+    public static GetServiceHealthResponse Failure(string message) =>
+        new() { Success = false, Message = message };
+}

--- a/src/ReadyStackGo.Application/UseCases/Health/GetServiceHealth/GetServiceHealthQuery.cs
+++ b/src/ReadyStackGo.Application/UseCases/Health/GetServiceHealth/GetServiceHealthQuery.cs
@@ -1,0 +1,13 @@
+using MediatR;
+
+namespace ReadyStackGo.Application.UseCases.Health.GetServiceHealth;
+
+/// <summary>
+/// Query to get detailed health information for a specific service within a deployment.
+/// Returns the service health with full health check entries.
+/// </summary>
+public record GetServiceHealthQuery(
+    string EnvironmentId,
+    string DeploymentId,
+    string ServiceName,
+    bool ForceRefresh = false) : IRequest<GetServiceHealthResponse>;

--- a/src/ReadyStackGo.Application/UseCases/Health/HealthSnapshotMapper.cs
+++ b/src/ReadyStackGo.Application/UseCases/Health/HealthSnapshotMapper.cs
@@ -56,6 +56,13 @@ public static class HealthSnapshotMapper
         };
     }
 
+    /// <summary>
+    /// Maps a single ServiceHealth domain object to a ServiceHealthDto.
+    /// Used by GetServiceHealthHandler for service-level detail queries.
+    /// </summary>
+    public static ServiceHealthDto MapServiceToDto(ServiceHealth service) =>
+        MapServiceHealth(service);
+
     private static ServiceHealthDto MapServiceHealth(ServiceHealth service)
     {
         return new ServiceHealthDto


### PR DESCRIPTION
## Summary
- New `GET /api/health/{envId}/deployments/{depId}/services/{serviceName}` endpoint
- `GetServiceHealthQuery` + `GetServiceHealthHandler` following existing GetStackHealth pattern
- Returns `ServiceHealthDto` with full `HealthCheckEntries` for a single service
- Support `forceRefresh=true` query parameter for on-demand health checks
- Expose `MapServiceToDto` on `HealthSnapshotMapper` for service-level mapping
- Same permission model as GetStackHealth (`Health / Read`)

## Test plan
- [ ] Verify build succeeds with 0 errors
- [ ] Test endpoint with valid deployment/service → returns service health
- [ ] Test with invalid service name → 404
- [ ] Test forceRefresh parameter triggers fresh health check