### PR TITLE
Fix deploy hook creating duplicate stacks for product deployments

### DIFF
--- a/src/ReadyStackGo.Application/UseCases/Hooks/DeployStack/DeployViaHookCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Hooks/DeployStack/DeployViaHookCommand.cs
@@ -4,6 +4,7 @@ using ReadyStackGo.Application.Services;
 using ReadyStackGo.Application.UseCases.Deployments.DeployStack;
 using ReadyStackGo.Domain.Deployment.Deployments;
 using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.Deployment.ProductDeployments;
 using ReadyStackGo.Domain.StackManagement.Stacks;
 
 namespace ReadyStackGo.Application.UseCases.Hooks.DeployStack;
@@ -45,17 +46,20 @@ public record DeployViaHookCommand(
 public class DeployViaHookHandler : IRequestHandler<DeployViaHookCommand, DeployViaHookResponse>
 {
     private readonly IDeploymentRepository _deploymentRepository;
+    private readonly IProductDeploymentRepository _productDeploymentRepository;
     private readonly IProductSourceService _productSourceService;
     private readonly IMediator _mediator;
     private readonly ILogger<DeployViaHookHandler> _logger;
 
     public DeployViaHookHandler(
         IDeploymentRepository deploymentRepository,
+        IProductDeploymentRepository productDeploymentRepository,
         IProductSourceService productSourceService,
         IMediator mediator,
         ILogger<DeployViaHookHandler> logger)
     {
         _deploymentRepository = deploymentRepository;
+        _productDeploymentRepository = productDeploymentRepository;
         _productSourceService = productSourceService;
         _mediator = mediator;
         _logger = logger;
@@ -81,6 +85,7 @@ public class DeployViaHookHandler : IRequestHandler<DeployViaHookCommand, Deploy
 
         // 1b. Resolve StackId from ProductId if not directly provided
         string resolvedStackId;
+        string? resolvedStackDefinitionName = null;
         if (!string.IsNullOrWhiteSpace(request.StackId))
         {
             resolvedStackId = request.StackId;
@@ -94,12 +99,40 @@ public class DeployViaHookHandler : IRequestHandler<DeployViaHookCommand, Deploy
                 return DeployViaHookResponse.Failed(resolveResult.Error!);
             }
             resolvedStackId = resolveResult.StackId!;
+            resolvedStackDefinitionName = resolveResult.StackDefinitionName;
         }
 
         var environmentId = new EnvironmentId(envGuid);
 
+        // 1c. If deploying via ProductId, check if stack belongs to an active ProductDeployment
+        // and resolve the actual deployment stack name (e.g., "Analytics" → "ams-project-analytics")
+        var deployStackName = request.StackName;
+        if (!string.IsNullOrWhiteSpace(request.ProductId))
+        {
+            var productDeployment = _productDeploymentRepository
+                .GetActiveByProductGroupId(environmentId, request.ProductId);
+
+            if (productDeployment != null)
+            {
+                var stackDefName = resolvedStackDefinitionName ?? request.StackDefinitionName;
+                if (!string.IsNullOrWhiteSpace(stackDefName))
+                {
+                    var productStack = productDeployment.Stacks.FirstOrDefault(s =>
+                        string.Equals(s.StackName, stackDefName, StringComparison.OrdinalIgnoreCase));
+
+                    if (productStack?.DeploymentStackName != null)
+                    {
+                        deployStackName = productStack.DeploymentStackName;
+                        _logger.LogInformation(
+                            "Stack is part of product deployment '{ProductName}', using deployment name '{DeploymentStackName}' instead of '{RequestStackName}'",
+                            productDeployment.ProductName, deployStackName, request.StackName);
+                    }
+                }
+            }
+        }
+
         // 2. Check for existing deployment (idempotent behavior)
-        var existing = _deploymentRepository.GetByStackName(environmentId, request.StackName);
+        var existing = _deploymentRepository.GetByStackName(environmentId, deployStackName);
         string action;
         string stackId;
         Dictionary<string, string> variables;
@@ -127,7 +160,7 @@ public class DeployViaHookHandler : IRequestHandler<DeployViaHookCommand, Deploy
 
             _logger.LogInformation(
                 "Stack '{StackName}' already running in environment {EnvironmentId}, triggering redeploy with {VarCount} variables ({OverrideCount} overrides from webhook)",
-                request.StackName, request.EnvironmentId, variables.Count, request.Variables.Count);
+                deployStackName, request.EnvironmentId, variables.Count, request.Variables.Count);
         }
         else
         {
@@ -138,14 +171,14 @@ public class DeployViaHookHandler : IRequestHandler<DeployViaHookCommand, Deploy
 
             _logger.LogInformation(
                 "Deploying stack '{StackName}' ({StackId}) to environment {EnvironmentId}",
-                request.StackName, resolvedStackId, request.EnvironmentId);
+                deployStackName, resolvedStackId, request.EnvironmentId);
         }
 
         // 3. Delegate to DeployStackCommand
         var deployResult = await _mediator.Send(new DeployStackCommand(
             request.EnvironmentId,
             stackId,
-            request.StackName,
+            deployStackName,
             variables,
             null), cancellationToken);
 
@@ -173,7 +206,7 @@ public class DeployViaHookHandler : IRequestHandler<DeployViaHookCommand, Deploy
         };
     }
 
-    private record StackIdResolutionResult(bool Success, string? StackId, string? Error);
+    private record StackIdResolutionResult(bool Success, string? StackId, string? StackDefinitionName, string? Error);
 
     private async Task<StackIdResolutionResult> ResolveStackIdFromProduct(
         string productId, string? version, string? stackDefinitionName, CancellationToken ct)
@@ -182,7 +215,7 @@ public class DeployViaHookHandler : IRequestHandler<DeployViaHookCommand, Deploy
         var product = await _productSourceService.GetProductAsync(productId, ct);
         if (product == null)
         {
-            return new(false, null, $"Product '{productId}' not found in catalog.");
+            return new(false, null, null, $"Product '{productId}' not found in catalog.");
         }
 
         // 2. If specific version requested, find that version
@@ -197,7 +230,7 @@ public class DeployViaHookHandler : IRequestHandler<DeployViaHookCommand, Deploy
                 var available = string.Join(", ", versions
                     .Where(v => v.ProductVersion != null)
                     .Select(v => v.ProductVersion));
-                return new(false, null,
+                return new(false, null, null,
                     $"Version '{version}' not found for product '{productId}'. Available versions: {available}");
             }
 
@@ -212,7 +245,7 @@ public class DeployViaHookHandler : IRequestHandler<DeployViaHookCommand, Deploy
             if (found == null)
             {
                 var availableStacks = string.Join(", ", product.Stacks.Select(s => s.Name));
-                return new(false, null,
+                return new(false, null, null,
                     $"Stack '{stackDefinitionName}' not found in product '{productId}'. " +
                     $"Available stacks: {availableStacks}");
             }
@@ -223,7 +256,7 @@ public class DeployViaHookHandler : IRequestHandler<DeployViaHookCommand, Deploy
             if (product.IsMultiStack)
             {
                 var availableStacks = string.Join(", ", product.Stacks.Select(s => s.Name));
-                return new(false, null,
+                return new(false, null, null,
                     $"Product '{productId}' contains multiple stacks. " +
                     $"Specify 'stackDefinitionName' to select one. Available stacks: {availableStacks}");
             }
@@ -234,6 +267,6 @@ public class DeployViaHookHandler : IRequestHandler<DeployViaHookCommand, Deploy
             "Resolved ProductId '{ProductId}' to StackId '{StackId}'",
             productId, stack.Id.Value);
 
-        return new(true, stack.Id.Value, null);
+        return new(true, stack.Id.Value, stack.Name, null);
     }
 }

--- a/tests/ReadyStackGo.UnitTests/Application/Hooks/DeployViaHookHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Hooks/DeployViaHookHandlerTests.cs
@@ -8,6 +8,7 @@ using ReadyStackGo.Application.UseCases.Hooks.DeployStack;
 using ReadyStackGo.Domain.Deployment;
 using ReadyStackGo.Domain.Deployment.Deployments;
 using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.Deployment.ProductDeployments;
 using ReadyStackGo.Domain.StackManagement.Stacks;
 
 namespace ReadyStackGo.UnitTests.Application.Hooks;
@@ -15,6 +16,7 @@ namespace ReadyStackGo.UnitTests.Application.Hooks;
 public class DeployViaHookHandlerTests
 {
     private readonly Mock<IDeploymentRepository> _deploymentRepoMock;
+    private readonly Mock<IProductDeploymentRepository> _productDeploymentRepoMock;
     private readonly Mock<IProductSourceService> _productSourceMock;
     private readonly Mock<IMediator> _mediatorMock;
     private readonly Mock<ILogger<DeployViaHookHandler>> _loggerMock;
@@ -27,11 +29,13 @@ public class DeployViaHookHandlerTests
     public DeployViaHookHandlerTests()
     {
         _deploymentRepoMock = new Mock<IDeploymentRepository>();
+        _productDeploymentRepoMock = new Mock<IProductDeploymentRepository>();
         _productSourceMock = new Mock<IProductSourceService>();
         _mediatorMock = new Mock<IMediator>();
         _loggerMock = new Mock<ILogger<DeployViaHookHandler>>();
         _handler = new DeployViaHookHandler(
             _deploymentRepoMock.Object,
+            _productDeploymentRepoMock.Object,
             _productSourceMock.Object,
             _mediatorMock.Object,
             _loggerMock.Object);
@@ -744,6 +748,263 @@ public class DeployViaHookHandlerTests
 
     #endregion
 
+    #region ProductDeployment-Aware Stack Name Resolution
+
+    [Fact]
+    public async Task Handle_ProductIdWithActiveProductDeployment_UsesDeploymentStackName()
+    {
+        // Product deployed as "ams-project" with stack "Analytics" → derived name "ams-project-analytics"
+        var product = CreateSingleStackProduct("com.test.product", version: "1.0.0",
+            sourceId: "source1", stackName: "Analytics");
+        SetupProductLookup("com.test.product", product);
+
+        var productDeployment = CreateRunningProductDeployment(
+            "com.test.product", "ams-project",
+            ("Analytics", "Analytics", product.DefaultStack.Id.Value));
+
+        _productDeploymentRepoMock
+            .Setup(r => r.GetActiveByProductGroupId(
+                It.Is<EnvironmentId>(e => e.Value == Guid.Parse(TestEnvironmentId)),
+                "com.test.product"))
+            .Returns(productDeployment);
+
+        // The existing deployment uses the derived name "ams-project-analytics"
+        var existingDeployment = CreateRunningDeployment(
+            stackName: "ams-project-analytics",
+            stackId: product.DefaultStack.Id.Value);
+        _deploymentRepoMock
+            .Setup(r => r.GetByStackName(
+                It.Is<EnvironmentId>(e => e.Value == Guid.Parse(TestEnvironmentId)),
+                "ams-project-analytics"))
+            .Returns(existingDeployment);
+
+        SetupSuccessfulDeploy();
+
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(null, "Analytics", TestEnvironmentId, new(),
+                ProductId: "com.test.product", StackDefinitionName: "Analytics"),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Action.Should().Be("redeployed");
+
+        // Should use the derived deployment stack name, not the raw request name
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<DeployStackCommand>(cmd => cmd.StackName == "ams-project-analytics"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ProductIdWithActiveProductDeployment_MergesVariablesFromExistingDeployment()
+    {
+        var product = CreateSingleStackProduct("com.test.product", version: "1.0.0",
+            sourceId: "source1", stackName: "Analytics");
+        SetupProductLookup("com.test.product", product);
+
+        var productDeployment = CreateRunningProductDeployment(
+            "com.test.product", "ams-project",
+            ("Analytics", "Analytics", product.DefaultStack.Id.Value));
+
+        _productDeploymentRepoMock
+            .Setup(r => r.GetActiveByProductGroupId(
+                It.Is<EnvironmentId>(e => e.Value == Guid.Parse(TestEnvironmentId)),
+                "com.test.product"))
+            .Returns(productDeployment);
+
+        var existingVars = new Dictionary<string, string>
+        {
+            ["DB_HOST"] = "stored-host",
+            ["LOG_LEVEL"] = "Warning"
+        };
+        var existingDeployment = CreateRunningDeployment(
+            stackName: "ams-project-analytics",
+            stackId: product.DefaultStack.Id.Value,
+            variables: existingVars);
+        _deploymentRepoMock
+            .Setup(r => r.GetByStackName(
+                It.Is<EnvironmentId>(e => e.Value == Guid.Parse(TestEnvironmentId)),
+                "ams-project-analytics"))
+            .Returns(existingDeployment);
+
+        SetupSuccessfulDeploy();
+
+        var webhookVars = new Dictionary<string, string> { ["LOG_LEVEL"] = "Debug" };
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(null, "Analytics", TestEnvironmentId, webhookVars,
+                ProductId: "com.test.product", StackDefinitionName: "Analytics"),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<DeployStackCommand>(cmd =>
+                cmd.Variables["DB_HOST"] == "stored-host" &&
+                cmd.Variables["LOG_LEVEL"] == "Debug"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ProductIdWithActiveProductDeployment_NoMatchingStack_FallsBackToRequestStackName()
+    {
+        var product = CreateSingleStackProduct("com.test.product", version: "1.0.0",
+            sourceId: "source1", stackName: "Analytics");
+        SetupProductLookup("com.test.product", product);
+
+        // Product deployment exists but has different stacks
+        var productDeployment = CreateRunningProductDeployment(
+            "com.test.product", "ams-project",
+            ("OtherStack", "Other Stack", "some-other-id"));
+
+        _productDeploymentRepoMock
+            .Setup(r => r.GetActiveByProductGroupId(
+                It.Is<EnvironmentId>(e => e.Value == Guid.Parse(TestEnvironmentId)),
+                "com.test.product"))
+            .Returns(productDeployment);
+
+        SetupNoExistingDeployment();
+        SetupSuccessfulDeploy();
+
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(null, "Analytics", TestEnvironmentId, new(),
+                ProductId: "com.test.product", StackDefinitionName: "Analytics"),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Action.Should().Be("deployed");
+
+        // Should use the raw request stack name since no matching product stack was found
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<DeployStackCommand>(cmd => cmd.StackName == "Analytics"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ProductIdWithNoActiveProductDeployment_DeploysAsStandalone()
+    {
+        var product = CreateSingleStackProduct("com.test.product", version: "1.0.0",
+            sourceId: "source1", stackName: "Analytics");
+        SetupProductLookup("com.test.product", product);
+
+        _productDeploymentRepoMock
+            .Setup(r => r.GetActiveByProductGroupId(
+                It.IsAny<EnvironmentId>(), "com.test.product"))
+            .Returns((ProductDeployment?)null);
+
+        SetupNoExistingDeployment();
+        SetupSuccessfulDeploy();
+
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(null, "Analytics", TestEnvironmentId, new(),
+                ProductId: "com.test.product", StackDefinitionName: "Analytics"),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Action.Should().Be("deployed");
+
+        // No product deployment → use raw request stack name
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<DeployStackCommand>(cmd => cmd.StackName == "Analytics"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_StackIdOnly_DoesNotCheckProductDeployment()
+    {
+        SetupNoExistingDeployment();
+        SetupSuccessfulDeploy();
+
+        await _handler.Handle(
+            new DeployViaHookCommand(TestStackId, TestStackName, TestEnvironmentId, new()),
+            CancellationToken.None);
+
+        // StackId path should NOT look up ProductDeployments
+        _productDeploymentRepoMock.Verify(
+            r => r.GetActiveByProductGroupId(It.IsAny<EnvironmentId>(), It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ProductIdWithActiveProductDeployment_ResponseUsesRequestStackName()
+    {
+        var product = CreateSingleStackProduct("com.test.product", version: "1.0.0",
+            sourceId: "source1", stackName: "Analytics");
+        SetupProductLookup("com.test.product", product);
+
+        var productDeployment = CreateRunningProductDeployment(
+            "com.test.product", "ams-project",
+            ("Analytics", "Analytics", product.DefaultStack.Id.Value));
+
+        _productDeploymentRepoMock
+            .Setup(r => r.GetActiveByProductGroupId(
+                It.Is<EnvironmentId>(e => e.Value == Guid.Parse(TestEnvironmentId)),
+                "com.test.product"))
+            .Returns(productDeployment);
+
+        var existingDeployment = CreateRunningDeployment(
+            stackName: "ams-project-analytics",
+            stackId: product.DefaultStack.Id.Value);
+        _deploymentRepoMock
+            .Setup(r => r.GetByStackName(
+                It.Is<EnvironmentId>(e => e.Value == Guid.Parse(TestEnvironmentId)),
+                "ams-project-analytics"))
+            .Returns(existingDeployment);
+
+        SetupSuccessfulDeploy();
+
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(null, "Analytics", TestEnvironmentId, new(),
+                ProductId: "com.test.product", StackDefinitionName: "Analytics"),
+            CancellationToken.None);
+
+        // Response should use the user-facing request stack name, not the derived name
+        result.StackName.Should().Be("Analytics");
+        result.Message.Should().Contain("Analytics");
+    }
+
+    [Fact]
+    public async Task Handle_ProductIdWithActiveProductDeployment_CaseInsensitiveStackMatch()
+    {
+        var product = CreateSingleStackProduct("com.test.product", version: "1.0.0",
+            sourceId: "source1", stackName: "ProjectManagement");
+        SetupProductLookup("com.test.product", product);
+
+        var productDeployment = CreateRunningProductDeployment(
+            "com.test.product", "ams-project",
+            ("ProjectManagement", "Project Management", product.DefaultStack.Id.Value));
+
+        _productDeploymentRepoMock
+            .Setup(r => r.GetActiveByProductGroupId(
+                It.Is<EnvironmentId>(e => e.Value == Guid.Parse(TestEnvironmentId)),
+                "com.test.product"))
+            .Returns(productDeployment);
+
+        var existingDeployment = CreateRunningDeployment(
+            stackName: "ams-project-projectmanagement",
+            stackId: product.DefaultStack.Id.Value);
+        _deploymentRepoMock
+            .Setup(r => r.GetByStackName(
+                It.Is<EnvironmentId>(e => e.Value == Guid.Parse(TestEnvironmentId)),
+                "ams-project-projectmanagement"))
+            .Returns(existingDeployment);
+
+        SetupSuccessfulDeploy();
+
+        // StackDefinitionName with different casing
+        var result = await _handler.Handle(
+            new DeployViaHookCommand(null, "ProjectManagement", TestEnvironmentId, new(),
+                ProductId: "com.test.product", StackDefinitionName: "projectmanagement"),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Action.Should().Be("redeployed");
+
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<DeployStackCommand>(cmd => cmd.StackName == "ams-project-projectmanagement"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    #endregion
+
     #region Helpers
 
     private void SetupNoExistingDeployment()
@@ -814,6 +1075,34 @@ public class DeployViaHookHandlerTests
         deployment.MarkAsRunning();
         deployment.MarkAsRemoved();
         return deployment;
+    }
+
+    private static ProductDeployment CreateRunningProductDeployment(
+        string productGroupId,
+        string deploymentName,
+        params (string stackName, string displayName, string stackId)[] stacks)
+    {
+        var envId = new EnvironmentId(Guid.Parse(TestEnvironmentId));
+        var stackConfigs = stacks.Select(s =>
+            new StackDeploymentConfig(s.stackName, s.displayName, s.stackId, 1,
+                new Dictionary<string, string>())).ToList();
+
+        var pd = ProductDeployment.InitiateDeployment(
+            ProductDeploymentId.NewId(), envId,
+            productGroupId, $"source1:{productGroupId}:1.0.0",
+            productGroupId, productGroupId, "1.0.0",
+            UserId.NewId(), deploymentName,
+            stackConfigs,
+            new Dictionary<string, string>());
+
+        // Transition each stack to Running
+        foreach (var stack in pd.GetStacksInDeployOrder())
+        {
+            pd.StartStack(stack.StackName, DeploymentId.NewId());
+            pd.CompleteStack(stack.StackName);
+        }
+
+        return pd;
     }
 
     #endregion


### PR DESCRIPTION
## Summary

- Deploy hook now resolves the correct deployment stack name when a stack belongs to an active ProductDeployment
- Previously, the hook searched for raw request name (e.g., "Analytics") instead of the derived name ("ams-project-analytics"), causing duplicate standalone deployments
- Adds `IProductDeploymentRepository` to `DeployViaHookHandler` and checks `GetActiveByProductGroupId` when `ProductId` is provided
- Falls back to raw request name when no active ProductDeployment exists (backward-compatible)

## Test plan

- [x] 7 new unit tests covering ProductDeployment-aware stack name resolution
- [x] All 2341 unit tests pass
- [x] All 409 integration tests pass
- [ ] Manual test: deploy product via UI, then redeploy individual stack via hook — should redeploy existing, not create duplicate