### PR TITLE
Extend redeploy hook to support product-level redeploy

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/Hooks/RedeployEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Hooks/RedeployEndpoint.cs
@@ -24,6 +24,12 @@ public class RedeployEndpoint : Endpoint<RedeployStackRequest, RedeployStackResp
 
     public override async Task HandleAsync(RedeployStackRequest req, CancellationToken ct)
     {
+        // Validate: either stackName or productId is required
+        if (string.IsNullOrWhiteSpace(req.StackName) && string.IsNullOrWhiteSpace(req.ProductId))
+        {
+            ThrowError("Either stackName or productId is required.");
+        }
+
         // Resolve EnvironmentId: from request body, or fallback to API Key's env_id claim
         var environmentId = req.EnvironmentId;
 
@@ -38,7 +44,7 @@ public class RedeployEndpoint : Endpoint<RedeployStackRequest, RedeployStackResp
         }
 
         var response = await _mediator.Send(
-            new RedeployStackCommand(req.StackName, environmentId!, req.Variables), ct);
+            new RedeployStackCommand(req.StackName, environmentId!, req.Variables, req.ProductId, req.StackDefinitionName), ct);
 
         if (!response.Success)
         {

--- a/src/ReadyStackGo.Application/UseCases/Hooks/RedeployStack/RedeployStackCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Hooks/RedeployStack/RedeployStackCommand.cs
@@ -1,15 +1,19 @@
 using MediatR;
 using Microsoft.Extensions.Logging;
 using ReadyStackGo.Application.UseCases.Deployments.DeployStack;
+using ReadyStackGo.Application.UseCases.Deployments.RedeployProduct;
 using ReadyStackGo.Domain.Deployment.Deployments;
 using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.Deployment.ProductDeployments;
 
 namespace ReadyStackGo.Application.UseCases.Hooks.RedeployStack;
 
 public record RedeployStackRequest
 {
-    public required string StackName { get; init; }
+    public string? StackName { get; init; }
     public string? EnvironmentId { get; init; }
+    public string? ProductId { get; init; }
+    public string? StackDefinitionName { get; init; }
     public Dictionary<string, string>? Variables { get; init; }
 }
 
@@ -18,6 +22,7 @@ public record RedeployStackResponse
     public bool Success { get; init; }
     public string? Message { get; init; }
     public string? DeploymentId { get; init; }
+    public string? ProductDeploymentId { get; init; }
     public string? StackName { get; init; }
     public string? StackVersion { get; init; }
 
@@ -26,23 +31,28 @@ public record RedeployStackResponse
 }
 
 public record RedeployStackCommand(
-    string StackName,
+    string? StackName,
     string EnvironmentId,
-    Dictionary<string, string>? Variables = null
+    Dictionary<string, string>? Variables = null,
+    string? ProductId = null,
+    string? StackDefinitionName = null
 ) : IRequest<RedeployStackResponse>;
 
 public class RedeployStackHandler : IRequestHandler<RedeployStackCommand, RedeployStackResponse>
 {
     private readonly IDeploymentRepository _deploymentRepository;
+    private readonly IProductDeploymentRepository _productDeploymentRepository;
     private readonly IMediator _mediator;
     private readonly ILogger<RedeployStackHandler> _logger;
 
     public RedeployStackHandler(
         IDeploymentRepository deploymentRepository,
+        IProductDeploymentRepository productDeploymentRepository,
         IMediator mediator,
         ILogger<RedeployStackHandler> logger)
     {
         _deploymentRepository = deploymentRepository;
+        _productDeploymentRepository = productDeploymentRepository;
         _mediator = mediator;
         _logger = logger;
     }
@@ -57,7 +67,84 @@ public class RedeployStackHandler : IRequestHandler<RedeployStackCommand, Redepl
 
         var environmentId = new EnvironmentId(envGuid);
 
-        // 2. Find deployment by stack name + environment
+        // 2. Route: Product redeploy or standalone stack redeploy?
+        if (!string.IsNullOrWhiteSpace(request.ProductId))
+        {
+            return await HandleProductRedeploy(request, environmentId, cancellationToken);
+        }
+
+        return await HandleStandaloneRedeploy(request, environmentId, cancellationToken);
+    }
+
+    private async Task<RedeployStackResponse> HandleProductRedeploy(
+        RedeployStackCommand request, EnvironmentId environmentId, CancellationToken cancellationToken)
+    {
+        // 1. Find active ProductDeployment by ProductGroupId
+        var productDeployment = _productDeploymentRepository
+            .GetActiveByProductGroupId(environmentId, request.ProductId!);
+
+        if (productDeployment == null)
+        {
+            return RedeployStackResponse.Failed(
+                $"No active product deployment found for product '{request.ProductId}' in environment '{request.EnvironmentId}'.");
+        }
+
+        // 2. Determine stack selection
+        List<string>? stackNames = null;
+        if (!string.IsNullOrWhiteSpace(request.StackDefinitionName))
+        {
+            stackNames = new List<string> { request.StackDefinitionName };
+        }
+
+        _logger.LogInformation(
+            "Starting product redeploy of '{ProductName}' (id: {ProductDeploymentId}) in environment {EnvironmentId}, stacks: {Stacks}",
+            productDeployment.ProductName,
+            productDeployment.Id.Value,
+            request.EnvironmentId,
+            stackNames != null ? string.Join(", ", stackNames) : "all");
+
+        // 3. Dispatch RedeployProductCommand
+        var result = await _mediator.Send(new RedeployProductCommand(
+            request.EnvironmentId,
+            productDeployment.Id.Value.ToString(),
+            stackNames,
+            request.Variables,
+            null,
+            true,
+            null), cancellationToken);
+
+        if (!result.Success)
+        {
+            _logger.LogWarning(
+                "Product redeploy of '{ProductName}' failed: {Message}",
+                productDeployment.ProductName, result.Message);
+
+            return RedeployStackResponse.Failed(result.Message ?? "Product redeploy failed.");
+        }
+
+        _logger.LogInformation(
+            "Successfully triggered product redeploy of '{ProductName}'",
+            productDeployment.ProductName);
+
+        return new RedeployStackResponse
+        {
+            Success = true,
+            Message = $"Successfully triggered redeploy of product '{productDeployment.ProductName}'.",
+            ProductDeploymentId = result.ProductDeploymentId,
+            StackName = productDeployment.ProductName,
+            StackVersion = productDeployment.ProductVersion
+        };
+    }
+
+    private async Task<RedeployStackResponse> HandleStandaloneRedeploy(
+        RedeployStackCommand request, EnvironmentId environmentId, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.StackName))
+        {
+            return RedeployStackResponse.Failed("Either stackName or productId is required.");
+        }
+
+        // 1. Find deployment by stack name + environment
         var deployment = _deploymentRepository.GetByStackName(environmentId, request.StackName);
         if (deployment == null)
         {
@@ -65,17 +152,17 @@ public class RedeployStackHandler : IRequestHandler<RedeployStackCommand, Redepl
                 $"No deployment found for stack '{request.StackName}' in environment '{request.EnvironmentId}'.");
         }
 
-        // 3. Validate: only running stacks can be redeployed
+        // 2. Validate: only running stacks can be redeployed
         if (deployment.Status != DeploymentStatus.Running)
         {
             return RedeployStackResponse.Failed(
                 $"Only running deployments can be redeployed. Current status: {deployment.Status}");
         }
 
-        // 4. Extract redeployment data from existing deployment
+        // 3. Extract redeployment data from existing deployment
         var (stackId, stackVersion, storedVariables) = deployment.GetRedeploymentData();
 
-        // 5. Merge variables: stored deployment values as base, webhook values as overrides
+        // 4. Merge variables: stored deployment values as base, webhook values as overrides
         var variables = new Dictionary<string, string>(storedVariables);
         if (request.Variables != null)
         {
@@ -89,7 +176,7 @@ public class RedeployStackHandler : IRequestHandler<RedeployStackCommand, Redepl
             "Starting redeploy of stack '{StackName}' (version {Version}) in environment {EnvironmentId} with {VarCount} variables ({OverrideCount} overrides from webhook)",
             request.StackName, stackVersion, request.EnvironmentId, variables.Count, request.Variables?.Count ?? 0);
 
-        // 6. Delegate to DeployStackCommand (same parameters, no SessionId for webhook)
+        // 5. Delegate to DeployStackCommand (same parameters, no SessionId for webhook)
         var deployResult = await _mediator.Send(new DeployStackCommand(
             request.EnvironmentId,
             stackId,

--- a/tests/ReadyStackGo.UnitTests/Application/Hooks/RedeployStackHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Hooks/RedeployStackHandlerTests.cs
@@ -2,17 +2,21 @@ using FluentAssertions;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Moq;
+using ReadyStackGo.Application.UseCases.Deployments.DeployProduct;
 using ReadyStackGo.Application.UseCases.Deployments.DeployStack;
+using ReadyStackGo.Application.UseCases.Deployments.RedeployProduct;
 using ReadyStackGo.Application.UseCases.Hooks.RedeployStack;
 using ReadyStackGo.Domain.Deployment;
 using ReadyStackGo.Domain.Deployment.Deployments;
 using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.Deployment.ProductDeployments;
 
 namespace ReadyStackGo.UnitTests.Application.Hooks;
 
 public class RedeployStackHandlerTests
 {
     private readonly Mock<IDeploymentRepository> _deploymentRepoMock;
+    private readonly Mock<IProductDeploymentRepository> _productDeploymentRepoMock;
     private readonly Mock<IMediator> _mediatorMock;
     private readonly Mock<ILogger<RedeployStackHandler>> _loggerMock;
     private readonly RedeployStackHandler _handler;
@@ -24,10 +28,12 @@ public class RedeployStackHandlerTests
     public RedeployStackHandlerTests()
     {
         _deploymentRepoMock = new Mock<IDeploymentRepository>();
+        _productDeploymentRepoMock = new Mock<IProductDeploymentRepository>();
         _mediatorMock = new Mock<IMediator>();
         _loggerMock = new Mock<ILogger<RedeployStackHandler>>();
         _handler = new RedeployStackHandler(
             _deploymentRepoMock.Object,
+            _productDeploymentRepoMock.Object,
             _mediatorMock.Object,
             _loggerMock.Object);
     }
@@ -257,6 +263,28 @@ public class RedeployStackHandlerTests
         result.Message.Should().Contain("Invalid environment ID");
     }
 
+    [Fact]
+    public async Task Handle_NoStackNameOrProductId_ReturnsError()
+    {
+        var result = await _handler.Handle(
+            new RedeployStackCommand(null, TestEnvironmentId),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("stackName or productId");
+    }
+
+    [Fact]
+    public async Task Handle_EmptyStackNameAndNoProductId_ReturnsError()
+    {
+        var result = await _handler.Handle(
+            new RedeployStackCommand("", TestEnvironmentId),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("stackName or productId");
+    }
+
     #endregion
 
     #region Deploy Failure Propagation
@@ -471,6 +499,168 @@ public class RedeployStackHandlerTests
 
     #endregion
 
+    #region Product Redeploy
+
+    [Fact]
+    public async Task Handle_ProductId_RoutesToProductRedeploy()
+    {
+        var productDeployment = CreateRunningProductDeployment("test.product");
+        SetupProductDeploymentLookup("test.product", productDeployment);
+        SetupSuccessfulProductRedeploy(productDeployment.Id.Value.ToString());
+
+        var result = await _handler.Handle(
+            new RedeployStackCommand(null, TestEnvironmentId, ProductId: "test.product"),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.ProductDeploymentId.Should().Be(productDeployment.Id.Value.ToString());
+        result.Message.Should().Contain("test-product");
+    }
+
+    [Fact]
+    public async Task Handle_ProductId_DispatchesRedeployProductCommand()
+    {
+        var productDeployment = CreateRunningProductDeployment("test.product");
+        SetupProductDeploymentLookup("test.product", productDeployment);
+        SetupSuccessfulProductRedeploy(productDeployment.Id.Value.ToString());
+
+        await _handler.Handle(
+            new RedeployStackCommand(null, TestEnvironmentId, ProductId: "test.product"),
+            CancellationToken.None);
+
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<RedeployProductCommand>(cmd =>
+                cmd.EnvironmentId == TestEnvironmentId &&
+                cmd.ProductDeploymentId == productDeployment.Id.Value.ToString() &&
+                cmd.StackNames == null),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ProductIdWithStackDefinitionName_RedeploysOnlyNamedStack()
+    {
+        var productDeployment = CreateRunningProductDeployment("test.product");
+        SetupProductDeploymentLookup("test.product", productDeployment);
+        SetupSuccessfulProductRedeploy(productDeployment.Id.Value.ToString());
+
+        await _handler.Handle(
+            new RedeployStackCommand(null, TestEnvironmentId,
+                ProductId: "test.product", StackDefinitionName: "Analytics"),
+            CancellationToken.None);
+
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<RedeployProductCommand>(cmd =>
+                cmd.StackNames != null &&
+                cmd.StackNames.Count == 1 &&
+                cmd.StackNames[0] == "Analytics"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ProductIdWithVariables_PassesVariablesToCommand()
+    {
+        var productDeployment = CreateRunningProductDeployment("test.product");
+        SetupProductDeploymentLookup("test.product", productDeployment);
+        SetupSuccessfulProductRedeploy(productDeployment.Id.Value.ToString());
+
+        var variables = new Dictionary<string, string> { ["BUILD_NUM"] = "42" };
+
+        await _handler.Handle(
+            new RedeployStackCommand(null, TestEnvironmentId, variables, ProductId: "test.product"),
+            CancellationToken.None);
+
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<RedeployProductCommand>(cmd =>
+                cmd.VariableOverrides != null &&
+                cmd.VariableOverrides["BUILD_NUM"] == "42"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ProductIdNotFound_ReturnsError()
+    {
+        _productDeploymentRepoMock
+            .Setup(r => r.GetActiveByProductGroupId(It.IsAny<EnvironmentId>(), It.IsAny<string>()))
+            .Returns((ProductDeployment?)null);
+
+        var result = await _handler.Handle(
+            new RedeployStackCommand(null, TestEnvironmentId, ProductId: "unknown.product"),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("No active product deployment");
+        result.Message.Should().Contain("unknown.product");
+    }
+
+    [Fact]
+    public async Task Handle_ProductRedeployFails_PropagatesError()
+    {
+        var productDeployment = CreateRunningProductDeployment("test.product");
+        SetupProductDeploymentLookup("test.product", productDeployment);
+
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<RedeployProductCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(DeployProductResponse.Failed("Lock acquisition failed"));
+
+        var result = await _handler.Handle(
+            new RedeployStackCommand(null, TestEnvironmentId, ProductId: "test.product"),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Lock acquisition failed");
+    }
+
+    [Fact]
+    public async Task Handle_ProductIdWithInvalidEnvironmentId_ReturnsError()
+    {
+        var result = await _handler.Handle(
+            new RedeployStackCommand(null, "not-a-guid", ProductId: "test.product"),
+            CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.Message.Should().Contain("Invalid environment ID");
+    }
+
+    [Fact]
+    public async Task Handle_ProductIdNullStackDefinitionName_RedeploysAllStacks()
+    {
+        var productDeployment = CreateRunningProductDeployment("test.product");
+        SetupProductDeploymentLookup("test.product", productDeployment);
+        SetupSuccessfulProductRedeploy(productDeployment.Id.Value.ToString());
+
+        await _handler.Handle(
+            new RedeployStackCommand(null, TestEnvironmentId,
+                ProductId: "test.product", StackDefinitionName: null),
+            CancellationToken.None);
+
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<RedeployProductCommand>(cmd => cmd.StackNames == null),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ProductIdWithStackNameIgnored_UsesProductPath()
+    {
+        // When productId is set, stackName should be ignored and product path should be used
+        var productDeployment = CreateRunningProductDeployment("test.product");
+        SetupProductDeploymentLookup("test.product", productDeployment);
+        SetupSuccessfulProductRedeploy(productDeployment.Id.Value.ToString());
+
+        var result = await _handler.Handle(
+            new RedeployStackCommand("some-stack-name", TestEnvironmentId, ProductId: "test.product"),
+            CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _mediatorMock.Verify(m => m.Send(
+            It.IsAny<RedeployProductCommand>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _mediatorMock.Verify(m => m.Send(
+            It.IsAny<DeployStackCommand>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    #endregion
+
     #region Helpers
 
     private void SetupDeploymentLookup(Deployment deployment)
@@ -517,6 +707,52 @@ public class RedeployStackHandlerTests
         deployment.MarkAsRunning();
         deployment.MarkAsRemoved();
         return deployment;
+    }
+
+    private static ProductDeployment CreateRunningProductDeployment(string productGroupId)
+    {
+        var stackConfigs = new List<StackDeploymentConfig>
+        {
+            new("Analytics", "Analytics", "source1:analytics", 2, new Dictionary<string, string>()),
+            new("Backend", "Backend", "source1:backend", 1, new Dictionary<string, string>())
+        };
+
+        var deployment = ProductDeployment.InitiateDeployment(
+            ProductDeploymentId.NewId(),
+            new EnvironmentId(Guid.Parse(TestEnvironmentId)),
+            productGroupId, $"{productGroupId}:1.0.0",
+            "test-product", "Test Product", "1.0.0",
+            UserId.Create(), "test-deployment",
+            stackConfigs, new Dictionary<string, string>());
+
+        foreach (var stack in deployment.GetStacksInDeployOrder())
+        {
+            deployment.StartStack(stack.StackName, DeploymentId.NewId());
+            deployment.CompleteStack(stack.StackName);
+        }
+
+        return deployment;
+    }
+
+    private void SetupProductDeploymentLookup(string productGroupId, ProductDeployment productDeployment)
+    {
+        _productDeploymentRepoMock
+            .Setup(r => r.GetActiveByProductGroupId(
+                It.Is<EnvironmentId>(e => e.Value == Guid.Parse(TestEnvironmentId)),
+                It.Is<string>(s => s == productGroupId)))
+            .Returns(productDeployment);
+    }
+
+    private void SetupSuccessfulProductRedeploy(string productDeploymentId)
+    {
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<RedeployProductCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new DeployProductResponse
+            {
+                Success = true,
+                ProductDeploymentId = productDeploymentId,
+                Message = "Redeploy completed"
+            });
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- Extends the existing `/api/hooks/redeploy` endpoint with optional `productId` and `stackDefinitionName` fields
- When `productId` is provided, resolves the active ProductDeployment and dispatches `RedeployProductCommand` instead of standalone stack redeploy
- Supports selective stack redeploy via `stackDefinitionName` (null = all stacks)
- Variable overrides are passed through to the product redeploy command
- Backward compatible: existing `stackName`-only requests continue to work unchanged

## Changed files
- `RedeployStackCommand.cs` — Extended request/command with `productId`/`stackDefinitionName`, added routing logic in handler
- `RedeployEndpoint.cs` — Passes new fields through, validates either `stackName` or `productId` is present
- `RedeployStackHandlerTests.cs` — 11 new tests (product routing, stack selection, variable passthrough, error handling, validation)

## Test plan
- [x] All 2551 unit tests pass
- [x] 31 redeploy hook handler tests pass (20 existing + 11 new)
- [ ] Manual test: POST `/api/hooks/redeploy` with `productId` triggers product redeploy
- [ ] Manual test: POST `/api/hooks/redeploy` with `stackName` only (backward compat)