### PR TITLE
Add notification types for Notifications Phase 2

### DIFF
--- a/docs/Plans/PLAN-notifications-phase2.md
+++ b/docs/Plans/PLAN-notifications-phase2.md
@@ -155,16 +155,17 @@ Drei neue Notification-Typen für proaktive Benachrichtigungen hinzufügen: Cont
 
 ## Offene Punkte
 
-- [ ] Sollen Self-Signed-Zertifikate Expiry-Warnungen erzeugen? (Sie werden meist automatisch neu generiert beim Neustart)
-- [ ] Soll der Health-Change-Cooldown konfigurierbar sein oder fest auf 5 Minuten?
-- [ ] Soll die Health-Recovery (Unhealthy→Healthy) auch eine Notification erzeugen? (Info-Severity "Service recovered")
+- [x] ~~Sollen Self-Signed-Zertifikate Expiry-Warnungen erzeugen?~~ → Ja, alle Zertifikate warnen
+- [x] ~~Soll der Health-Change-Cooldown konfigurierbar sein oder fest auf 5 Minuten?~~ → Konfigurierbar über Settings-Page
+- [x] ~~Soll die Health-Recovery (Unhealthy→Healthy) auch eine Notification erzeugen?~~ → Ja, Info-Severity "Service recovered"
 
 ## Entscheidungen
 
 | Entscheidung | Optionen | Gewählt | Begründung |
 |---|---|---|---|
-| Health Throttle | A) ExistsAsync Dedup, B) ConcurrentDict Cooldown, C) Beides | **C) Beides** | ConcurrentDict für Echtzeit-Cooldown (5 Min), ExistsAsync als Backup gegen Restarts |
+| Health Throttle | A) ExistsAsync Dedup, B) ConcurrentDict Cooldown, C) Beides | **C) Beides** | ConcurrentDict für Echtzeit-Cooldown (default 5 Min), ExistsAsync als Backup gegen Restarts |
 | TLS Service | A) CertificateRenewalService erweitern, B) Neuer Service | **B) Neuer Service** | Separation of Concerns — Renewal ≠ Expiry Notification |
 | First-Use DI | A) Constructor Injection, B) ServiceProvider Resolve | **B) ServiceProvider** | Auth Handler hat keinen Zugriff auf DI-Container direkt, `HttpContext.RequestServices` ist der Standard-Weg |
-| Health Notification Scope | A) Nur Verschlechterung, B) Verschlechterung + Recovery | - | **Offen — User fragen** |
-| Self-Signed Expiry | A) Warnen, B) Ignorieren | - | **Offen — User fragen** |
+| Health Notification Scope | A) Nur Verschlechterung, B) Verschlechterung + Recovery | **B) Verschlechterung + Recovery** | Recovery als Info-Notification — User möchte wissen wenn Services wieder gesund sind |
+| Self-Signed Expiry | A) Warnen, B) Ignorieren | **A) Warnen** | Alle Zertifikate gleich behandeln — User explizit gewünscht |
+| Health Cooldown | A) Fix 5 Min, B) Konfigurierbar | **B) Konfigurierbar** | Settings-Page-Eintrag, Default 5 Minuten. User möchte den Wert selbst anpassen können |

--- a/src/ReadyStackGo.Application/Notifications/Notification.cs
+++ b/src/ReadyStackGo.Application/Notifications/Notification.cs
@@ -23,7 +23,10 @@ public enum NotificationType
     UpdateAvailable,
     SourceSyncResult,
     DeploymentResult,
-    ProductDeploymentResult
+    ProductDeploymentResult,
+    HealthChange,
+    ApiKeyFirstUse,
+    CertificateExpiry
 }
 
 public enum NotificationSeverity

--- a/src/ReadyStackGo.Application/Notifications/NotificationFactory.cs
+++ b/src/ReadyStackGo.Application/Notifications/NotificationFactory.cs
@@ -110,6 +110,101 @@ public static class NotificationFactory
         };
     }
 
+    public static Notification CreateHealthChangeNotification(
+        string stackName, string serviceName,
+        string previousStatus, string currentStatus,
+        string? deploymentId = null)
+    {
+        var isRecovery = currentStatus.Equals("Healthy", StringComparison.OrdinalIgnoreCase);
+        var severity = ResolveHealthSeverity(currentStatus);
+        var title = isRecovery ? "Service Recovered" : "Service Health Changed";
+        var message = $"Service '{serviceName}' in stack '{stackName}' changed from {previousStatus} to {currentStatus}.";
+
+        var metadata = new Dictionary<string, string>
+        {
+            ["serviceKey"] = $"{deploymentId}:{serviceName}",
+            ["stackName"] = stackName,
+            ["serviceName"] = serviceName,
+            ["previousStatus"] = previousStatus,
+            ["currentStatus"] = currentStatus
+        };
+
+        string? actionUrl = null;
+        if (!string.IsNullOrEmpty(deploymentId))
+        {
+            metadata["deploymentId"] = deploymentId;
+            actionUrl = $"/deployments/{Uri.EscapeDataString(stackName)}";
+        }
+
+        return new Notification
+        {
+            Type = NotificationType.HealthChange,
+            Title = title,
+            Message = message,
+            Severity = severity,
+            ActionUrl = actionUrl ?? "/health",
+            ActionLabel = actionUrl != null ? "View Deployment" : "View Health",
+            Metadata = metadata
+        };
+    }
+
+    public static Notification CreateApiKeyFirstUseNotification(
+        string keyName, string keyPrefix)
+    {
+        return new Notification
+        {
+            Type = NotificationType.ApiKeyFirstUse,
+            Title = "API Key First Used",
+            Message = $"API key '{keyName}' ({keyPrefix}...) was used for the first time.",
+            Severity = NotificationSeverity.Info,
+            ActionUrl = "/settings/api-keys",
+            ActionLabel = "View API Keys",
+            Metadata = new Dictionary<string, string>
+            {
+                ["keyName"] = keyName,
+                ["keyPrefix"] = keyPrefix
+            }
+        };
+    }
+
+    public static Notification CreateCertificateExpiryNotification(
+        string subject, string thumbprint, DateTime expiresAt, int daysRemaining)
+    {
+        var severity = daysRemaining <= 7
+            ? NotificationSeverity.Error
+            : NotificationSeverity.Warning;
+
+        var title = daysRemaining <= 0 ? "Certificate Expired!" : "Certificate Expiring Soon";
+        var message = daysRemaining <= 0
+            ? $"Certificate for '{subject}' has expired!"
+            : $"Certificate for '{subject}' expires in {daysRemaining} day(s).";
+
+        return new Notification
+        {
+            Type = NotificationType.CertificateExpiry,
+            Title = title,
+            Message = message,
+            Severity = severity,
+            ActionUrl = "/settings/tls",
+            ActionLabel = "View TLS Settings",
+            Metadata = new Dictionary<string, string>
+            {
+                ["subject"] = subject,
+                ["thumbprint"] = thumbprint,
+                ["daysRemaining"] = daysRemaining.ToString(),
+                ["threshold"] = $"{thumbprint}:{daysRemaining}"
+            }
+        };
+    }
+
+    private static NotificationSeverity ResolveHealthSeverity(string currentStatus) =>
+        currentStatus.ToLowerInvariant() switch
+        {
+            "unhealthy" or "notfound" => NotificationSeverity.Error,
+            "degraded" => NotificationSeverity.Warning,
+            _ => NotificationSeverity.Info
+        };
+
     private static (NotificationSeverity Severity, string Title, string Message) ResolveSyncSeverity(
         bool success, int stacksLoaded, int sourcesSynced,
         IReadOnlyList<string> errors, IReadOnlyList<string> warnings,

--- a/tests/ReadyStackGo.UnitTests/Notifications/NotificationFactoryTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Notifications/NotificationFactoryTests.cs
@@ -221,4 +221,247 @@ public class NotificationFactoryTests
         notification.Metadata["operation"].Should().Be("deploy");
         notification.Metadata["stackName"].Should().Be("my-stack");
     }
+
+    // --- CreateHealthChangeNotification ---
+
+    [Fact]
+    public void CreateHealthChangeNotification_Unhealthy_ReturnsErrorSeverity()
+    {
+        var notification = NotificationFactory.CreateHealthChangeNotification(
+            stackName: "web-app", serviceName: "api",
+            previousStatus: "Healthy", currentStatus: "Unhealthy");
+
+        notification.Severity.Should().Be(NotificationSeverity.Error);
+        notification.Title.Should().Be("Service Health Changed");
+        notification.Message.Should().Contain("Healthy").And.Contain("Unhealthy");
+    }
+
+    [Fact]
+    public void CreateHealthChangeNotification_NotFound_ReturnsErrorSeverity()
+    {
+        var notification = NotificationFactory.CreateHealthChangeNotification(
+            stackName: "web-app", serviceName: "api",
+            previousStatus: "Healthy", currentStatus: "NotFound");
+
+        notification.Severity.Should().Be(NotificationSeverity.Error);
+    }
+
+    [Fact]
+    public void CreateHealthChangeNotification_Degraded_ReturnsWarningSeverity()
+    {
+        var notification = NotificationFactory.CreateHealthChangeNotification(
+            stackName: "web-app", serviceName: "api",
+            previousStatus: "Healthy", currentStatus: "Degraded");
+
+        notification.Severity.Should().Be(NotificationSeverity.Warning);
+    }
+
+    [Fact]
+    public void CreateHealthChangeNotification_Recovery_ReturnsInfoSeverityAndRecoveryTitle()
+    {
+        var notification = NotificationFactory.CreateHealthChangeNotification(
+            stackName: "web-app", serviceName: "api",
+            previousStatus: "Unhealthy", currentStatus: "Healthy");
+
+        notification.Severity.Should().Be(NotificationSeverity.Info);
+        notification.Title.Should().Be("Service Recovered");
+    }
+
+    [Fact]
+    public void CreateHealthChangeNotification_SetsCorrectType()
+    {
+        var notification = NotificationFactory.CreateHealthChangeNotification(
+            stackName: "web-app", serviceName: "api",
+            previousStatus: "Healthy", currentStatus: "Unhealthy");
+
+        notification.Type.Should().Be(NotificationType.HealthChange);
+    }
+
+    [Fact]
+    public void CreateHealthChangeNotification_WithDeploymentId_SetsActionUrl()
+    {
+        var notification = NotificationFactory.CreateHealthChangeNotification(
+            stackName: "web-app", serviceName: "api",
+            previousStatus: "Healthy", currentStatus: "Unhealthy",
+            deploymentId: "dep-123");
+
+        notification.ActionUrl.Should().Be("/deployments/web-app");
+        notification.ActionLabel.Should().Be("View Deployment");
+        notification.Metadata["deploymentId"].Should().Be("dep-123");
+    }
+
+    [Fact]
+    public void CreateHealthChangeNotification_WithoutDeploymentId_FallsBackToHealthUrl()
+    {
+        var notification = NotificationFactory.CreateHealthChangeNotification(
+            stackName: "web-app", serviceName: "api",
+            previousStatus: "Healthy", currentStatus: "Unhealthy");
+
+        notification.ActionUrl.Should().Be("/health");
+        notification.ActionLabel.Should().Be("View Health");
+    }
+
+    [Fact]
+    public void CreateHealthChangeNotification_IncludesMetadata()
+    {
+        var notification = NotificationFactory.CreateHealthChangeNotification(
+            stackName: "web-app", serviceName: "api",
+            previousStatus: "Healthy", currentStatus: "Unhealthy",
+            deploymentId: "dep-123");
+
+        notification.Metadata["serviceKey"].Should().Be("dep-123:api");
+        notification.Metadata["stackName"].Should().Be("web-app");
+        notification.Metadata["serviceName"].Should().Be("api");
+        notification.Metadata["previousStatus"].Should().Be("Healthy");
+        notification.Metadata["currentStatus"].Should().Be("Unhealthy");
+    }
+
+    [Fact]
+    public void CreateHealthChangeNotification_SpecialCharsInStackName_EscapesInActionUrl()
+    {
+        var notification = NotificationFactory.CreateHealthChangeNotification(
+            stackName: "my stack/special", serviceName: "api",
+            previousStatus: "Healthy", currentStatus: "Unhealthy",
+            deploymentId: "dep-123");
+
+        notification.ActionUrl.Should().Be("/deployments/my%20stack%2Fspecial");
+    }
+
+    // --- CreateApiKeyFirstUseNotification ---
+
+    [Fact]
+    public void CreateApiKeyFirstUseNotification_ReturnsInfoSeverity()
+    {
+        var notification = NotificationFactory.CreateApiKeyFirstUseNotification(
+            keyName: "CI Pipeline", keyPrefix: "rsgo_abc");
+
+        notification.Severity.Should().Be(NotificationSeverity.Info);
+    }
+
+    [Fact]
+    public void CreateApiKeyFirstUseNotification_SetsCorrectType()
+    {
+        var notification = NotificationFactory.CreateApiKeyFirstUseNotification(
+            keyName: "CI Pipeline", keyPrefix: "rsgo_abc");
+
+        notification.Type.Should().Be(NotificationType.ApiKeyFirstUse);
+    }
+
+    [Fact]
+    public void CreateApiKeyFirstUseNotification_ContainsKeyNameAndPrefix()
+    {
+        var notification = NotificationFactory.CreateApiKeyFirstUseNotification(
+            keyName: "CI Pipeline", keyPrefix: "rsgo_abc");
+
+        notification.Title.Should().Be("API Key First Used");
+        notification.Message.Should().Contain("CI Pipeline").And.Contain("rsgo_abc");
+    }
+
+    [Fact]
+    public void CreateApiKeyFirstUseNotification_SetsActionUrl()
+    {
+        var notification = NotificationFactory.CreateApiKeyFirstUseNotification(
+            keyName: "CI Pipeline", keyPrefix: "rsgo_abc");
+
+        notification.ActionUrl.Should().Be("/settings/api-keys");
+        notification.ActionLabel.Should().Be("View API Keys");
+    }
+
+    [Fact]
+    public void CreateApiKeyFirstUseNotification_IncludesMetadata()
+    {
+        var notification = NotificationFactory.CreateApiKeyFirstUseNotification(
+            keyName: "CI Pipeline", keyPrefix: "rsgo_abc");
+
+        notification.Metadata["keyName"].Should().Be("CI Pipeline");
+        notification.Metadata["keyPrefix"].Should().Be("rsgo_abc");
+    }
+
+    // --- CreateCertificateExpiryNotification ---
+
+    [Theory]
+    [InlineData(30)]
+    [InlineData(14)]
+    [InlineData(8)]
+    public void CreateCertificateExpiryNotification_WarningThresholds_ReturnsWarningSeverity(
+        int daysRemaining)
+    {
+        var notification = NotificationFactory.CreateCertificateExpiryNotification(
+            subject: "*.example.com", thumbprint: "ABC123",
+            expiresAt: DateTime.UtcNow.AddDays(daysRemaining), daysRemaining: daysRemaining);
+
+        notification.Severity.Should().Be(NotificationSeverity.Warning);
+        notification.Title.Should().Be("Certificate Expiring Soon");
+    }
+
+    [Theory]
+    [InlineData(7)]
+    [InlineData(3)]
+    [InlineData(1)]
+    public void CreateCertificateExpiryNotification_ErrorThresholds_ReturnsErrorSeverity(
+        int daysRemaining)
+    {
+        var notification = NotificationFactory.CreateCertificateExpiryNotification(
+            subject: "*.example.com", thumbprint: "ABC123",
+            expiresAt: DateTime.UtcNow.AddDays(daysRemaining), daysRemaining: daysRemaining);
+
+        notification.Severity.Should().Be(NotificationSeverity.Error);
+        notification.Title.Should().Be("Certificate Expiring Soon");
+    }
+
+    [Fact]
+    public void CreateCertificateExpiryNotification_Expired_ReturnsErrorWithExpiredTitle()
+    {
+        var notification = NotificationFactory.CreateCertificateExpiryNotification(
+            subject: "*.example.com", thumbprint: "ABC123",
+            expiresAt: DateTime.UtcNow.AddDays(-1), daysRemaining: 0);
+
+        notification.Severity.Should().Be(NotificationSeverity.Error);
+        notification.Title.Should().Be("Certificate Expired!");
+        notification.Message.Should().Contain("has expired");
+    }
+
+    [Fact]
+    public void CreateCertificateExpiryNotification_NotExpired_ContainsDaysInMessage()
+    {
+        var notification = NotificationFactory.CreateCertificateExpiryNotification(
+            subject: "*.example.com", thumbprint: "ABC123",
+            expiresAt: DateTime.UtcNow.AddDays(14), daysRemaining: 14);
+
+        notification.Message.Should().Contain("14 day(s)");
+    }
+
+    [Fact]
+    public void CreateCertificateExpiryNotification_SetsCorrectType()
+    {
+        var notification = NotificationFactory.CreateCertificateExpiryNotification(
+            subject: "*.example.com", thumbprint: "ABC123",
+            expiresAt: DateTime.UtcNow.AddDays(30), daysRemaining: 30);
+
+        notification.Type.Should().Be(NotificationType.CertificateExpiry);
+    }
+
+    [Fact]
+    public void CreateCertificateExpiryNotification_SetsActionUrl()
+    {
+        var notification = NotificationFactory.CreateCertificateExpiryNotification(
+            subject: "*.example.com", thumbprint: "ABC123",
+            expiresAt: DateTime.UtcNow.AddDays(30), daysRemaining: 30);
+
+        notification.ActionUrl.Should().Be("/settings/tls");
+        notification.ActionLabel.Should().Be("View TLS Settings");
+    }
+
+    [Fact]
+    public void CreateCertificateExpiryNotification_IncludesMetadata()
+    {
+        var notification = NotificationFactory.CreateCertificateExpiryNotification(
+            subject: "*.example.com", thumbprint: "ABC123",
+            expiresAt: DateTime.UtcNow.AddDays(14), daysRemaining: 14);
+
+        notification.Metadata["subject"].Should().Be("*.example.com");
+        notification.Metadata["thumbprint"].Should().Be("ABC123");
+        notification.Metadata["daysRemaining"].Should().Be("14");
+        notification.Metadata["threshold"].Should().Be("ABC123:14");
+    }
 }


### PR DESCRIPTION
## Summary
- Add 3 new `NotificationType` enum values: `HealthChange`, `ApiKeyFirstUse`, `CertificateExpiry`
- Add 3 corresponding `NotificationFactory` methods with severity mapping logic
- 24 new unit tests covering all severity mappings, metadata, and edge cases
- Update plan file with resolved open questions (health recovery, self-signed certs, configurable cooldown)

## Test plan
- [x] `dotnet build` — 0 errors, 0 new warnings
- [x] `dotnet test --filter "NotificationFactory"` — 45 tests pass (21 existing + 24 new)