### PR TITLE
Update roadmap: move completed epics to Released

### DIFF
--- a/docs/Plans/PLAN-orphaned-container-recovery.md
+++ b/docs/Plans/PLAN-orphaned-container-recovery.md
@@ -63,14 +63,14 @@ Ziel ist es, dem User zwei Aktionen für verwaiste Container-Gruppen anzubieten:
 
 Reihenfolge basierend auf Abhängigkeiten:
 
-- [ ] **Feature 1: Remove Orphaned Stack** – Alle Container einer verwaisten Stack-Gruppe entfernen
+- [x] **Feature 1: Remove Orphaned Stack** – Alle Container einer verwaisten Stack-Gruppe entfernen
   - Neuer Command: `RemoveOrphanedStackCommand(EnvironmentId, StackName)`
   - Handler: Container mit `rsgo.stack == stackName` listen, `RemoveContainerAsync(force: true)` für jeden
   - Neuer Endpoint: `DELETE /api/containers/orphaned-stacks/{stackName}?environment={envId}`
   - Permission: `Deployments.Delete`
   - Abhängig von: -
 
-- [ ] **Feature 2: Repair Orphaned Stack** – Deployment-Eintrag für verwaiste Container erstellen
+- [x] **Feature 2: Repair Orphaned Stack** – Deployment-Eintrag für verwaiste Container erstellen
   - Neuer Command: `RepairOrphanedStackCommand(EnvironmentId, StackName)`
   - Handler:
     1. Container mit `rsgo.stack == stackName` aus Docker listen
@@ -83,7 +83,7 @@ Reihenfolge basierend auf Abhängigkeiten:
   - Response: Erfolg/Misserfolg + erstellte DeploymentId
   - Abhängig von: -
 
-- [ ] **Feature 3: UI-Aktionen im Container-View** – Buttons für Remove und Repair bei Orphaned Stacks
+- [x] **Feature 3: UI-Aktionen im Container-View** – Buttons für Remove und Repair bei Orphaned Stacks
   - In allen drei Views (List, Stack, Product): Aktions-Buttons bei Orphaned Badge anzeigen
   - "Repair" Button: Ruft Repair-Endpoint auf, refresht View
   - "Remove" Button: Confirmation Dialog, ruft Remove-Endpoint auf, refresht View
@@ -92,13 +92,13 @@ Reihenfolge basierend auf Abhängigkeiten:
   - Product-View: Buttons im "Unknown Product" Bereich
   - Abhängig von: Feature 1, Feature 2
 
-- [ ] **Feature 4: Tests** – Unit Tests für Handler, Edge Cases
+- [x] **Feature 4: Tests** – Unit Tests für Handler, Edge Cases
   - `RemoveOrphanedStackHandlerTests`: Happy path, Stack nicht gefunden, Environment nicht gefunden
   - `RepairOrphanedStackHandlerTests`: Happy path, Catalog-Match gefunden, kein Catalog-Match, Container ohne Labels
   - Edge Cases: Was passiert wenn Container während Repair/Remove gestoppt werden?
   - Abhängig von: Feature 1, Feature 2
 
-- [ ] **Phase abschließen** – Build, Tests, Commit, PR gegen main
+- [x] **Phase abschließen** – Build, Tests, Commit, PR gegen main
 
 ## Test-Strategie
 

--- a/docs/Reference/Roadmap.md
+++ b/docs/Reference/Roadmap.md
@@ -184,7 +184,7 @@ Release version numbers are assigned when an Epic ships, not during planning.
   - Volume Details (Size, Mount Points, Labels, Container References)
   - Create/Delete Volumes with Driver Selection
   - Orphaned Volume Detection and Bulk Cleanup
-- **v0.26** – Container Management Improvements (2026-02-17)
+- **v0.26** – Container Management, Notifications & System Info (2026-02-17)
   - Container Remove Action with Force Flag and Safety Checks
   - Container Context Endpoint (Stack/Product/Deployment Resolution)
   - Three Container Views (List, Stack-Grouped, Product-Grouped)
@@ -193,7 +193,17 @@ Release version numbers are assigned when an Epic ships, not during planning.
   - Dedicated Delete Confirmation Pages (Stack Sources, Environments)
   - ams.project Stack Source in Curated Registry
   - External Network Auto-Creation for Multi-Stack Products
-- **v0.27** – Product Deployment (2026-02-21)
+  - In-Memory Notification Store (Max 50, FIFO Eviction, Singleton — Transient Pre-v1.0)
+  - Notification API Endpoints (List, Unread-Count, Mark-Read, Mark-All-Read, Dismiss)
+  - NotificationDropdown (Bell Icon with Animated Badge, 60s Polling)
+  - Update Available Notification (Deduplicated Per Version)
+  - Source Sync Result Notification (Success/Warning/Error with Detail Rollup)
+  - Deployment Result Notification (Deploy, Upgrade, Rollback, Remove — Stack & Product)
+  - Settings > System Tab (Version Info, Build Info, "Check for Updates" Button)
+  - User-Dropdown Version Badge (Version Display + Update Indicator)
+  - Shared `useVersionInfo` Hook (SidebarWidget, UserDropdown, SystemInfo)
+  - `forceCheck` Query Parameter on Version Endpoint (Bypass 24h Cache)
+- **v0.27** – Product Deployment & Orphaned Container Recovery (2026-02-21)
   - ProductDeployment Aggregate Root with ProductStackDeployment Child Entities
   - Product-Level State Machine (Deploying → Running / PartiallyRunning / Failed → Removing → Removed)
   - Deploy Product Flow (Orchestrated N-Stack Deployment with Shared Variable Wizard)
@@ -209,6 +219,10 @@ Release version numbers are assigned when an Epic ships, not during planning.
   - Shared DeploymentProgressPanel Component (Extracted from Single-Stack Deployment)
   - Product Deployment E2E Tests with Multi-Stack Test Product
   - Step-by-Step Documentation with Screenshots (DE/EN)
+  - Repair Orphaned Stacks (Reconcile Running Containers with Fresh Database via Catalog Matching)
+  - Bulk Remove Orphaned Stacks (Delete All Containers of an Orphaned Stack Group)
+  - Repair All Orphaned Stacks (Batch Repair with Per-Stack Error Handling)
+  - Orphaned Stack UI Actions (Repair/Remove Buttons with Confirmation Dialogs in All Container Views)
 
 - **v0.28** – Deployments Overview with Product Info (2026-02-25)
   - Product Deployments Section in Deployments Overview (Above Stack Deployments)
@@ -240,27 +254,8 @@ Release version numbers are assigned when an Epic ships, not during planning.
 
 Epics are listed in priority order. Top = next.
 
-### Epic: Orphaned Container Recovery
+### Epic: Notifications Phase 2
 
-- Repair Orphaned Stacks (Reconcile running containers with fresh database)
-- Bulk Remove Orphaned Stacks (Delete all containers of an orphaned stack group)
-- UI Actions in Container Views (Repair/Remove buttons on orphaned badges)
-
-### Epic: Notifications & System Info
-
-**Phase 1** (next)
-- In-Memory Notification Store (max 50, transient, no DB)
-- Notification API Endpoints (list, unread-count, mark-read, dismiss)
-- NotificationDropdown with Real Data (Bell Icon, Badge, Polling 60s)
-- Update Available Notification (deduplicated per version)
-- Source Sync Result Notification (success/warning/error)
-- Deployment Result Notification (deploy, upgrade, rollback, remove)
-- Settings > System Tab (version info, build info, "Check for updates" button)
-- User-Dropdown Version Badge (version display + update indicator)
-- Shared `useVersionInfo` Hook (SidebarWidget, UserDropdown, Settings)
-- `forceCheck` Query Parameter on Version Endpoint (bypass 24h cache)
-
-**Phase 2** (later)
 - Container Health Change Notification (unhealthy, stopped — with throttling)
 - API Key First-Use Notification
 - TLS Certificate Expiry Notification (30d, 14d, 7d, 3d, 1d staged warnings)


### PR DESCRIPTION
## Summary

- Move **Orphaned Container Recovery** from Planned to Released under v0.27
- Move **Notifications & System Info Phase 1** from Planned to Released under v0.26
- Mark all features in `PLAN-orphaned-container-recovery.md` as complete
- Restructure Planned section: Phase 2 becomes the next epic

Both epics were fully implemented and merged to main but the roadmap was not updated at the time.