### PR TITLE
Fix notification click-through URLs

### DIFF
--- a/src/ReadyStackGo.Application/Notifications/NotificationFactory.cs
+++ b/src/ReadyStackGo.Application/Notifications/NotificationFactory.cs
@@ -20,7 +20,7 @@ public static class NotificationFactory
             Title = title,
             Message = message,
             Severity = severity,
-            ActionUrl = "/stack-sources",
+            ActionUrl = "/settings/stack-sources",
             ActionLabel = "View Sources",
             Metadata = new Dictionary<string, string>
             {
@@ -48,7 +48,7 @@ public static class NotificationFactory
         if (!string.IsNullOrEmpty(deploymentId))
         {
             metadata["deploymentId"] = deploymentId;
-            actionUrl = $"/deployments/{deploymentId}";
+            actionUrl = $"/deployments/{Uri.EscapeDataString(stackName)}";
         }
 
         return new Notification

--- a/tests/ReadyStackGo.UnitTests/Notifications/NotificationFactoryTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Notifications/NotificationFactoryTests.cs
@@ -91,7 +91,7 @@ public class NotificationFactoryTests
             success: true, stacksLoaded: 1, sourcesSynced: 1,
             errors: [], warnings: []);
 
-        notification.ActionUrl.Should().Be("/stack-sources");
+        notification.ActionUrl.Should().Be("/settings/stack-sources");
         notification.ActionLabel.Should().Be("View Sources");
     }
 
@@ -178,9 +178,19 @@ public class NotificationFactoryTests
             success: true, operation: "deploy", stackName: "my-stack",
             deploymentId: "dep-123");
 
-        notification.ActionUrl.Should().Be("/deployments/dep-123");
+        notification.ActionUrl.Should().Be("/deployments/my-stack");
         notification.ActionLabel.Should().Be("View Deployment");
         notification.Metadata["deploymentId"].Should().Be("dep-123");
+    }
+
+    [Fact]
+    public void CreateDeploymentResult_WithDeploymentId_UsesStackNameInActionUrl()
+    {
+        var notification = NotificationFactory.CreateDeploymentResult(
+            success: true, operation: "deploy", stackName: "my stack/special",
+            deploymentId: "dep-123");
+
+        notification.ActionUrl.Should().Be("/deployments/my%20stack%2Fspecial");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- Source sync notification linked to `/stack-sources` (404), corrected to `/settings/stack-sources`
- Deployment notification linked to `/deployments/{GUID}` but the route expects a stack name, corrected to `/deployments/{stackName}` with URL encoding