### PR TITLE
Add comprehensive tests for health check details

### DIFF
--- a/tests/ReadyStackGo.UnitTests/Application/Health/HealthSnapshotMapperTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Health/HealthSnapshotMapperTests.cs
@@ -344,4 +344,156 @@ public class HealthSnapshotMapperTests
     }
 
     #endregion
+
+    #region Health Check Entries Mapping
+
+    [Fact]
+    public void MapToStackHealthDto_MapsHealthCheckEntries()
+    {
+        var entries = new List<HealthCheckEntry>
+        {
+            HealthCheckEntry.Create("database", HealthStatus.Healthy, "SQL OK", 12.3,
+                new Dictionary<string, string> { { "server", "sql01" } },
+                new List<string> { "db" }),
+            HealthCheckEntry.Create("redis", HealthStatus.Unhealthy, "Connection refused", 5001.2,
+                exception: "SocketException")
+        };
+
+        var service = ServiceHealth.Create("api", HealthStatus.Degraded,
+            "c123", "api-container", "Some checks failing", null, entries, 150);
+        var selfHealth = SelfHealth.Create(new[] { service });
+        var snapshot = HealthSnapshot.Capture(
+            _orgId, _envId, _deploymentId, "my-stack",
+            OperationMode.Normal,
+            self: selfHealth);
+
+        var dto = HealthSnapshotMapper.MapToStackHealthDto(snapshot, _envId);
+        var serviceDto = dto.Self.Services.Single();
+
+        serviceDto.HealthCheckEntries.Should().NotBeNull();
+        serviceDto.HealthCheckEntries.Should().HaveCount(2);
+        serviceDto.ResponseTimeMs.Should().Be(150);
+
+        var dbEntry = serviceDto.HealthCheckEntries!.Single(e => e.Name == "database");
+        dbEntry.Status.Should().Be("Healthy");
+        dbEntry.Description.Should().Be("SQL OK");
+        dbEntry.DurationMs.Should().Be(12.3);
+        dbEntry.Data.Should().ContainKey("server");
+        dbEntry.Tags.Should().ContainSingle("db");
+        dbEntry.Exception.Should().BeNull();
+
+        var redisEntry = serviceDto.HealthCheckEntries!.Single(e => e.Name == "redis");
+        redisEntry.Status.Should().Be("Unhealthy");
+        redisEntry.Exception.Should().Be("SocketException");
+    }
+
+    [Fact]
+    public void MapToStackHealthDto_NullEntries_MapsToNull()
+    {
+        var service = ServiceHealth.Create("api", HealthStatus.Healthy, "c123", "api-container");
+        var selfHealth = SelfHealth.Create(new[] { service });
+        var snapshot = HealthSnapshot.Capture(
+            _orgId, _envId, _deploymentId, "my-stack",
+            OperationMode.Normal,
+            self: selfHealth);
+
+        var dto = HealthSnapshotMapper.MapToStackHealthDto(snapshot, _envId);
+        var serviceDto = dto.Self.Services.Single();
+
+        serviceDto.HealthCheckEntries.Should().BeNull();
+        serviceDto.ResponseTimeMs.Should().BeNull();
+    }
+
+    [Fact]
+    public void MapToStackHealthDto_EmptyEntries_MapsToEmptyList()
+    {
+        var entries = new List<HealthCheckEntry>();
+        var service = ServiceHealth.Create("api", HealthStatus.Healthy,
+            "c123", "api-container", null, null, entries, 50);
+        var selfHealth = SelfHealth.Create(new[] { service });
+        var snapshot = HealthSnapshot.Capture(
+            _orgId, _envId, _deploymentId, "my-stack",
+            OperationMode.Normal,
+            self: selfHealth);
+
+        var dto = HealthSnapshotMapper.MapToStackHealthDto(snapshot, _envId);
+        var serviceDto = dto.Self.Services.Single();
+
+        serviceDto.HealthCheckEntries.Should().NotBeNull();
+        serviceDto.HealthCheckEntries.Should().BeEmpty();
+        serviceDto.ResponseTimeMs.Should().Be(50);
+    }
+
+    [Fact]
+    public void MapServiceToDto_MapsEntriesCorrectly()
+    {
+        var entries = new List<HealthCheckEntry>
+        {
+            HealthCheckEntry.Create("check1", HealthStatus.Healthy, "OK"),
+        };
+        var service = ServiceHealth.Create("api", HealthStatus.Healthy,
+            "c123", "api-container", null, null, entries, 25);
+
+        var dto = HealthSnapshotMapper.MapServiceToDto(service);
+
+        dto.Name.Should().Be("api");
+        dto.HealthCheckEntries.Should().HaveCount(1);
+        dto.HealthCheckEntries![0].Name.Should().Be("check1");
+        dto.ResponseTimeMs.Should().Be(25);
+    }
+
+    [Fact]
+    public void MapToStackHealthDto_EntryDataDictionary_MappedCorrectly()
+    {
+        var data = new Dictionary<string, string>
+        {
+            { "key1", "value1" },
+            { "key2", "value2" }
+        };
+        var entries = new List<HealthCheckEntry>
+        {
+            HealthCheckEntry.Create("check", HealthStatus.Healthy, data: data)
+        };
+        var service = ServiceHealth.Create("api", HealthStatus.Healthy,
+            healthCheckEntries: entries);
+        var selfHealth = SelfHealth.Create(new[] { service });
+        var snapshot = HealthSnapshot.Capture(
+            _orgId, _envId, _deploymentId, "my-stack",
+            OperationMode.Normal,
+            self: selfHealth);
+
+        var dto = HealthSnapshotMapper.MapToStackHealthDto(snapshot, _envId);
+        var entryDto = dto.Self.Services.Single().HealthCheckEntries!.Single();
+
+        entryDto.Data.Should().HaveCount(2);
+        entryDto.Data!["key1"].Should().Be("value1");
+        entryDto.Data!["key2"].Should().Be("value2");
+    }
+
+    [Fact]
+    public void MapToStackHealthDto_EntryTags_MappedCorrectly()
+    {
+        var tags = new List<string> { "critical", "db", "infrastructure" };
+        var entries = new List<HealthCheckEntry>
+        {
+            HealthCheckEntry.Create("check", HealthStatus.Healthy, tags: tags)
+        };
+        var service = ServiceHealth.Create("api", HealthStatus.Healthy,
+            healthCheckEntries: entries);
+        var selfHealth = SelfHealth.Create(new[] { service });
+        var snapshot = HealthSnapshot.Capture(
+            _orgId, _envId, _deploymentId, "my-stack",
+            OperationMode.Normal,
+            self: selfHealth);
+
+        var dto = HealthSnapshotMapper.MapToStackHealthDto(snapshot, _envId);
+        var entryDto = dto.Self.Services.Single().HealthCheckEntries!.Single();
+
+        entryDto.Tags.Should().HaveCount(3);
+        entryDto.Tags.Should().Contain("critical");
+        entryDto.Tags.Should().Contain("db");
+        entryDto.Tags.Should().Contain("infrastructure");
+    }
+
+    #endregion
 }

--- a/tests/ReadyStackGo.UnitTests/Domain/Health/HealthCheckEntryTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Domain/Health/HealthCheckEntryTests.cs
@@ -1,0 +1,177 @@
+using FluentAssertions;
+using ReadyStackGo.Domain.Deployment.Health;
+
+namespace ReadyStackGo.UnitTests.Domain.Health;
+
+/// <summary>
+/// Unit tests for HealthCheckEntry value object.
+/// </summary>
+public class HealthCheckEntryTests
+{
+    #region Create
+
+    [Fact]
+    public void Create_WithAllFields_CreatesEntry()
+    {
+        var data = new Dictionary<string, string> { { "server", "sql01" } };
+        var tags = new List<string> { "db", "critical" };
+
+        var entry = HealthCheckEntry.Create(
+            "database",
+            HealthStatus.Healthy,
+            "SQL Server connection OK",
+            12.3,
+            data,
+            tags,
+            null);
+
+        entry.Name.Should().Be("database");
+        entry.Status.Should().Be(HealthStatus.Healthy);
+        entry.Description.Should().Be("SQL Server connection OK");
+        entry.DurationMs.Should().Be(12.3);
+        entry.Data.Should().ContainKey("server");
+        entry.Data!["server"].Should().Be("sql01");
+        entry.Tags.Should().HaveCount(2);
+        entry.Tags.Should().Contain("db");
+        entry.Tags.Should().Contain("critical");
+        entry.Exception.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_WithMinimalFields_CreatesEntry()
+    {
+        var entry = HealthCheckEntry.Create("redis", HealthStatus.Healthy);
+
+        entry.Name.Should().Be("redis");
+        entry.Status.Should().Be(HealthStatus.Healthy);
+        entry.Description.Should().BeNull();
+        entry.DurationMs.Should().BeNull();
+        entry.Data.Should().BeNull();
+        entry.Tags.Should().BeNull();
+        entry.Exception.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_WithException_StoresException()
+    {
+        var entry = HealthCheckEntry.Create(
+            "redis",
+            HealthStatus.Unhealthy,
+            "Connection refused",
+            5001.2,
+            exception: "System.Net.Sockets.SocketException: Connection refused");
+
+        entry.Status.Should().Be(HealthStatus.Unhealthy);
+        entry.Description.Should().Be("Connection refused");
+        entry.Exception.Should().Contain("SocketException");
+    }
+
+    [Fact]
+    public void Create_WithEmptyName_ThrowsArgumentException()
+    {
+        var act = () => HealthCheckEntry.Create("", HealthStatus.Healthy);
+
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*cannot be empty*");
+    }
+
+    [Fact]
+    public void Create_WithEmptyData_StoresEmptyDictionary()
+    {
+        var data = new Dictionary<string, string>();
+        var entry = HealthCheckEntry.Create("check", HealthStatus.Healthy, data: data);
+
+        entry.Data.Should().NotBeNull();
+        entry.Data.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Create_WithEmptyTags_StoresEmptyList()
+    {
+        var tags = new List<string>();
+        var entry = HealthCheckEntry.Create("check", HealthStatus.Healthy, tags: tags);
+
+        entry.Tags.Should().NotBeNull();
+        entry.Tags.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region Equality
+
+    [Fact]
+    public void Equality_SameValues_AreEqual()
+    {
+        var entry1 = HealthCheckEntry.Create("database", HealthStatus.Healthy, "OK", 10.5);
+        var entry2 = HealthCheckEntry.Create("database", HealthStatus.Healthy, "OK", 10.5);
+
+        entry1.Should().Be(entry2);
+        (entry1 == entry2).Should().BeTrue();
+        entry1.GetHashCode().Should().Be(entry2.GetHashCode());
+    }
+
+    [Fact]
+    public void Equality_DifferentName_AreNotEqual()
+    {
+        var entry1 = HealthCheckEntry.Create("database", HealthStatus.Healthy);
+        var entry2 = HealthCheckEntry.Create("redis", HealthStatus.Healthy);
+
+        entry1.Should().NotBe(entry2);
+        (entry1 != entry2).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equality_DifferentStatus_AreNotEqual()
+    {
+        var entry1 = HealthCheckEntry.Create("database", HealthStatus.Healthy);
+        var entry2 = HealthCheckEntry.Create("database", HealthStatus.Unhealthy);
+
+        entry1.Should().NotBe(entry2);
+    }
+
+    [Fact]
+    public void Equality_DifferentDescription_AreNotEqual()
+    {
+        var entry1 = HealthCheckEntry.Create("database", HealthStatus.Healthy, "OK");
+        var entry2 = HealthCheckEntry.Create("database", HealthStatus.Healthy, "Connection OK");
+
+        entry1.Should().NotBe(entry2);
+    }
+
+    [Fact]
+    public void Equality_DifferentDuration_AreNotEqual()
+    {
+        var entry1 = HealthCheckEntry.Create("database", HealthStatus.Healthy, durationMs: 10.0);
+        var entry2 = HealthCheckEntry.Create("database", HealthStatus.Healthy, durationMs: 20.0);
+
+        entry1.Should().NotBe(entry2);
+    }
+
+    [Fact]
+    public void Equality_DifferentException_AreNotEqual()
+    {
+        var entry1 = HealthCheckEntry.Create("database", HealthStatus.Unhealthy, exception: "Error A");
+        var entry2 = HealthCheckEntry.Create("database", HealthStatus.Unhealthy, exception: "Error B");
+
+        entry1.Should().NotBe(entry2);
+    }
+
+    #endregion
+
+    #region All HealthStatus Values
+
+    [Theory]
+    [InlineData("Healthy")]
+    [InlineData("Degraded")]
+    [InlineData("Unhealthy")]
+    [InlineData("Unknown")]
+    public void Create_WithEachStatus_StoresCorrectStatus(string statusName)
+    {
+        var status = HealthStatus.FromName(statusName);
+        var entry = HealthCheckEntry.Create("check", status);
+
+        entry.Status.Should().Be(status);
+    }
+
+    #endregion
+}

--- a/tests/ReadyStackGo.UnitTests/Infrastructure/Health/HttpHealthCheckerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Infrastructure/Health/HttpHealthCheckerTests.cs
@@ -1,0 +1,481 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Infrastructure.Services.Health;
+
+namespace ReadyStackGo.UnitTests.Infrastructure.Health;
+
+/// <summary>
+/// Unit tests for HttpHealthChecker.
+/// Tests the full health check flow including JSON parsing of ASP.NET Core HealthReport entries.
+/// </summary>
+public class HttpHealthCheckerTests
+{
+    private readonly Mock<ILogger<HttpHealthChecker>> _loggerMock = new();
+
+    private HttpHealthChecker CreateChecker(string responseContent, HttpStatusCode statusCode = HttpStatusCode.OK)
+    {
+        var handler = new MockHttpMessageHandler(responseContent, statusCode);
+        var httpClient = new HttpClient(handler);
+        return new HttpHealthChecker(httpClient, _loggerMock.Object);
+    }
+
+    private static HttpHealthCheckConfig DefaultConfig => new()
+    {
+        Path = "/hc",
+        Port = 80,
+        Timeout = TimeSpan.FromSeconds(5),
+        HealthyStatusCodes = new[] { 200 }
+    };
+
+    #region Simple String Responses
+
+    [Fact]
+    public async Task CheckHealth_SimpleHealthyString_ReturnsHealthy()
+    {
+        var checker = CreateChecker("Healthy");
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.IsHealthy.Should().BeTrue();
+        result.ReportedStatus.Should().Be("Healthy");
+        result.Entries.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CheckHealth_SimpleUnhealthyString_ReturnsUnhealthy()
+    {
+        var checker = CreateChecker("Unhealthy");
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.IsHealthy.Should().BeFalse();
+        result.ReportedStatus.Should().Be("Unhealthy");
+    }
+
+    [Fact]
+    public async Task CheckHealth_SimpleDegradedString_ReturnsNotHealthy()
+    {
+        var checker = CreateChecker("Degraded");
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.IsHealthy.Should().BeFalse();
+        result.ReportedStatus.Should().Be("Degraded");
+    }
+
+    #endregion
+
+    #region Full HealthReport JSON
+
+    [Fact]
+    public async Task CheckHealth_FullHealthReport_ParsesAllEntries()
+    {
+        var json = """
+        {
+          "status": "Degraded",
+          "entries": {
+            "database": {
+              "status": "Healthy",
+              "description": "SQL Server connection OK",
+              "duration": "00:00:00.0123456",
+              "data": { "server": "sql01", "database": "ams_project" },
+              "tags": ["db", "critical"],
+              "exception": null
+            },
+            "disk": {
+              "status": "Degraded",
+              "description": "Disk space low on /data",
+              "duration": "00:00:00.0001234",
+              "data": { "freeSpace": "5GB", "totalSpace": "100GB" },
+              "tags": ["infrastructure"],
+              "exception": null
+            },
+            "redis": {
+              "status": "Unhealthy",
+              "description": "Connection refused",
+              "duration": "00:00:05.0012345",
+              "data": {},
+              "tags": ["cache"],
+              "exception": "System.Net.Sockets.SocketException: Connection refused"
+            }
+          }
+        }
+        """;
+
+        var checker = CreateChecker(json);
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.IsHealthy.Should().BeFalse();
+        result.ReportedStatus.Should().Be("Degraded");
+        result.Entries.Should().NotBeNull();
+        result.Entries.Should().HaveCount(3);
+
+        // Database entry
+        var db = result.Entries!.Single(e => e.Name == "database");
+        db.Status.Should().Be("Healthy");
+        db.Description.Should().Be("SQL Server connection OK");
+        db.DurationMs.Should().BeApproximately(12.3456, 0.01);
+        db.Data.Should().ContainKey("server").WhoseValue.Should().Be("sql01");
+        db.Data.Should().ContainKey("database").WhoseValue.Should().Be("ams_project");
+        db.Tags.Should().Contain("db");
+        db.Tags.Should().Contain("critical");
+        db.Exception.Should().BeNull();
+
+        // Disk entry
+        var disk = result.Entries!.Single(e => e.Name == "disk");
+        disk.Status.Should().Be("Degraded");
+        disk.Description.Should().Be("Disk space low on /data");
+        disk.Tags.Should().ContainSingle("infrastructure");
+
+        // Redis entry (with exception)
+        var redis = result.Entries!.Single(e => e.Name == "redis");
+        redis.Status.Should().Be("Unhealthy");
+        redis.Exception.Should().Contain("SocketException");
+        redis.Data.Should().NotBeNull();
+        redis.Data.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CheckHealth_HealthyReport_ParsesEntries()
+    {
+        var json = """
+        {
+          "status": "Healthy",
+          "entries": {
+            "database": {
+              "status": "Healthy",
+              "description": "OK"
+            }
+          }
+        }
+        """;
+
+        var checker = CreateChecker(json);
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.IsHealthy.Should().BeTrue();
+        result.Entries.Should().HaveCount(1);
+        result.Entries![0].Name.Should().Be("database");
+        result.Entries![0].Status.Should().Be("Healthy");
+    }
+
+    #endregion
+
+    #region Minimal / Partial JSON
+
+    [Fact]
+    public async Task CheckHealth_MinimalEntries_OnlyStatus_ParsesCorrectly()
+    {
+        var json = """
+        {
+          "status": "Healthy",
+          "entries": {
+            "check1": { "status": "Healthy" }
+          }
+        }
+        """;
+
+        var checker = CreateChecker(json);
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.Entries.Should().HaveCount(1);
+        var entry = result.Entries![0];
+        entry.Name.Should().Be("check1");
+        entry.Status.Should().Be("Healthy");
+        entry.Description.Should().BeNull();
+        entry.DurationMs.Should().BeNull();
+        entry.Data.Should().BeNull();
+        entry.Tags.Should().BeNull();
+        entry.Exception.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CheckHealth_NoEntries_ReturnsNullEntries()
+    {
+        var json = """{ "status": "Healthy" }""";
+
+        var checker = CreateChecker(json);
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.IsHealthy.Should().BeTrue();
+        result.Entries.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CheckHealth_EmptyEntries_ReturnsEmptyList()
+    {
+        var json = """{ "status": "Healthy", "entries": {} }""";
+
+        var checker = CreateChecker(json);
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.Entries.Should().NotBeNull();
+        result.Entries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CheckHealth_NullExceptionField_ParsesAsNull()
+    {
+        var json = """
+        {
+          "status": "Healthy",
+          "entries": {
+            "check": { "status": "Healthy", "exception": null }
+          }
+        }
+        """;
+
+        var checker = CreateChecker(json);
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.Entries![0].Exception.Should().BeNull();
+    }
+
+    #endregion
+
+    #region Duration Parsing
+
+    [Fact]
+    public async Task CheckHealth_TimeSpanDuration_ParsedToMs()
+    {
+        var json = """
+        {
+          "status": "Healthy",
+          "entries": {
+            "check": { "status": "Healthy", "duration": "00:00:01.5000000" }
+          }
+        }
+        """;
+
+        var checker = CreateChecker(json);
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.Entries![0].DurationMs.Should().BeApproximately(1500.0, 0.1);
+    }
+
+    [Fact]
+    public async Task CheckHealth_SubMillisecondDuration_ParsedCorrectly()
+    {
+        var json = """
+        {
+          "status": "Healthy",
+          "entries": {
+            "check": { "status": "Healthy", "duration": "00:00:00.0001234" }
+          }
+        }
+        """;
+
+        var checker = CreateChecker(json);
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.Entries![0].DurationMs.Should().BeApproximately(0.1234, 0.001);
+    }
+
+    [Fact]
+    public async Task CheckHealth_NumericDuration_ParsedAsMs()
+    {
+        var json = """
+        {
+          "status": "Healthy",
+          "entries": {
+            "check": { "status": "Healthy", "duration": 42.5 }
+          }
+        }
+        """;
+
+        var checker = CreateChecker(json);
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.Entries![0].DurationMs.Should().Be(42.5);
+    }
+
+    [Fact]
+    public async Task CheckHealth_InvalidDurationString_ReturnsNull()
+    {
+        var json = """
+        {
+          "status": "Healthy",
+          "entries": {
+            "check": { "status": "Healthy", "duration": "not-a-timespan" }
+          }
+        }
+        """;
+
+        var checker = CreateChecker(json);
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.Entries![0].DurationMs.Should().BeNull();
+    }
+
+    #endregion
+
+    #region Alternative Property Names
+
+    [Fact]
+    public async Task CheckHealth_PascalCaseProperties_ParsedCorrectly()
+    {
+        var json = """
+        {
+          "Status": "Healthy",
+          "Entries": {
+            "database": {
+              "Status": "Healthy",
+              "Description": "OK",
+              "Duration": "00:00:00.0100000",
+              "Data": { "key": "value" },
+              "Tags": ["tag1"],
+              "Exception": null
+            }
+          }
+        }
+        """;
+
+        var checker = CreateChecker(json);
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.IsHealthy.Should().BeTrue();
+        result.Entries.Should().HaveCount(1);
+        result.Entries![0].Description.Should().Be("OK");
+        result.Entries![0].Data.Should().ContainKey("key");
+        result.Entries![0].Tags.Should().ContainSingle("tag1");
+    }
+
+    [Fact]
+    public async Task CheckHealth_ResultsPropertyName_ParsedCorrectly()
+    {
+        var json = """
+        {
+          "status": "Healthy",
+          "results": {
+            "check1": { "status": "Healthy" }
+          }
+        }
+        """;
+
+        var checker = CreateChecker(json);
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.Entries.Should().HaveCount(1);
+        result.Entries![0].Name.Should().Be("check1");
+    }
+
+    #endregion
+
+    #region Invalid / Edge Cases
+
+    [Fact]
+    public async Task CheckHealth_InvalidJson_ReturnsNoEntries()
+    {
+        var checker = CreateChecker("not valid json at all");
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        // Falls back to HTTP status code check (200 = healthy)
+        result.IsHealthy.Should().BeTrue();
+        result.Entries.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CheckHealth_EmptyResponse_FallsBackToStatusCode()
+    {
+        var checker = CreateChecker("");
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.IsHealthy.Should().BeTrue();
+        result.Entries.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CheckHealth_ResponseTimeMsPopulated()
+    {
+        var checker = CreateChecker("Healthy");
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.ResponseTimeMs.Should().NotBeNull();
+        result.ResponseTimeMs!.Value.Should().BeGreaterThanOrEqualTo(0);
+    }
+
+    [Fact]
+    public async Task CheckHealth_EntryWithMissingStatusField_DefaultsToUnknown()
+    {
+        var json = """
+        {
+          "status": "Healthy",
+          "entries": {
+            "check": { "description": "No status field" }
+          }
+        }
+        """;
+
+        var checker = CreateChecker(json);
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.Entries![0].Status.Should().Be("Unknown");
+    }
+
+    [Fact]
+    public async Task CheckHealth_MultipleDataEntries_AllParsed()
+    {
+        var json = """
+        {
+          "status": "Healthy",
+          "entries": {
+            "check": {
+              "status": "Healthy",
+              "data": {
+                "key1": "value1",
+                "key2": "value2",
+                "key3": "value3"
+              }
+            }
+          }
+        }
+        """;
+
+        var checker = CreateChecker(json);
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.Entries![0].Data.Should().HaveCount(3);
+        result.Entries![0].Data!["key1"].Should().Be("value1");
+        result.Entries![0].Data!["key2"].Should().Be("value2");
+        result.Entries![0].Data!["key3"].Should().Be("value3");
+    }
+
+    [Fact]
+    public async Task CheckHealth_NonObjectEntries_ReturnsNullEntries()
+    {
+        var json = """{ "status": "Healthy", "entries": "not-an-object" }""";
+
+        var checker = CreateChecker(json);
+        var result = await checker.CheckHealthAsync("localhost", DefaultConfig);
+
+        result.Entries.Should().BeNull();
+    }
+
+    #endregion
+
+    #region MockHttpMessageHandler
+
+    private class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly string _content;
+        private readonly HttpStatusCode _statusCode;
+
+        public MockHttpMessageHandler(string content, HttpStatusCode statusCode = HttpStatusCode.OK)
+        {
+            _content = content;
+            _statusCode = statusCode;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent(_content)
+            });
+        }
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- **HttpHealthCheckerTests** (21 tests): Full HealthReport JSON parsing, simple string responses, entry field extraction (description, duration, data, tags, exception), duration parsing (TimeSpan, numeric, invalid), alternative property names (PascalCase, results), edge cases (empty entries, missing fields, invalid JSON)
- **HealthCheckEntryTests** (13 tests): Value object creation, validation (empty name), equality (same/different values), all HealthStatus values
- **HealthSnapshotMapperTests** (7 new tests): Health check entry mapping with data/tags, null entries, empty entries, MapServiceToDto method

## Test plan
- [x] All 287 health-related tests pass
- [x] Build succeeds with 0 errors