### PR TITLE
Add health change notifications with configurable throttling

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/System/GetHealthNotificationSettingsEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/System/GetHealthNotificationSettingsEndpoint.cs
@@ -1,0 +1,34 @@
+using FastEndpoints;
+using MediatR;
+using ReadyStackGo.Api.Authorization;
+using ReadyStackGo.Application.UseCases.System.GetHealthNotificationSettings;
+
+namespace ReadyStackGo.Api.Endpoints.System;
+
+/// <summary>
+/// GET /api/system/health-notification-settings
+/// Get current health notification settings (cooldown).
+/// </summary>
+[RequirePermission("System", "Read")]
+public class GetHealthNotificationSettingsEndpoint : EndpointWithoutRequest<GetHealthNotificationSettingsResponse>
+{
+    private readonly IMediator _mediator;
+
+    public GetHealthNotificationSettingsEndpoint(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Get("/api/system/health-notification-settings");
+        Description(b => b.WithTags("System"));
+        PreProcessor<RbacPreProcessor<EmptyRequest>>();
+    }
+
+    public override async Task HandleAsync(CancellationToken ct)
+    {
+        var query = new GetHealthNotificationSettingsQuery();
+        Response = await _mediator.Send(query, ct);
+    }
+}

--- a/src/ReadyStackGo.Api/Endpoints/System/UpdateHealthNotificationSettingsEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/System/UpdateHealthNotificationSettingsEndpoint.cs
@@ -1,0 +1,53 @@
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using ReadyStackGo.Api.Authorization;
+using ReadyStackGo.Application.UseCases.System.UpdateHealthNotificationSettings;
+
+namespace ReadyStackGo.Api.Endpoints.System;
+
+/// <summary>
+/// Request DTO for health notification settings update.
+/// </summary>
+public class UpdateHealthNotificationSettingsRequest
+{
+    public int CooldownSeconds { get; set; }
+}
+
+/// <summary>
+/// PUT /api/system/health-notification-settings
+/// Update health notification settings (cooldown).
+/// </summary>
+[RequirePermission("System", "Write")]
+public class UpdateHealthNotificationSettingsEndpoint
+    : Endpoint<UpdateHealthNotificationSettingsRequest, UpdateHealthNotificationSettingsResponse>
+{
+    private readonly IMediator _mediator;
+
+    public UpdateHealthNotificationSettingsEndpoint(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Put("/api/system/health-notification-settings");
+        Description(b => b.WithTags("System"));
+        PreProcessor<RbacPreProcessor<UpdateHealthNotificationSettingsRequest>>();
+    }
+
+    public override async Task HandleAsync(UpdateHealthNotificationSettingsRequest req, CancellationToken ct)
+    {
+        var command = new UpdateHealthNotificationSettingsCommand
+        {
+            CooldownSeconds = req.CooldownSeconds
+        };
+
+        Response = await _mediator.Send(command, ct);
+
+        if (!Response.Success)
+        {
+            HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+        }
+    }
+}

--- a/src/ReadyStackGo.Application/Services/IHealthChangeTracker.cs
+++ b/src/ReadyStackGo.Application/Services/IHealthChangeTracker.cs
@@ -1,0 +1,23 @@
+namespace ReadyStackGo.Application.Services;
+
+/// <summary>
+/// Tracks health status changes across collection cycles and creates
+/// in-app notifications with throttling to prevent spam from flapping services.
+/// </summary>
+public interface IHealthChangeTracker
+{
+    /// <summary>
+    /// Processes a health update for a deployment's services.
+    /// Compares current status against previous status and creates notifications for changes.
+    /// </summary>
+    Task ProcessHealthUpdateAsync(
+        string deploymentId,
+        string stackName,
+        IReadOnlyList<ServiceHealthUpdate> serviceStatuses,
+        CancellationToken ct = default);
+}
+
+/// <summary>
+/// Represents a service's current health status for change detection.
+/// </summary>
+public record ServiceHealthUpdate(string ServiceName, string Status);

--- a/src/ReadyStackGo.Application/Services/ISystemConfigService.cs
+++ b/src/ReadyStackGo.Application/Services/ISystemConfigService.cs
@@ -14,4 +14,14 @@ public interface ISystemConfigService
     /// Sets the wizard state.
     /// </summary>
     Task SetWizardStateAsync(WizardState state);
+
+    /// <summary>
+    /// Gets the health notification cooldown in seconds.
+    /// </summary>
+    Task<int> GetHealthNotificationCooldownSecondsAsync();
+
+    /// <summary>
+    /// Sets the health notification cooldown in seconds.
+    /// </summary>
+    Task SetHealthNotificationCooldownSecondsAsync(int seconds);
 }

--- a/src/ReadyStackGo.Application/UseCases/System/GetHealthNotificationSettings/GetHealthNotificationSettingsHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/System/GetHealthNotificationSettings/GetHealthNotificationSettingsHandler.cs
@@ -1,0 +1,26 @@
+using MediatR;
+using ReadyStackGo.Application.Services;
+
+namespace ReadyStackGo.Application.UseCases.System.GetHealthNotificationSettings;
+
+public class GetHealthNotificationSettingsHandler
+    : IRequestHandler<GetHealthNotificationSettingsQuery, GetHealthNotificationSettingsResponse>
+{
+    private readonly ISystemConfigService _systemConfigService;
+
+    public GetHealthNotificationSettingsHandler(ISystemConfigService systemConfigService)
+    {
+        _systemConfigService = systemConfigService;
+    }
+
+    public async Task<GetHealthNotificationSettingsResponse> Handle(
+        GetHealthNotificationSettingsQuery request, CancellationToken cancellationToken)
+    {
+        var cooldownSeconds = await _systemConfigService.GetHealthNotificationCooldownSecondsAsync();
+
+        return new GetHealthNotificationSettingsResponse
+        {
+            CooldownSeconds = cooldownSeconds
+        };
+    }
+}

--- a/src/ReadyStackGo.Application/UseCases/System/GetHealthNotificationSettings/GetHealthNotificationSettingsQuery.cs
+++ b/src/ReadyStackGo.Application/UseCases/System/GetHealthNotificationSettings/GetHealthNotificationSettingsQuery.cs
@@ -1,0 +1,5 @@
+using MediatR;
+
+namespace ReadyStackGo.Application.UseCases.System.GetHealthNotificationSettings;
+
+public record GetHealthNotificationSettingsQuery() : IRequest<GetHealthNotificationSettingsResponse>;

--- a/src/ReadyStackGo.Application/UseCases/System/GetHealthNotificationSettings/GetHealthNotificationSettingsResponse.cs
+++ b/src/ReadyStackGo.Application/UseCases/System/GetHealthNotificationSettings/GetHealthNotificationSettingsResponse.cs
@@ -1,0 +1,6 @@
+namespace ReadyStackGo.Application.UseCases.System.GetHealthNotificationSettings;
+
+public record GetHealthNotificationSettingsResponse
+{
+    public int CooldownSeconds { get; init; }
+}

--- a/src/ReadyStackGo.Application/UseCases/System/UpdateHealthNotificationSettings/UpdateHealthNotificationSettingsCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/System/UpdateHealthNotificationSettings/UpdateHealthNotificationSettingsCommand.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace ReadyStackGo.Application.UseCases.System.UpdateHealthNotificationSettings;
+
+public record UpdateHealthNotificationSettingsCommand : IRequest<UpdateHealthNotificationSettingsResponse>
+{
+    public int CooldownSeconds { get; init; }
+}

--- a/src/ReadyStackGo.Application/UseCases/System/UpdateHealthNotificationSettings/UpdateHealthNotificationSettingsHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/System/UpdateHealthNotificationSettings/UpdateHealthNotificationSettingsHandler.cs
@@ -1,0 +1,36 @@
+using MediatR;
+using ReadyStackGo.Application.Services;
+
+namespace ReadyStackGo.Application.UseCases.System.UpdateHealthNotificationSettings;
+
+public class UpdateHealthNotificationSettingsHandler
+    : IRequestHandler<UpdateHealthNotificationSettingsCommand, UpdateHealthNotificationSettingsResponse>
+{
+    private readonly ISystemConfigService _systemConfigService;
+
+    public UpdateHealthNotificationSettingsHandler(ISystemConfigService systemConfigService)
+    {
+        _systemConfigService = systemConfigService;
+    }
+
+    public async Task<UpdateHealthNotificationSettingsResponse> Handle(
+        UpdateHealthNotificationSettingsCommand request, CancellationToken cancellationToken)
+    {
+        if (request.CooldownSeconds < 60 || request.CooldownSeconds > 3600)
+        {
+            return new UpdateHealthNotificationSettingsResponse
+            {
+                Success = false,
+                Message = "Cooldown must be between 60 and 3600 seconds."
+            };
+        }
+
+        await _systemConfigService.SetHealthNotificationCooldownSecondsAsync(request.CooldownSeconds);
+
+        return new UpdateHealthNotificationSettingsResponse
+        {
+            Success = true,
+            Message = "Health notification settings updated."
+        };
+    }
+}

--- a/src/ReadyStackGo.Application/UseCases/System/UpdateHealthNotificationSettings/UpdateHealthNotificationSettingsResponse.cs
+++ b/src/ReadyStackGo.Application/UseCases/System/UpdateHealthNotificationSettings/UpdateHealthNotificationSettingsResponse.cs
@@ -1,0 +1,7 @@
+namespace ReadyStackGo.Application.UseCases.System.UpdateHealthNotificationSettings;
+
+public record UpdateHealthNotificationSettingsResponse
+{
+    public bool Success { get; init; }
+    public string? Message { get; init; }
+}

--- a/src/ReadyStackGo.Infrastructure/Configuration/SystemConfig.cs
+++ b/src/ReadyStackGo.Infrastructure/Configuration/SystemConfig.cs
@@ -57,4 +57,11 @@ public class SystemConfig
     /// Whether the user has dismissed the onboarding checklist on the dashboard.
     /// </summary>
     public bool OnboardingDismissed { get; set; }
+
+    /// <summary>
+    /// Cooldown in seconds between health change notifications for the same service.
+    /// Prevents notification spam when services flap between statuses.
+    /// Default: 300 seconds (5 minutes).
+    /// </summary>
+    public int HealthNotificationCooldownSeconds { get; set; } = 300;
 }

--- a/src/ReadyStackGo.Infrastructure/Configuration/SystemConfigService.cs
+++ b/src/ReadyStackGo.Infrastructure/Configuration/SystemConfigService.cs
@@ -40,6 +40,19 @@ public class SystemConfigService : ISystemConfigService
         };
     }
 
+    public async Task<int> GetHealthNotificationCooldownSecondsAsync()
+    {
+        var config = await _configStore.GetSystemConfigAsync();
+        return config.HealthNotificationCooldownSeconds;
+    }
+
+    public async Task SetHealthNotificationCooldownSecondsAsync(int seconds)
+    {
+        var config = await _configStore.GetSystemConfigAsync();
+        config.HealthNotificationCooldownSeconds = seconds;
+        await _configStore.SaveSystemConfigAsync(config);
+    }
+
     private static InfraWizardState MapToInfraWizardState(AppWizardState state)
     {
         return state switch

--- a/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
+++ b/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
@@ -88,6 +88,7 @@ public static class DependencyInjection
         // Health Monitoring (v0.11)
         services.AddScoped<IHealthMonitoringService, HealthMonitoringService>();
         services.AddScoped<IHealthCollectorService, HealthCollectorService>();
+        services.AddSingleton<IHealthChangeTracker, HealthChangeTracker>();
 
         // Maintenance Observers (v0.11)
         services.AddSingleton<IMaintenanceObserverFactory, MaintenanceObserverFactory>();

--- a/src/ReadyStackGo.Infrastructure/Services/Health/HealthChangeTracker.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Health/HealthChangeTracker.cs
@@ -1,0 +1,100 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using ReadyStackGo.Application.Notifications;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Infrastructure.Configuration;
+
+namespace ReadyStackGo.Infrastructure.Services.Health;
+
+/// <summary>
+/// Singleton service that tracks health status changes across collection cycles
+/// and creates in-app notifications with configurable cooldown throttling.
+/// </summary>
+public class HealthChangeTracker : IHealthChangeTracker
+{
+    private readonly INotificationService _notificationService;
+    private readonly IConfigStore _configStore;
+    private readonly ILogger<HealthChangeTracker> _logger;
+
+    private readonly ConcurrentDictionary<string, string> _previousStatuses = new();
+    private readonly ConcurrentDictionary<string, DateTime> _cooldownTimestamps = new();
+
+    public HealthChangeTracker(
+        INotificationService notificationService,
+        IConfigStore configStore,
+        ILogger<HealthChangeTracker> logger)
+    {
+        _notificationService = notificationService;
+        _configStore = configStore;
+        _logger = logger;
+    }
+
+    public async Task ProcessHealthUpdateAsync(
+        string deploymentId,
+        string stackName,
+        IReadOnlyList<ServiceHealthUpdate> serviceStatuses,
+        CancellationToken ct = default)
+    {
+        var config = await _configStore.GetSystemConfigAsync();
+        var cooldownSeconds = config.HealthNotificationCooldownSeconds;
+
+        foreach (var service in serviceStatuses)
+        {
+            var serviceKey = $"{deploymentId}:{service.ServiceName}";
+            var currentStatus = service.Status;
+
+            var previousStatus = _previousStatuses.GetValueOrDefault(serviceKey);
+            _previousStatuses[serviceKey] = currentStatus;
+
+            // No previous status (first collection) or no change — skip
+            if (previousStatus == null || string.Equals(previousStatus, currentStatus, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            // Status changed — check cooldown
+            if (!IsOutsideCooldown(serviceKey, cooldownSeconds))
+            {
+                _logger.LogDebug(
+                    "Health notification throttled for {ServiceKey} (cooldown {Cooldown}s)",
+                    serviceKey, cooldownSeconds);
+                continue;
+            }
+
+            // Check dedup via notification store
+            try
+            {
+                var alreadyExists = await _notificationService.ExistsAsync(
+                    NotificationType.HealthChange, "serviceKey", serviceKey, ct);
+
+                if (alreadyExists)
+                {
+                    _logger.LogDebug("Health notification deduplicated for {ServiceKey}", serviceKey);
+                    continue;
+                }
+
+                var notification = NotificationFactory.CreateHealthChangeNotification(
+                    stackName, service.ServiceName,
+                    previousStatus, currentStatus,
+                    deploymentId);
+
+                await _notificationService.AddAsync(notification, ct);
+                _cooldownTimestamps[serviceKey] = DateTime.UtcNow;
+
+                _logger.LogInformation(
+                    "Health notification created: {ServiceName} in {StackName} changed from {Previous} to {Current}",
+                    service.ServiceName, stackName, previousStatus, currentStatus);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogDebug(ex, "Failed to create health change notification for {ServiceKey}", serviceKey);
+            }
+        }
+    }
+
+    private bool IsOutsideCooldown(string serviceKey, int cooldownSeconds)
+    {
+        if (!_cooldownTimestamps.TryGetValue(serviceKey, out var lastNotificationTime))
+            return true;
+
+        return (DateTime.UtcNow - lastNotificationTime).TotalSeconds >= cooldownSeconds;
+    }
+}

--- a/src/ReadyStackGo.Infrastructure/Services/Health/HealthCollectorService.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Health/HealthCollectorService.cs
@@ -18,6 +18,7 @@ public class HealthCollectorService : IHealthCollectorService
 {
     private readonly IHealthMonitoringService _healthMonitoringService;
     private readonly IHealthNotificationService _healthNotificationService;
+    private readonly IHealthChangeTracker _healthChangeTracker;
     private readonly IDeploymentRepository _deploymentRepository;
     private readonly IEnvironmentRepository _environmentRepository;
     private readonly IProductDeploymentRepository _productDeploymentRepository;
@@ -26,6 +27,7 @@ public class HealthCollectorService : IHealthCollectorService
     public HealthCollectorService(
         IHealthMonitoringService healthMonitoringService,
         IHealthNotificationService healthNotificationService,
+        IHealthChangeTracker healthChangeTracker,
         IDeploymentRepository deploymentRepository,
         IEnvironmentRepository environmentRepository,
         IProductDeploymentRepository productDeploymentRepository,
@@ -33,6 +35,7 @@ public class HealthCollectorService : IHealthCollectorService
     {
         _healthMonitoringService = healthMonitoringService;
         _healthNotificationService = healthNotificationService;
+        _healthChangeTracker = healthChangeTracker;
         _deploymentRepository = deploymentRepository;
         _environmentRepository = environmentRepository;
         _productDeploymentRepository = productDeploymentRepository;
@@ -87,7 +90,17 @@ public class HealthCollectorService : IHealthCollectorService
                 EnrichWithProductInfo(dto, deployment.Id);
                 stackHealthDtos.Add(dto);
 
-                // Notify about individual deployment health change
+                // Track health changes and create in-app notifications
+                var serviceStatuses = dto.Self.Services
+                    .Select(s => new ServiceHealthUpdate(s.Name, s.Status))
+                    .ToList();
+                await _healthChangeTracker.ProcessHealthUpdateAsync(
+                    deployment.Id.Value.ToString(),
+                    deployment.StackName,
+                    serviceStatuses,
+                    cancellationToken);
+
+                // Notify about individual deployment health change (SignalR real-time)
                 await _healthNotificationService.NotifyDeploymentHealthChangedAsync(
                     deployment.Id,
                     dto,
@@ -170,7 +183,17 @@ public class HealthCollectorService : IHealthCollectorService
             var dto = HealthSnapshotMapper.MapToStackHealthDto(snapshot, deployment.EnvironmentId);
             EnrichWithProductInfo(dto, deploymentId);
 
-            // Notify about deployment health change
+            // Track health changes and create in-app notifications
+            var serviceStatuses = dto.Self.Services
+                .Select(s => new ServiceHealthUpdate(s.Name, s.Status))
+                .ToList();
+            await _healthChangeTracker.ProcessHealthUpdateAsync(
+                deploymentId.Value.ToString(),
+                deployment.StackName,
+                serviceStatuses,
+                cancellationToken);
+
+            // Notify about deployment health change (SignalR real-time)
             await _healthNotificationService.NotifyDeploymentHealthChangedAsync(
                 deploymentId,
                 dto,

--- a/src/ReadyStackGo.WebUi/src/api/system.ts
+++ b/src/ReadyStackGo.WebUi/src/api/system.ts
@@ -129,6 +129,20 @@ export interface UpdateProgressInfo {
   progressPercent?: number;
 }
 
+// Health Notification Settings
+export interface HealthNotificationSettings {
+  cooldownSeconds: number;
+}
+
+export interface UpdateHealthNotificationSettingsRequest {
+  cooldownSeconds: number;
+}
+
+export interface UpdateHealthNotificationSettingsResponse {
+  success: boolean;
+  message?: string;
+}
+
 export const systemApi = {
   getVersion: (forceCheck?: boolean) =>
     apiGet<VersionInfo>(`/api/system/version${forceCheck ? '?forceCheck=true' : ''}`),
@@ -144,4 +158,10 @@ export const systemApi = {
     apiPost<ConfigureLetsEncryptResponse>('/api/system/tls/letsencrypt', request),
   confirmLetsEncryptDns: () =>
     apiPost<ConfigureLetsEncryptResponse>('/api/system/tls/letsencrypt/confirm-dns', {}),
+
+  // Health Notification Settings
+  getHealthNotificationSettings: () =>
+    apiGet<HealthNotificationSettings>('/api/system/health-notification-settings'),
+  updateHealthNotificationSettings: (request: UpdateHealthNotificationSettingsRequest) =>
+    apiPut<UpdateHealthNotificationSettingsResponse>('/api/system/health-notification-settings', request),
 };

--- a/src/ReadyStackGo.WebUi/src/pages/Settings/System/SystemInfo.tsx
+++ b/src/ReadyStackGo.WebUi/src/pages/Settings/System/SystemInfo.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { systemApi } from "../../../api/system";
 import { useVersionInfo } from "../../../hooks/useVersionInfo";
 
 function formatRelativeTime(isoString?: string): string {
@@ -23,6 +24,41 @@ export default function SystemInfo() {
   const [checking, setChecking] = useState(false);
   const [checkResult, setCheckResult] = useState<"up-to-date" | null>(null);
   const navigate = useNavigate();
+
+  // Health Notification Settings
+  const [cooldownMinutes, setCooldownMinutes] = useState(5);
+  const [cooldownLoading, setCooldownLoading] = useState(true);
+  const [cooldownSaving, setCooldownSaving] = useState(false);
+  const [cooldownSuccess, setCooldownSuccess] = useState<string | null>(null);
+  const [cooldownError, setCooldownError] = useState<string | null>(null);
+
+  useEffect(() => {
+    systemApi.getHealthNotificationSettings()
+      .then((settings) => setCooldownMinutes(Math.round(settings.cooldownSeconds / 60)))
+      .catch(() => setCooldownError("Failed to load health notification settings"))
+      .finally(() => setCooldownLoading(false));
+  }, []);
+
+  const handleSaveCooldown = async () => {
+    setCooldownSaving(true);
+    setCooldownSuccess(null);
+    setCooldownError(null);
+    try {
+      const response = await systemApi.updateHealthNotificationSettings({
+        cooldownSeconds: cooldownMinutes * 60,
+      });
+      if (response.success) {
+        setCooldownSuccess(response.message ?? "Settings saved.");
+        setTimeout(() => setCooldownSuccess(null), 5000);
+      } else {
+        setCooldownError(response.message ?? "Failed to save settings.");
+      }
+    } catch {
+      setCooldownError("Failed to save health notification settings.");
+    } finally {
+      setCooldownSaving(false);
+    }
+  };
 
   const handleCheckNow = async () => {
     setChecking(true);
@@ -229,6 +265,78 @@ export default function SystemInfo() {
           {error}
         </div>
       )}
+
+      {/* Health Notification Settings */}
+      <div className="mt-6 rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03]">
+        <div className="border-b border-gray-200 px-6 py-5 dark:border-gray-700">
+          <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+            Health Notifications
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Configure how health change notifications behave.
+          </p>
+        </div>
+        <div className="px-6 py-5">
+          {cooldownLoading ? (
+            <div className="flex items-center gap-2 text-sm text-gray-500">
+              <div className="h-4 w-4 animate-spin rounded-full border-2 border-brand-500 border-t-transparent" />
+              Loading...
+            </div>
+          ) : (
+            <div className="space-y-4">
+              <div className="flex items-end gap-4">
+                <div className="flex-1 max-w-xs">
+                  <label
+                    htmlFor="cooldown-minutes"
+                    className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                  >
+                    Notification Cooldown
+                  </label>
+                  <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                    Minimum time between notifications for the same service (1–60 minutes).
+                  </p>
+                  <div className="mt-2 flex items-center gap-2">
+                    <input
+                      id="cooldown-minutes"
+                      type="number"
+                      min={1}
+                      max={60}
+                      value={cooldownMinutes}
+                      onChange={(e) => setCooldownMinutes(Number(e.target.value))}
+                      className="w-20 rounded-lg border border-gray-300 bg-transparent px-3 py-2 text-sm text-gray-900 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:text-white"
+                    />
+                    <span className="text-sm text-gray-500 dark:text-gray-400">
+                      minutes
+                    </span>
+                  </div>
+                </div>
+                <button
+                  onClick={handleSaveCooldown}
+                  disabled={cooldownSaving}
+                  className="inline-flex items-center gap-2 rounded-lg bg-brand-500 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-600 disabled:opacity-50"
+                >
+                  {cooldownSaving ? "Saving..." : "Save"}
+                </button>
+              </div>
+
+              {cooldownSuccess && (
+                <div className="flex items-center gap-2 text-sm text-green-700 dark:text-green-300">
+                  <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
+                  </svg>
+                  {cooldownSuccess}
+                </div>
+              )}
+
+              {cooldownError && (
+                <div className="text-sm text-red-600 dark:text-red-400">
+                  {cooldownError}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/tests/ReadyStackGo.UnitTests/Notifications/HealthChangeTrackerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Notifications/HealthChangeTrackerTests.cs
@@ -1,0 +1,247 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ReadyStackGo.Application.Notifications;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Infrastructure.Configuration;
+using ReadyStackGo.Infrastructure.Services.Health;
+
+namespace ReadyStackGo.UnitTests.Notifications;
+
+public class HealthChangeTrackerTests
+{
+    private readonly Mock<INotificationService> _notificationService = new();
+    private readonly Mock<IConfigStore> _configStore = new();
+    private readonly HealthChangeTracker _tracker;
+
+    public HealthChangeTrackerTests()
+    {
+        var config = new SystemConfig { HealthNotificationCooldownSeconds = 300 };
+        _configStore.Setup(c => c.GetSystemConfigAsync()).ReturnsAsync(config);
+
+        _notificationService
+            .Setup(n => n.ExistsAsync(It.IsAny<NotificationType>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _tracker = new HealthChangeTracker(
+            _notificationService.Object,
+            _configStore.Object,
+            Mock.Of<ILogger<HealthChangeTracker>>());
+    }
+
+    [Fact]
+    public async Task FirstCollection_NoNotification()
+    {
+        var statuses = new List<ServiceHealthUpdate>
+        {
+            new("api", "Healthy")
+        };
+
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app", statuses);
+
+        _notificationService.Verify(
+            n => n.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task HealthyToUnhealthy_CreatesErrorNotification()
+    {
+        // First collection: establish baseline
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Healthy") });
+
+        // Second collection: status changed
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Unhealthy") });
+
+        _notificationService.Verify(n => n.AddAsync(
+            It.Is<Notification>(not =>
+                not.Type == NotificationType.HealthChange &&
+                not.Severity == NotificationSeverity.Error &&
+                not.Metadata["currentStatus"] == "Unhealthy"),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task UnhealthyToHealthy_CreatesInfoRecoveryNotification()
+    {
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Unhealthy") });
+
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Healthy") });
+
+        _notificationService.Verify(n => n.AddAsync(
+            It.Is<Notification>(not =>
+                not.Type == NotificationType.HealthChange &&
+                not.Severity == NotificationSeverity.Info &&
+                not.Title == "Service Recovered"),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task HealthyToDegraded_CreatesWarningNotification()
+    {
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Healthy") });
+
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Degraded") });
+
+        _notificationService.Verify(n => n.AddAsync(
+            It.Is<Notification>(not =>
+                not.Severity == NotificationSeverity.Warning),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NoStatusChange_NoNotification()
+    {
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Healthy") });
+
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Healthy") });
+
+        _notificationService.Verify(
+            n => n.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SameDegradationWithinCooldown_Throttled()
+    {
+        // Long cooldown — all subsequent changes should be throttled after the first
+        var config = new SystemConfig { HealthNotificationCooldownSeconds = 600 };
+        _configStore.Setup(c => c.GetSystemConfigAsync()).ReturnsAsync(config);
+
+        // Establish baseline
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Healthy") });
+
+        // First change: Healthy → Unhealthy (creates notification, starts cooldown)
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Unhealthy") });
+
+        // Recovery within cooldown: Unhealthy → Healthy (throttled)
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Healthy") });
+
+        // Second degradation within cooldown: Healthy → Unhealthy (throttled)
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Unhealthy") });
+
+        // Only 1 notification total — subsequent changes within cooldown are throttled
+        _notificationService.Verify(
+            n => n.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DifferentServicesTrackedIndependently()
+    {
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate>
+            {
+                new("api", "Healthy"),
+                new("worker", "Healthy")
+            });
+
+        // Only api changes, worker stays the same
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate>
+            {
+                new("api", "Unhealthy"),
+                new("worker", "Healthy")
+            });
+
+        _notificationService.Verify(
+            n => n.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DifferentDeploymentsTrackedIndependently()
+    {
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Healthy") });
+
+        await _tracker.ProcessHealthUpdateAsync("dep-2", "backend",
+            new List<ServiceHealthUpdate> { new("api", "Healthy") });
+
+        // Both change at same time
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Unhealthy") });
+
+        await _tracker.ProcessHealthUpdateAsync("dep-2", "backend",
+            new List<ServiceHealthUpdate> { new("api", "Degraded") });
+
+        _notificationService.Verify(
+            n => n.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task ExistsAsyncTrue_SkipsNotification()
+    {
+        _notificationService
+            .Setup(n => n.ExistsAsync(NotificationType.HealthChange, "serviceKey", "dep-1:api", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Healthy") });
+
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Unhealthy") });
+
+        _notificationService.Verify(
+            n => n.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task NotificationServiceFails_NoException()
+    {
+        _notificationService
+            .Setup(n => n.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Service unavailable"));
+
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Healthy") });
+
+        // Should not throw
+        var act = () => _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Unhealthy") });
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task CooldownReadFromConfig()
+    {
+        // Very short cooldown
+        var config = new SystemConfig { HealthNotificationCooldownSeconds = 0 };
+        _configStore.Setup(c => c.GetSystemConfigAsync()).ReturnsAsync(config);
+
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Healthy") });
+
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Unhealthy") });
+
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Healthy") });
+
+        await _tracker.ProcessHealthUpdateAsync("dep-1", "web-app",
+            new List<ServiceHealthUpdate> { new("api", "Unhealthy") });
+
+        // With cooldown=0, all changes should create notifications
+        _notificationService.Verify(
+            n => n.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(3)); // Unhealthy + Healthy(recovery) + Unhealthy
+    }
+}

--- a/tests/ReadyStackGo.UnitTests/UseCases/System/HealthNotificationSettingsTests.cs
+++ b/tests/ReadyStackGo.UnitTests/UseCases/System/HealthNotificationSettingsTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using Moq;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Application.UseCases.System.GetHealthNotificationSettings;
+using ReadyStackGo.Application.UseCases.System.UpdateHealthNotificationSettings;
+
+namespace ReadyStackGo.UnitTests.UseCases.System;
+
+public class HealthNotificationSettingsTests
+{
+    private readonly Mock<ISystemConfigService> _systemConfigService = new();
+
+    // --- Get ---
+
+    [Fact]
+    public async Task GetHandler_ReturnsCurrentCooldown()
+    {
+        _systemConfigService
+            .Setup(s => s.GetHealthNotificationCooldownSecondsAsync())
+            .ReturnsAsync(300);
+
+        var handler = new GetHealthNotificationSettingsHandler(_systemConfigService.Object);
+        var result = await handler.Handle(new GetHealthNotificationSettingsQuery(), CancellationToken.None);
+
+        result.CooldownSeconds.Should().Be(300);
+    }
+
+    [Fact]
+    public async Task GetHandler_ReturnsCustomCooldown()
+    {
+        _systemConfigService
+            .Setup(s => s.GetHealthNotificationCooldownSecondsAsync())
+            .ReturnsAsync(600);
+
+        var handler = new GetHealthNotificationSettingsHandler(_systemConfigService.Object);
+        var result = await handler.Handle(new GetHealthNotificationSettingsQuery(), CancellationToken.None);
+
+        result.CooldownSeconds.Should().Be(600);
+    }
+
+    // --- Update ---
+
+    [Fact]
+    public async Task UpdateHandler_ValidCooldown_SavesAndReturnsSuccess()
+    {
+        var handler = new UpdateHealthNotificationSettingsHandler(_systemConfigService.Object);
+        var command = new UpdateHealthNotificationSettingsCommand { CooldownSeconds = 120 };
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _systemConfigService.Verify(
+            s => s.SetHealthNotificationCooldownSecondsAsync(120),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task UpdateHandler_TooLow_ReturnsError()
+    {
+        var handler = new UpdateHealthNotificationSettingsHandler(_systemConfigService.Object);
+        var command = new UpdateHealthNotificationSettingsCommand { CooldownSeconds = 30 };
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("between 60 and 3600");
+        _systemConfigService.Verify(
+            s => s.SetHealthNotificationCooldownSecondsAsync(It.IsAny<int>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task UpdateHandler_TooHigh_ReturnsError()
+    {
+        var handler = new UpdateHealthNotificationSettingsHandler(_systemConfigService.Object);
+        var command = new UpdateHealthNotificationSettingsCommand { CooldownSeconds = 7200 };
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        _systemConfigService.Verify(
+            s => s.SetHealthNotificationCooldownSecondsAsync(It.IsAny<int>()),
+            Times.Never);
+    }
+
+    [Theory]
+    [InlineData(60)]
+    [InlineData(300)]
+    [InlineData(3600)]
+    public async Task UpdateHandler_BoundaryValues_Accepted(int cooldown)
+    {
+        var handler = new UpdateHealthNotificationSettingsHandler(_systemConfigService.Object);
+        var command = new UpdateHealthNotificationSettingsCommand { CooldownSeconds = cooldown };
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## Summary
- **HealthChangeTracker** (Singleton): tracks per-service health status changes across collection cycles with configurable cooldown + ExistsAsync deduplication
- Notifications for both degradation (Warning/Error) and recovery (Info)
- Configurable cooldown via **Settings > System** page (1-60 minutes, default 5 min)
- `SystemConfig.HealthNotificationCooldownSeconds` persisted in rsgo.system.json
- GET/PUT `/api/system/health-notification-settings` endpoints with RBAC
- MediatR use cases with input validation (min 60s, max 3600s)

## Files changed
- **New**: IHealthChangeTracker, HealthChangeTracker, Get/Update health settings use cases + endpoints
- **Modified**: HealthCollectorService (inject tracker), SystemConfig, ISystemConfigService, DI registration
- **Frontend**: system.ts API client, SystemInfo.tsx settings card

## Test plan
- [x] `dotnet build` — 0 errors, 0 new warnings
- [x] 19 new unit tests covering change detection, throttling, dedup, graceful degradation, boundary values