### PR TITLE
Extract store hooks for product deployment pages into @rsgo/core

### DIFF
--- a/src/ReadyStackGo.WebUi/packages/core/src/hooks/useRedeployProductStore.ts
+++ b/src/ReadyStackGo.WebUi/packages/core/src/hooks/useRedeployProductStore.ts
@@ -1,0 +1,171 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import {
+  getProductDeployment,
+  redeployProduct,
+  type GetProductDeploymentResponse,
+  type DeployProductStackResult,
+} from '../api/deployments';
+import { useDeploymentHub } from '../realtime/useDeploymentHub';
+import type { DeploymentProgressUpdate } from '../realtime/useDeploymentHub';
+
+export type RedeployProductState = 'loading' | 'confirm' | 'redeploying' | 'success' | 'error';
+export type StackRedeployStatus = 'pending' | 'deploying' | 'running' | 'failed';
+
+export interface UseRedeployProductStoreReturn {
+  state: RedeployProductState;
+  deployment: GetProductDeploymentResponse | null;
+  error: string;
+  stackResults: DeployProductStackResult[];
+  stackStatuses: Record<string, StackRedeployStatus>;
+  progressUpdate: DeploymentProgressUpdate | null;
+  connectionState: string;
+  handleRedeploy: () => Promise<void>;
+}
+
+export function useRedeployProductStore(
+  token: string | null,
+  environmentId: string | undefined,
+  productDeploymentId: string | undefined,
+): UseRedeployProductStoreReturn {
+  const [state, setState] = useState<RedeployProductState>('loading');
+  const [deployment, setDeployment] = useState<GetProductDeploymentResponse | null>(null);
+  const [error, setError] = useState('');
+  const [stackResults, setStackResults] = useState<DeployProductStackResult[]>([]);
+  const [stackStatuses, setStackStatuses] = useState<Record<string, StackRedeployStatus>>({});
+  const redeploySessionIdRef = useRef<string | null>(null);
+  const [progressUpdate, setProgressUpdate] = useState<DeploymentProgressUpdate | null>(null);
+  const completedRef = useRef(false);
+
+  const handleRedeployProgress = useCallback((update: DeploymentProgressUpdate) => {
+    const currentSessionId = redeploySessionIdRef.current;
+    if (!currentSessionId || update.sessionId !== currentSessionId) return;
+
+    setProgressUpdate(update);
+
+    if (update.phase === 'ProductDeploy' && update.currentService) {
+      const stackName = update.currentService;
+      if (update.message?.startsWith('Redeploying stack')) {
+        setStackStatuses(prev => ({ ...prev, [stackName]: 'deploying' }));
+      } else if (update.message?.includes('redeployed successfully')) {
+        setStackStatuses(prev => ({ ...prev, [stackName]: 'running' }));
+      } else if (update.message?.includes('redeploy failed')) {
+        setStackStatuses(prev => ({ ...prev, [stackName]: 'failed' }));
+      }
+    }
+
+    if (update.isComplete && !completedRef.current) {
+      completedRef.current = true;
+      if (update.isError) {
+        setError(update.errorMessage || 'Redeploy failed');
+        setState('error');
+      } else {
+        setState('success');
+      }
+    }
+  }, []);
+
+  const { subscribeToDeployment, connectionState } = useDeploymentHub(token, {
+    onDeploymentProgress: handleRedeployProgress,
+  });
+
+  useEffect(() => {
+    if (!environmentId || !productDeploymentId) {
+      setState('error');
+      setError('No environment or product deployment ID provided');
+      return;
+    }
+
+    const loadDeployment = async () => {
+      try {
+        setState('loading');
+        setError('');
+
+        const response = await getProductDeployment(environmentId, productDeploymentId);
+        setDeployment(response);
+
+        if (!response.canRedeploy) {
+          setError(`Product "${response.productDisplayName}" cannot be redeployed in its current state (${response.status})`);
+          setState('error');
+          return;
+        }
+
+        const initialStatuses: Record<string, StackRedeployStatus> = {};
+        for (const stack of response.stacks) {
+          initialStatuses[stack.stackName] = 'pending';
+        }
+        setStackStatuses(initialStatuses);
+
+        setState('confirm');
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load product deployment');
+        setState('error');
+      }
+    };
+
+    loadDeployment();
+  }, [environmentId, productDeploymentId]);
+
+  const handleRedeploy = useCallback(async () => {
+    if (!environmentId || !deployment) {
+      setError('No deployment to redeploy');
+      return;
+    }
+
+    const sessionId = `product-redeploy-${deployment.productName}-${Date.now()}`;
+    redeploySessionIdRef.current = sessionId;
+    completedRef.current = false;
+
+    setState('redeploying');
+    setError('');
+    setProgressUpdate(null);
+
+    if (connectionState === 'connected') {
+      await subscribeToDeployment(sessionId);
+    }
+
+    redeployProduct(environmentId, deployment.productDeploymentId, { sessionId, continueOnError: true })
+      .then(response => {
+        setStackResults(response.stackResults || []);
+
+        setTimeout(() => {
+          if (!completedRef.current) {
+            completedRef.current = true;
+
+            const finalStatuses: Record<string, StackRedeployStatus> = {};
+            for (const stack of deployment.stacks) {
+              const result = response.stackResults.find(r => r.stackName === stack.stackName);
+              finalStatuses[stack.stackName] = result?.success ? 'running' : 'failed';
+            }
+            setStackStatuses(finalStatuses);
+
+            if (!response.success) {
+              setError(response.message || 'Redeploy completed with errors');
+              setState('error');
+            } else {
+              setState('success');
+            }
+          }
+        }, 3000);
+      })
+      .catch(err => {
+        setTimeout(() => {
+          if (!completedRef.current) {
+            completedRef.current = true;
+            setError(err instanceof Error ? err.message : 'Redeploy failed');
+            setState('error');
+          }
+        }, 3000);
+      });
+  }, [environmentId, deployment, connectionState, subscribeToDeployment]);
+
+  return {
+    state,
+    deployment,
+    error,
+    stackResults,
+    stackStatuses,
+    progressUpdate,
+    connectionState,
+    handleRedeploy,
+  };
+}

--- a/src/ReadyStackGo.WebUi/packages/core/src/hooks/useRemoveProductStore.ts
+++ b/src/ReadyStackGo.WebUi/packages/core/src/hooks/useRemoveProductStore.ts
@@ -1,0 +1,181 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import {
+  getProductDeployment,
+  removeProductDeployment,
+  type GetProductDeploymentResponse,
+  type RemoveProductStackResult,
+} from '../api/deployments';
+import { useDeploymentHub } from '../realtime/useDeploymentHub';
+import type { DeploymentProgressUpdate } from '../realtime/useDeploymentHub';
+
+const formatPhase = (phase: string | undefined): string => {
+  if (!phase) return '';
+  return phase.replace(/([A-Z])/g, ' $1').trim();
+};
+
+export type RemoveProductState = 'loading' | 'confirm' | 'removing' | 'success' | 'error';
+export type StackRemoveStatus = 'pending' | 'removing' | 'removed' | 'failed';
+
+export interface UseRemoveProductStoreReturn {
+  state: RemoveProductState;
+  deployment: GetProductDeploymentResponse | null;
+  error: string;
+  stackResults: RemoveProductStackResult[];
+  stackStatuses: Record<string, StackRemoveStatus>;
+  progressUpdate: DeploymentProgressUpdate | null;
+  connectionState: string;
+  formattedPhase: string;
+  totalServices: number;
+  handleRemove: () => Promise<void>;
+}
+
+export function useRemoveProductStore(
+  token: string | null,
+  environmentId: string | undefined,
+  productDeploymentId: string | undefined,
+): UseRemoveProductStoreReturn {
+  const [state, setState] = useState<RemoveProductState>('loading');
+  const [deployment, setDeployment] = useState<GetProductDeploymentResponse | null>(null);
+  const [error, setError] = useState('');
+  const [stackResults, setStackResults] = useState<RemoveProductStackResult[]>([]);
+  const [stackStatuses, setStackStatuses] = useState<Record<string, StackRemoveStatus>>({});
+  const removeSessionIdRef = useRef<string | null>(null);
+  const [progressUpdate, setProgressUpdate] = useState<DeploymentProgressUpdate | null>(null);
+  const completedRef = useRef(false);
+
+  const totalServices = deployment?.stacks.reduce((sum, s) => sum + s.serviceCount, 0) ?? 0;
+
+  const handleRemoveProgress = useCallback((update: DeploymentProgressUpdate) => {
+    const currentSessionId = removeSessionIdRef.current;
+    if (!currentSessionId || update.sessionId !== currentSessionId) return;
+
+    setProgressUpdate(update);
+
+    if (update.phase === 'ProductRemoval' && update.currentService) {
+      const stackName = update.currentService;
+      if (update.message?.startsWith('Removing stack')) {
+        setStackStatuses(prev => ({ ...prev, [stackName]: 'removing' }));
+      } else if (update.message?.startsWith('Stack removed:')) {
+        setStackStatuses(prev => ({ ...prev, [stackName]: 'removed' }));
+      } else if (update.message?.startsWith('Stack removal failed:')) {
+        setStackStatuses(prev => ({ ...prev, [stackName]: 'failed' }));
+      }
+    }
+
+    if (update.isComplete && !completedRef.current) {
+      completedRef.current = true;
+      if (update.isError) {
+        setError(update.errorMessage || 'Removal failed');
+        setState('error');
+      } else {
+        setState('success');
+      }
+    }
+  }, []);
+
+  const { subscribeToDeployment, connectionState } = useDeploymentHub(token, {
+    onDeploymentProgress: handleRemoveProgress,
+  });
+
+  useEffect(() => {
+    if (!environmentId || !productDeploymentId) {
+      setState('error');
+      setError('No environment or product deployment ID provided');
+      return;
+    }
+
+    const loadDeployment = async () => {
+      try {
+        setState('loading');
+        setError('');
+
+        const response = await getProductDeployment(environmentId, productDeploymentId);
+        setDeployment(response);
+
+        if (!response.canRemove) {
+          setError(`Product "${response.productDisplayName}" cannot be removed in its current state (${response.status})`);
+          setState('error');
+          return;
+        }
+
+        const initialStatuses: Record<string, StackRemoveStatus> = {};
+        for (const stack of response.stacks) {
+          initialStatuses[stack.stackName] = 'pending';
+        }
+        setStackStatuses(initialStatuses);
+
+        setState('confirm');
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load product deployment');
+        setState('error');
+      }
+    };
+
+    loadDeployment();
+  }, [environmentId, productDeploymentId]);
+
+  const handleRemove = useCallback(async () => {
+    if (!environmentId || !deployment) {
+      setError('No deployment to remove');
+      return;
+    }
+
+    const sessionId = `product-remove-${deployment.productName}-${Date.now()}`;
+    removeSessionIdRef.current = sessionId;
+    completedRef.current = false;
+
+    setState('removing');
+    setError('');
+    setProgressUpdate(null);
+
+    if (connectionState === 'connected') {
+      await subscribeToDeployment(sessionId);
+    }
+
+    removeProductDeployment(environmentId, deployment.productDeploymentId, { sessionId })
+      .then(response => {
+        setStackResults(response.stackResults || []);
+
+        setTimeout(() => {
+          if (!completedRef.current) {
+            completedRef.current = true;
+
+            const finalStatuses: Record<string, StackRemoveStatus> = {};
+            for (const result of response.stackResults) {
+              finalStatuses[result.stackName] = result.success ? 'removed' : 'failed';
+            }
+            setStackStatuses(finalStatuses);
+
+            if (!response.success) {
+              setError(response.message || 'Removal completed with errors');
+              setState('error');
+            } else {
+              setState('success');
+            }
+          }
+        }, 3000);
+      })
+      .catch(err => {
+        setTimeout(() => {
+          if (!completedRef.current) {
+            completedRef.current = true;
+            setError(err instanceof Error ? err.message : 'Removal failed');
+            setState('error');
+          }
+        }, 3000);
+      });
+  }, [environmentId, deployment, connectionState, subscribeToDeployment]);
+
+  return {
+    state,
+    deployment,
+    error,
+    stackResults,
+    stackStatuses,
+    progressUpdate,
+    connectionState,
+    formattedPhase: formatPhase(progressUpdate?.phase),
+    totalServices,
+    handleRemove,
+  };
+}

--- a/src/ReadyStackGo.WebUi/packages/core/src/hooks/useRetryProductStore.ts
+++ b/src/ReadyStackGo.WebUi/packages/core/src/hooks/useRetryProductStore.ts
@@ -1,0 +1,182 @@
+import { useState, useRef, useCallback, useEffect } from 'react';
+import {
+  getProductDeployment,
+  retryProduct,
+  type GetProductDeploymentResponse,
+  type DeployProductStackResult,
+} from '../api/deployments';
+import { useDeploymentHub } from '../realtime/useDeploymentHub';
+import type { DeploymentProgressUpdate } from '../realtime/useDeploymentHub';
+
+export type RetryProductState = 'loading' | 'confirm' | 'retrying' | 'success' | 'error';
+export type StackRetryStatus = 'skipped' | 'pending' | 'deploying' | 'running' | 'failed';
+
+export interface UseRetryProductStoreReturn {
+  state: RetryProductState;
+  deployment: GetProductDeploymentResponse | null;
+  error: string;
+  stackResults: DeployProductStackResult[];
+  stackStatuses: Record<string, StackRetryStatus>;
+  progressUpdate: DeploymentProgressUpdate | null;
+  connectionState: string;
+  failedStacks: GetProductDeploymentResponse['stacks'];
+  runningStacks: GetProductDeploymentResponse['stacks'];
+  handleRetry: () => Promise<void>;
+}
+
+export function useRetryProductStore(
+  token: string | null,
+  environmentId: string | undefined,
+  productDeploymentId: string | undefined,
+): UseRetryProductStoreReturn {
+  const [state, setState] = useState<RetryProductState>('loading');
+  const [deployment, setDeployment] = useState<GetProductDeploymentResponse | null>(null);
+  const [error, setError] = useState('');
+  const [stackResults, setStackResults] = useState<DeployProductStackResult[]>([]);
+  const [stackStatuses, setStackStatuses] = useState<Record<string, StackRetryStatus>>({});
+  const retrySessionIdRef = useRef<string | null>(null);
+  const [progressUpdate, setProgressUpdate] = useState<DeploymentProgressUpdate | null>(null);
+  const completedRef = useRef(false);
+
+  const failedStacks = deployment?.stacks.filter(s => s.status === 'Failed' || s.status === 'Pending') ?? [];
+  const runningStacks = deployment?.stacks.filter(s => s.status === 'Running') ?? [];
+
+  const handleRetryProgress = useCallback((update: DeploymentProgressUpdate) => {
+    const currentSessionId = retrySessionIdRef.current;
+    if (!currentSessionId || update.sessionId !== currentSessionId) return;
+
+    setProgressUpdate(update);
+
+    if (update.phase === 'ProductDeploy' && update.currentService) {
+      const stackName = update.currentService;
+      if (update.message?.startsWith('Retrying stack')) {
+        setStackStatuses(prev => ({ ...prev, [stackName]: 'deploying' }));
+      } else if (update.message?.includes('retried successfully')) {
+        setStackStatuses(prev => ({ ...prev, [stackName]: 'running' }));
+      } else if (update.message?.includes('retry failed')) {
+        setStackStatuses(prev => ({ ...prev, [stackName]: 'failed' }));
+      }
+    }
+
+    if (update.isComplete && !completedRef.current) {
+      completedRef.current = true;
+      if (update.isError) {
+        setError(update.errorMessage || 'Retry failed');
+        setState('error');
+      } else {
+        setState('success');
+      }
+    }
+  }, []);
+
+  const { subscribeToDeployment, connectionState } = useDeploymentHub(token, {
+    onDeploymentProgress: handleRetryProgress,
+  });
+
+  useEffect(() => {
+    if (!environmentId || !productDeploymentId) {
+      setState('error');
+      setError('No environment or product deployment ID provided');
+      return;
+    }
+
+    const loadDeployment = async () => {
+      try {
+        setState('loading');
+        setError('');
+
+        const response = await getProductDeployment(environmentId, productDeploymentId);
+        setDeployment(response);
+
+        if (!response.canRetry) {
+          setError(`Product "${response.productDisplayName}" cannot be retried in its current state (${response.status})`);
+          setState('error');
+          return;
+        }
+
+        const initialStatuses: Record<string, StackRetryStatus> = {};
+        for (const stack of response.stacks) {
+          initialStatuses[stack.stackName] = stack.status === 'Running' ? 'skipped' : 'pending';
+        }
+        setStackStatuses(initialStatuses);
+
+        setState('confirm');
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load product deployment');
+        setState('error');
+      }
+    };
+
+    loadDeployment();
+  }, [environmentId, productDeploymentId]);
+
+  const handleRetry = useCallback(async () => {
+    if (!environmentId || !deployment) {
+      setError('No deployment to retry');
+      return;
+    }
+
+    const sessionId = `product-retry-${deployment.productName}-${Date.now()}`;
+    retrySessionIdRef.current = sessionId;
+    completedRef.current = false;
+
+    setState('retrying');
+    setError('');
+    setProgressUpdate(null);
+
+    if (connectionState === 'connected') {
+      await subscribeToDeployment(sessionId);
+    }
+
+    retryProduct(environmentId, deployment.productDeploymentId, { sessionId, continueOnError: true })
+      .then(response => {
+        setStackResults(response.stackResults || []);
+
+        setTimeout(() => {
+          if (!completedRef.current) {
+            completedRef.current = true;
+
+            const finalStatuses: Record<string, StackRetryStatus> = {};
+            for (const stack of deployment.stacks) {
+              if (stack.status === 'Running') {
+                finalStatuses[stack.stackName] = 'skipped';
+              } else {
+                const result = response.stackResults.find(r => r.stackName === stack.stackName);
+                finalStatuses[stack.stackName] = result?.success ? 'running' : 'failed';
+              }
+            }
+            setStackStatuses(finalStatuses);
+
+            if (!response.success) {
+              setError(response.message || 'Retry completed with errors');
+              setState('error');
+            } else {
+              setState('success');
+            }
+          }
+        }, 3000);
+      })
+      .catch(err => {
+        setTimeout(() => {
+          if (!completedRef.current) {
+            completedRef.current = true;
+            setError(err instanceof Error ? err.message : 'Retry failed');
+            setState('error');
+          }
+        }, 3000);
+      });
+  }, [environmentId, deployment, connectionState, subscribeToDeployment]);
+
+  return {
+    state,
+    deployment,
+    error,
+    stackResults,
+    stackStatuses,
+    progressUpdate,
+    connectionState,
+    failedStacks,
+    runningStacks,
+    handleRetry,
+  };
+}

--- a/src/ReadyStackGo.WebUi/packages/core/src/index.ts
+++ b/src/ReadyStackGo.WebUi/packages/core/src/index.ts
@@ -56,6 +56,9 @@ export { useRemoveStackStore, type UseRemoveStackStoreReturn, type RemoveState }
 export { useRollbackStore, type UseRollbackStoreReturn, type RollbackState } from './hooks/useRollbackStore';
 export { useDeployStackStore, type UseDeployStackStoreReturn, type DeployState } from './hooks/useDeployStackStore';
 export { useUpgradeStackStore, type UseUpgradeStackStoreReturn, type UpgradeState } from './hooks/useUpgradeStackStore';
+export { useRemoveProductStore, type UseRemoveProductStoreReturn, type RemoveProductState } from './hooks/useRemoveProductStore';
+export { useRetryProductStore, type UseRetryProductStoreReturn, type RetryProductState } from './hooks/useRetryProductStore';
+export { useRedeployProductStore, type UseRedeployProductStoreReturn, type RedeployProductState } from './hooks/useRedeployProductStore';
 
 // Services
 export * from './services/AuthService';

--- a/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Deployments/RemoveProduct.tsx
+++ b/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Deployments/RemoveProduct.tsx
@@ -1,14 +1,10 @@
-import { useEffect, useState, useRef, useCallback } from 'react';
 import { useParams, Link } from 'react-router';
 import {
-  getProductDeployment,
-  removeProductDeployment,
-  type GetProductDeploymentResponse,
+  useRemoveProductStore,
   type RemoveProductStackResult,
-  type DeploymentProgressUpdate,
 } from '@rsgo/core';
+import { useAuth } from '../../context/AuthContext';
 import { useEnvironment } from '../../context/EnvironmentContext';
-import { useDeploymentHub } from '../../hooks/useDeploymentHub';
 
 // Format phase names for display (RemovingContainers -> Removing Containers)
 const formatPhase = (phase: string | undefined): string => {
@@ -16,179 +12,15 @@ const formatPhase = (phase: string | undefined): string => {
   return phase.replace(/([A-Z])/g, ' $1').trim();
 };
 
-type RemoveState = 'loading' | 'confirm' | 'removing' | 'success' | 'error';
-type StackRemoveStatus = 'pending' | 'removing' | 'removed' | 'failed';
-
 export default function RemoveProduct() {
   const { productDeploymentId } = useParams<{ productDeploymentId: string }>();
+  const { token } = useAuth();
   const { activeEnvironment } = useEnvironment();
 
-  const [state, setState] = useState<RemoveState>('loading');
-  const [deployment, setDeployment] = useState<GetProductDeploymentResponse | null>(null);
-  const [error, setError] = useState('');
-  const [stackResults, setStackResults] = useState<RemoveProductStackResult[]>([]);
-
-  // Per-stack progress tracking
-  const [stackStatuses, setStackStatuses] = useState<Record<string, StackRemoveStatus>>({});
-  // Progress state
-  const removeSessionIdRef = useRef<string | null>(null);
-  const [progressUpdate, setProgressUpdate] = useState<DeploymentProgressUpdate | null>(null);
-
-  // Prevent race condition: first completion (SignalR or API) wins
-  const completedRef = useRef(false);
-
-  // Total service count
-  const totalServices = deployment?.stacks.reduce((sum, s) => sum + s.serviceCount, 0) ?? 0;
-
-  // SignalR hub for real-time progress
-  const handleRemoveProgress = useCallback((update: DeploymentProgressUpdate) => {
-    const currentSessionId = removeSessionIdRef.current;
-    if (!currentSessionId || update.sessionId !== currentSessionId) return;
-
-    setProgressUpdate(update);
-
-    // Track per-stack status using currentService (stack technical name)
-    if (update.phase === 'ProductRemoval' && update.currentService) {
-      const stackName = update.currentService;
-      if (update.message?.startsWith('Removing stack')) {
-        setStackStatuses(prev => ({
-          ...prev,
-          [stackName]: 'removing',
-        }));
-      } else if (update.message?.startsWith('Stack removed:')) {
-        setStackStatuses(prev => ({
-          ...prev,
-          [stackName]: 'removed',
-        }));
-      } else if (update.message?.startsWith('Stack removal failed:')) {
-        setStackStatuses(prev => ({
-          ...prev,
-          [stackName]: 'failed',
-        }));
-      }
-    }
-
-    // SignalR isComplete drives the final state transition
-    if (update.isComplete && !completedRef.current) {
-      completedRef.current = true;
-      if (update.isError) {
-        setError(update.errorMessage || 'Removal failed');
-        setState('error');
-      } else {
-        setState('success');
-      }
-    }
-  }, []);
-
-  const { subscribeToDeployment, connectionState } = useDeploymentHub({
-    onDeploymentProgress: handleRemoveProgress,
-  });
-
-  // Load product deployment details
-  useEffect(() => {
-    if (!activeEnvironment || !productDeploymentId) {
-      setState('error');
-      setError('No environment or product deployment ID provided');
-      return;
-    }
-
-    const loadDeployment = async () => {
-      try {
-        setState('loading');
-        setError('');
-
-        const response = await getProductDeployment(activeEnvironment.id, productDeploymentId);
-        setDeployment(response);
-
-        if (!response.canRemove) {
-          setError(`Product "${response.productDisplayName}" cannot be removed in its current state (${response.status})`);
-          setState('error');
-          return;
-        }
-
-        // Initialize stack statuses
-        const initialStatuses: Record<string, StackRemoveStatus> = {};
-        for (const stack of response.stacks) {
-          initialStatuses[stack.stackName] = 'pending';
-        }
-        setStackStatuses(initialStatuses);
-
-        setState('confirm');
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load product deployment');
-        setState('error');
-      }
-    };
-
-    loadDeployment();
-  }, [activeEnvironment, productDeploymentId]);
-
-  const handleRemove = async () => {
-    if (!activeEnvironment || !deployment) {
-      setError('No deployment to remove');
-      return;
-    }
-
-    // Generate session ID BEFORE the API call
-    const sessionId = `product-remove-${deployment.productName}-${Date.now()}`;
-    removeSessionIdRef.current = sessionId;
-    completedRef.current = false;
-
-    setState('removing');
-    setError('');
-    setProgressUpdate(null);
-
-    // Subscribe to SignalR group BEFORE starting the API call
-    if (connectionState === 'connected') {
-      await subscribeToDeployment(sessionId);
-    }
-
-    // Fire-and-forget: SignalR drives live progress.
-    // API response is stored for the success screen and serves as a fallback
-    // if SignalR doesn't deliver the completion message.
-    removeProductDeployment(
-      activeEnvironment.id,
-      deployment.productDeploymentId,
-      { sessionId }
-    )
-      .then(response => {
-        // Always store API results (success screen needs them)
-        setStackResults(response.stackResults || []);
-
-        // Fallback: if SignalR hasn't completed within 3s, use API response
-        setTimeout(() => {
-          if (!completedRef.current) {
-            completedRef.current = true;
-
-            const finalStatuses: Record<string, StackRemoveStatus> = {};
-            for (const result of response.stackResults) {
-              finalStatuses[result.stackName] = result.success ? 'removed' : 'failed';
-            }
-            setStackStatuses(finalStatuses);
-
-            if (!response.success) {
-              setError(response.message || 'Removal completed with errors');
-              setState('error');
-            } else {
-              setState('success');
-            }
-          }
-        }, 3000);
-      })
-      .catch(err => {
-        // Fallback: if SignalR hasn't completed within 3s, use API error
-        setTimeout(() => {
-          if (!completedRef.current) {
-            completedRef.current = true;
-            setError(err instanceof Error ? err.message : 'Removal failed');
-            setState('error');
-          }
-        }, 3000);
-      });
-  };
+  const store = useRemoveProductStore(token, activeEnvironment?.id, productDeploymentId);
 
   // --- Loading state ---
-  if (state === 'loading') {
+  if (store.state === 'loading') {
     return (
       <div className="mx-auto max-w-screen-xl p-4 md:p-6 2xl:p-10">
         <div className="flex items-center justify-center py-12">
@@ -202,7 +34,7 @@ export default function RemoveProduct() {
   }
 
   // --- Error state (no deployment loaded) ---
-  if (state === 'error' && !deployment) {
+  if (store.state === 'error' && !store.deployment) {
     return (
       <div className="mx-auto max-w-screen-xl p-4 md:p-6 2xl:p-10">
         <div className="mb-6">
@@ -217,22 +49,21 @@ export default function RemoveProduct() {
           </Link>
         </div>
         <div className="rounded-md bg-red-50 p-4 dark:bg-red-900/20">
-          <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
+          <p className="text-sm text-red-800 dark:text-red-200">{store.error}</p>
         </div>
       </div>
     );
   }
 
   // --- Success state ---
-  if (state === 'success') {
-    // Build display results: prefer API response, fall back to SignalR-tracked statuses
-    const displayResults: RemoveProductStackResult[] = stackResults.length > 0
-      ? stackResults
-      : (deployment?.stacks.map(s => ({
+  if (store.state === 'success') {
+    const displayResults: RemoveProductStackResult[] = store.stackResults.length > 0
+      ? store.stackResults
+      : (store.deployment?.stacks.map(s => ({
           stackName: s.stackName,
           stackDisplayName: s.stackDisplayName,
           serviceCount: s.serviceCount,
-          success: stackStatuses[s.stackName] !== 'failed',
+          success: store.stackStatuses[s.stackName] !== 'failed',
         })) ?? []);
     const successCount = displayResults.filter(r => r.success).length;
 
@@ -249,10 +80,9 @@ export default function RemoveProduct() {
               Product Removed Successfully!
             </h1>
             <p className="text-gray-600 dark:text-gray-400 mb-6">
-              {deployment?.productDisplayName} ({successCount} stack{successCount !== 1 ? 's' : ''}) has been removed from {activeEnvironment?.name}
+              {store.deployment?.productDisplayName} ({successCount} stack{successCount !== 1 ? 's' : ''}) has been removed from {activeEnvironment?.name}
             </p>
 
-            {/* Stack Results Summary */}
             {displayResults.length > 0 && (
               <div className="w-full max-w-lg mb-6">
                 <div className="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
@@ -294,10 +124,10 @@ export default function RemoveProduct() {
   }
 
   // --- Removing state ---
-  if (state === 'removing') {
-    const totalStacks = deployment?.stacks.length ?? 0;
-    const removedStacks = Object.values(stackStatuses).filter(s => s === 'removed').length;
-    const failedStacks = Object.values(stackStatuses).filter(s => s === 'failed').length;
+  if (store.state === 'removing') {
+    const totalStacks = store.deployment?.stacks.length ?? 0;
+    const removedStacks = Object.values(store.stackStatuses).filter(s => s === 'removed').length;
+    const failedStacks = Object.values(store.stackStatuses).filter(s => s === 'failed').length;
     const processedStacks = removedStacks + failedStacks;
 
     return (
@@ -309,15 +139,14 @@ export default function RemoveProduct() {
               Removing Product...
             </h1>
             <p className="text-gray-600 dark:text-gray-400 mb-6">
-              Removing {deployment?.productDisplayName} from {activeEnvironment?.name}
+              Removing {store.deployment?.productDisplayName} from {activeEnvironment?.name}
             </p>
 
             <div className="w-full max-w-lg">
-              {/* Overall Progress */}
               <div className="mb-6">
                 <div className="flex justify-between text-sm mb-1">
                   <span className="text-gray-600 dark:text-gray-400">
-                    {formatPhase(progressUpdate?.phase) || 'Initializing'}
+                    {formatPhase(store.progressUpdate?.phase) || 'Initializing'}
                   </span>
                   <span className="text-gray-600 dark:text-gray-400">
                     {processedStacks}/{totalStacks} stacks
@@ -331,20 +160,18 @@ export default function RemoveProduct() {
                 </div>
               </div>
 
-              {/* Status Message */}
               <div className="text-center mb-6">
                 <p className="text-sm text-gray-700 dark:text-gray-300 font-medium">
-                  {progressUpdate?.message || 'Starting removal...'}
+                  {store.progressUpdate?.message || 'Starting removal...'}
                 </p>
               </div>
 
-              {/* Per-Stack Status List */}
               <div className="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
-                {deployment?.stacks
+                {store.deployment?.stacks
                   .slice()
-                  .sort((a, b) => b.order - a.order) // Reverse order (removal order)
+                  .sort((a, b) => b.order - a.order)
                   .map((stack) => {
-                    const status = stackStatuses[stack.stackName] || 'pending';
+                    const status = store.stackStatuses[stack.stackName] || 'pending';
                     return (
                       <div
                         key={stack.stackName}
@@ -353,7 +180,6 @@ export default function RemoveProduct() {
                         }`}
                       >
                         <div className="flex items-center gap-3">
-                          {/* Status Icon */}
                           {status === 'pending' && (
                             <div className="w-4 h-4 rounded-full border-2 border-gray-300 dark:border-gray-600" />
                           )}
@@ -387,17 +213,16 @@ export default function RemoveProduct() {
                   })}
               </div>
 
-              {/* Connection Status */}
               <div className="mt-6 flex items-center justify-center gap-2 text-xs text-gray-500 dark:text-gray-400">
                 <span className={`w-2 h-2 rounded-full ${
-                  connectionState === 'connected' ? 'bg-green-500' :
-                  connectionState === 'connecting' ? 'bg-yellow-500' :
-                  connectionState === 'reconnecting' ? 'bg-yellow-500' :
+                  store.connectionState === 'connected' ? 'bg-green-500' :
+                  store.connectionState === 'connecting' ? 'bg-yellow-500' :
+                  store.connectionState === 'reconnecting' ? 'bg-yellow-500' :
                   'bg-red-500'
                 }`} />
-                {connectionState === 'connected' ? 'Live updates' :
-                 connectionState === 'connecting' ? 'Connecting...' :
-                 connectionState === 'reconnecting' ? 'Reconnecting...' :
+                {store.connectionState === 'connected' ? 'Live updates' :
+                 store.connectionState === 'connecting' ? 'Connecting...' :
+                 store.connectionState === 'reconnecting' ? 'Reconnecting...' :
                  'Updates unavailable'}
               </div>
             </div>
@@ -408,16 +233,15 @@ export default function RemoveProduct() {
   }
 
   // --- Error state (with deployment loaded, e.g. partial failure) ---
-  if (state === 'error' && deployment) {
-    // Build display results: prefer API response, fall back to SignalR-tracked statuses
-    const errorDisplayResults: RemoveProductStackResult[] = stackResults.length > 0
-      ? stackResults
-      : (deployment.stacks.map(s => ({
+  if (store.state === 'error' && store.deployment) {
+    const errorDisplayResults: RemoveProductStackResult[] = store.stackResults.length > 0
+      ? store.stackResults
+      : (store.deployment.stacks.map(s => ({
           stackName: s.stackName,
           stackDisplayName: s.stackDisplayName,
           serviceCount: s.serviceCount,
-          success: stackStatuses[s.stackName] === 'removed',
-          errorMessage: stackStatuses[s.stackName] === 'failed' ? 'Removal failed' : undefined,
+          success: store.stackStatuses[s.stackName] === 'removed',
+          errorMessage: store.stackStatuses[s.stackName] === 'failed' ? 'Removal failed' : undefined,
         })));
     const successCount = errorDisplayResults.filter(r => r.success).length;
     const failedCount = errorDisplayResults.filter(r => !r.success).length;
@@ -448,7 +272,7 @@ export default function RemoveProduct() {
               Removal Completed with Errors
             </h1>
             <p className="text-gray-600 dark:text-gray-400 mb-2">
-              {error}
+              {store.error}
             </p>
             {errorDisplayResults.length > 0 && (
               <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
@@ -456,7 +280,6 @@ export default function RemoveProduct() {
               </p>
             )}
 
-            {/* Per-Stack Results */}
             {errorDisplayResults.length > 0 && (
               <div className="w-full max-w-lg mb-6">
                 <div className="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
@@ -519,7 +342,6 @@ export default function RemoveProduct() {
   // --- Confirm state ---
   return (
     <div className="mx-auto max-w-screen-xl p-4 md:p-6 2xl:p-10">
-      {/* Breadcrumb */}
       <div className="mb-6">
         <Link
           to="/catalog"
@@ -532,10 +354,8 @@ export default function RemoveProduct() {
         </Link>
       </div>
 
-      {/* Confirmation Card */}
       <div className="rounded-2xl border border-red-200 bg-white p-8 dark:border-red-800 dark:bg-white/[0.03]">
         <div className="flex flex-col items-center py-4">
-          {/* Warning Icon */}
           <div className="flex items-center justify-center w-16 h-16 mb-6 bg-red-100 rounded-full dark:bg-red-900/30">
             <svg className="w-8 h-8 text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
@@ -546,24 +366,23 @@ export default function RemoveProduct() {
             Remove Product Deployment
           </h1>
           <p className="text-gray-600 dark:text-gray-400 mb-2 text-center">
-            Are you sure you want to remove <strong className="text-gray-900 dark:text-white">{deployment?.productDisplayName}</strong>?
+            Are you sure you want to remove <strong className="text-gray-900 dark:text-white">{store.deployment?.productDisplayName}</strong>?
           </p>
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-6 text-center max-w-md">
-            This will stop and remove all {deployment?.totalStacks} stack{(deployment?.totalStacks ?? 0) !== 1 ? 's' : ''} with {totalServices} container{totalServices !== 1 ? 's' : ''}.
+            This will stop and remove all {store.deployment?.totalStacks} stack{(store.deployment?.totalStacks ?? 0) !== 1 ? 's' : ''} with {store.totalServices} container{store.totalServices !== 1 ? 's' : ''}.
             This action cannot be undone.
           </p>
 
-          {/* Deployment Info */}
           <div className="w-full max-w-lg mb-6 p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
             <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-3">Product Details</h3>
             <div className="space-y-2 text-sm mb-4">
               <div className="flex justify-between">
                 <span className="text-gray-600 dark:text-gray-400">Product:</span>
-                <span className="font-medium text-gray-900 dark:text-white">{deployment?.productDisplayName}</span>
+                <span className="font-medium text-gray-900 dark:text-white">{store.deployment?.productDisplayName}</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-gray-600 dark:text-gray-400">Version:</span>
-                <span className="font-medium text-gray-900 dark:text-white">v{deployment?.productVersion}</span>
+                <span className="font-medium text-gray-900 dark:text-white">v{store.deployment?.productVersion}</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-gray-600 dark:text-gray-400">Environment:</span>
@@ -571,20 +390,19 @@ export default function RemoveProduct() {
               </div>
               <div className="flex justify-between">
                 <span className="text-gray-600 dark:text-gray-400">Stacks:</span>
-                <span className="font-medium text-gray-900 dark:text-white">{deployment?.totalStacks}</span>
+                <span className="font-medium text-gray-900 dark:text-white">{store.deployment?.totalStacks}</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-gray-600 dark:text-gray-400">Total Services:</span>
-                <span className="font-medium text-gray-900 dark:text-white">{totalServices}</span>
+                <span className="font-medium text-gray-900 dark:text-white">{store.totalServices}</span>
               </div>
             </div>
 
-            {/* Stack List */}
             <h4 className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">
               Stacks to remove (in reverse order)
             </h4>
             <div className="space-y-1">
-              {deployment?.stacks
+              {store.deployment?.stacks
                 .slice()
                 .sort((a, b) => b.order - a.order)
                 .map((stack) => (
@@ -610,15 +428,13 @@ export default function RemoveProduct() {
             </div>
           </div>
 
-          {/* Error Display */}
-          {error && (
+          {store.error && (
             <div className="w-full max-w-lg mb-6 p-4 text-sm text-red-800 bg-red-100 rounded-lg dark:bg-red-900/30 dark:text-red-400">
               <p className="font-medium mb-1">Error</p>
-              <p>{error}</p>
+              <p>{store.error}</p>
             </div>
           )}
 
-          {/* Action Buttons */}
           <div className="flex gap-4">
             <Link
               to="/catalog"
@@ -627,7 +443,7 @@ export default function RemoveProduct() {
               Cancel
             </Link>
             <button
-              onClick={handleRemove}
+              onClick={store.handleRemove}
               className="inline-flex items-center justify-center gap-2 rounded-md bg-red-600 px-6 py-3 text-center font-medium text-white hover:bg-red-700"
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Deployments/RetryProduct.tsx
+++ b/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Deployments/RetryProduct.tsx
@@ -1,194 +1,20 @@
-import { useEffect, useState, useRef, useCallback } from 'react';
 import { useParams, Link } from 'react-router';
 import {
-  getProductDeployment,
-  retryProduct,
-  type GetProductDeploymentResponse,
+  useRetryProductStore,
   type DeployProductStackResult,
-  type DeploymentProgressUpdate,
 } from '@rsgo/core';
+import { useAuth } from '../../context/AuthContext';
 import { useEnvironment } from '../../context/EnvironmentContext';
-import { useDeploymentHub } from '../../hooks/useDeploymentHub';
-
-type RetryState = 'loading' | 'confirm' | 'retrying' | 'success' | 'error';
-type StackRetryStatus = 'skipped' | 'pending' | 'deploying' | 'running' | 'failed';
 
 export default function RetryProduct() {
   const { productDeploymentId } = useParams<{ productDeploymentId: string }>();
+  const { token } = useAuth();
   const { activeEnvironment } = useEnvironment();
 
-  const [state, setState] = useState<RetryState>('loading');
-  const [deployment, setDeployment] = useState<GetProductDeploymentResponse | null>(null);
-  const [error, setError] = useState('');
-  const [stackResults, setStackResults] = useState<DeployProductStackResult[]>([]);
-
-  // Per-stack progress tracking
-  const [stackStatuses, setStackStatuses] = useState<Record<string, StackRetryStatus>>({});
-  // Progress state
-  const retrySessionIdRef = useRef<string | null>(null);
-  const [progressUpdate, setProgressUpdate] = useState<DeploymentProgressUpdate | null>(null);
-
-  // Prevent race condition: first completion (SignalR or API) wins
-  const completedRef = useRef(false);
-
-  // SignalR hub for real-time progress
-  const handleRetryProgress = useCallback((update: DeploymentProgressUpdate) => {
-    const currentSessionId = retrySessionIdRef.current;
-    if (!currentSessionId || update.sessionId !== currentSessionId) return;
-
-    setProgressUpdate(update);
-
-    // Track per-stack status using currentService (stack technical name)
-    if (update.phase === 'ProductDeploy' && update.currentService) {
-      const stackName = update.currentService;
-      if (update.message?.startsWith('Retrying stack')) {
-        setStackStatuses(prev => ({
-          ...prev,
-          [stackName]: 'deploying',
-        }));
-      } else if (update.message?.includes('retried successfully')) {
-        setStackStatuses(prev => ({
-          ...prev,
-          [stackName]: 'running',
-        }));
-      } else if (update.message?.includes('retry failed')) {
-        setStackStatuses(prev => ({
-          ...prev,
-          [stackName]: 'failed',
-        }));
-      }
-    }
-
-    // SignalR isComplete drives the final state transition
-    if (update.isComplete && !completedRef.current) {
-      completedRef.current = true;
-      if (update.isError) {
-        setError(update.errorMessage || 'Retry failed');
-        setState('error');
-      } else {
-        setState('success');
-      }
-    }
-  }, []);
-
-  const { subscribeToDeployment, connectionState } = useDeploymentHub({
-    onDeploymentProgress: handleRetryProgress,
-  });
-
-  // Load product deployment details
-  useEffect(() => {
-    if (!activeEnvironment || !productDeploymentId) {
-      setState('error');
-      setError('No environment or product deployment ID provided');
-      return;
-    }
-
-    const loadDeployment = async () => {
-      try {
-        setState('loading');
-        setError('');
-
-        const response = await getProductDeployment(activeEnvironment.id, productDeploymentId);
-        setDeployment(response);
-
-        if (!response.canRetry) {
-          setError(`Product "${response.productDisplayName}" cannot be retried in its current state (${response.status})`);
-          setState('error');
-          return;
-        }
-
-        // Initialize stack statuses: Running stacks are skipped, Failed/Pending will be retried
-        const initialStatuses: Record<string, StackRetryStatus> = {};
-        for (const stack of response.stacks) {
-          initialStatuses[stack.stackName] = stack.status === 'Running' ? 'skipped' : 'pending';
-        }
-        setStackStatuses(initialStatuses);
-
-        setState('confirm');
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to load product deployment');
-        setState('error');
-      }
-    };
-
-    loadDeployment();
-  }, [activeEnvironment, productDeploymentId]);
-
-  const handleRetry = async () => {
-    if (!activeEnvironment || !deployment) {
-      setError('No deployment to retry');
-      return;
-    }
-
-    // Generate session ID BEFORE the API call
-    const sessionId = `product-retry-${deployment.productName}-${Date.now()}`;
-    retrySessionIdRef.current = sessionId;
-    completedRef.current = false;
-
-    setState('retrying');
-    setError('');
-    setProgressUpdate(null);
-
-    // Subscribe to SignalR group BEFORE starting the API call
-    if (connectionState === 'connected') {
-      await subscribeToDeployment(sessionId);
-    }
-
-    // Fire-and-forget: SignalR drives live progress.
-    // API response is stored for the success screen and serves as a fallback
-    // if SignalR doesn't deliver the completion message.
-    retryProduct(
-      activeEnvironment.id,
-      deployment.productDeploymentId,
-      { sessionId, continueOnError: true }
-    )
-      .then(response => {
-        // Always store API results (success screen needs them)
-        setStackResults(response.stackResults || []);
-
-        // Fallback: if SignalR hasn't completed within 3s, use API response
-        setTimeout(() => {
-          if (!completedRef.current) {
-            completedRef.current = true;
-
-            const finalStatuses: Record<string, StackRetryStatus> = {};
-            for (const stack of deployment.stacks) {
-              if (stack.status === 'Running') {
-                finalStatuses[stack.stackName] = 'skipped';
-              } else {
-                const result = response.stackResults.find(r => r.stackName === stack.stackName);
-                finalStatuses[stack.stackName] = result?.success ? 'running' : 'failed';
-              }
-            }
-            setStackStatuses(finalStatuses);
-
-            if (!response.success) {
-              setError(response.message || 'Retry completed with errors');
-              setState('error');
-            } else {
-              setState('success');
-            }
-          }
-        }, 3000);
-      })
-      .catch(err => {
-        // Fallback: if SignalR hasn't completed within 3s, use API error
-        setTimeout(() => {
-          if (!completedRef.current) {
-            completedRef.current = true;
-            setError(err instanceof Error ? err.message : 'Retry failed');
-            setState('error');
-          }
-        }, 3000);
-      });
-  };
-
-  // Computed values
-  const failedStacks = deployment?.stacks.filter(s => s.status === 'Failed' || s.status === 'Pending') ?? [];
-  const runningStacks = deployment?.stacks.filter(s => s.status === 'Running') ?? [];
+  const store = useRetryProductStore(token, activeEnvironment?.id, productDeploymentId);
 
   // --- Loading state ---
-  if (state === 'loading') {
+  if (store.state === 'loading') {
     return (
       <div className="mx-auto max-w-screen-xl p-4 md:p-6 2xl:p-10">
         <div className="flex items-center justify-center py-12">
@@ -202,7 +28,7 @@ export default function RetryProduct() {
   }
 
   // --- Error state (no deployment loaded) ---
-  if (state === 'error' && !deployment) {
+  if (store.state === 'error' && !store.deployment) {
     return (
       <div className="mx-auto max-w-screen-xl p-4 md:p-6 2xl:p-10">
         <div className="mb-6">
@@ -217,23 +43,23 @@ export default function RetryProduct() {
           </Link>
         </div>
         <div className="rounded-md bg-red-50 p-4 dark:bg-red-900/20">
-          <p className="text-sm text-red-800 dark:text-red-200">{error}</p>
+          <p className="text-sm text-red-800 dark:text-red-200">{store.error}</p>
         </div>
       </div>
     );
   }
 
   // --- Success state ---
-  if (state === 'success') {
-    const displayResults: DeployProductStackResult[] = stackResults.length > 0
-      ? stackResults
-      : (deployment?.stacks
+  if (store.state === 'success') {
+    const displayResults: DeployProductStackResult[] = store.stackResults.length > 0
+      ? store.stackResults
+      : (store.deployment?.stacks
           .filter(s => s.status !== 'Running')
           .map(s => ({
             stackName: s.stackName,
             stackDisplayName: s.stackDisplayName,
             serviceCount: s.serviceCount,
-            success: stackStatuses[s.stackName] !== 'failed',
+            success: store.stackStatuses[s.stackName] !== 'failed',
           })) ?? []);
     const successCount = displayResults.filter(r => r.success).length;
 
@@ -250,7 +76,7 @@ export default function RetryProduct() {
               Retry Successful!
             </h1>
             <p className="text-gray-600 dark:text-gray-400 mb-6">
-              {deployment?.productDisplayName} — {successCount} stack{successCount !== 1 ? 's' : ''} retried successfully
+              {store.deployment?.productDisplayName} — {successCount} stack{successCount !== 1 ? 's' : ''} retried successfully
             </p>
 
             {/* Stack Results Summary */}
@@ -276,7 +102,7 @@ export default function RetryProduct() {
 
             <div className="flex gap-4">
               <Link
-                to={`/product-deployments/${deployment?.productDeploymentId}`}
+                to={`/product-deployments/${store.deployment?.productDeploymentId}`}
                 className="inline-flex items-center justify-center gap-2 rounded-md bg-brand-600 px-6 py-3 text-center font-medium text-white hover:bg-brand-700"
               >
                 View Deployment
@@ -295,10 +121,10 @@ export default function RetryProduct() {
   }
 
   // --- Retrying state ---
-  if (state === 'retrying') {
-    const totalRetryStacks = failedStacks.length;
-    const completedRetryStacks = Object.values(stackStatuses).filter(s => s === 'running').length;
-    const failedRetryStacks = Object.values(stackStatuses).filter(s => s === 'failed').length;
+  if (store.state === 'retrying') {
+    const totalRetryStacks = store.failedStacks.length;
+    const completedRetryStacks = Object.values(store.stackStatuses).filter(s => s === 'running').length;
+    const failedRetryStacks = Object.values(store.stackStatuses).filter(s => s === 'failed').length;
     const processedStacks = completedRetryStacks + failedRetryStacks;
 
     return (
@@ -310,7 +136,7 @@ export default function RetryProduct() {
               Retrying Failed Stacks...
             </h1>
             <p className="text-gray-600 dark:text-gray-400 mb-6">
-              Retrying {deployment?.productDisplayName} in {activeEnvironment?.name}
+              Retrying {store.deployment?.productDisplayName} in {activeEnvironment?.name}
             </p>
 
             <div className="w-full max-w-lg">
@@ -318,7 +144,7 @@ export default function RetryProduct() {
               <div className="mb-6">
                 <div className="flex justify-between text-sm mb-1">
                   <span className="text-gray-600 dark:text-gray-400">
-                    {progressUpdate?.message || 'Initializing retry...'}
+                    {store.progressUpdate?.message || 'Initializing retry...'}
                   </span>
                   <span className="text-gray-600 dark:text-gray-400">
                     {processedStacks}/{totalRetryStacks} stacks
@@ -334,11 +160,11 @@ export default function RetryProduct() {
 
               {/* Per-Stack Status List */}
               <div className="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
-                {deployment?.stacks
+                {store.deployment?.stacks
                   .slice()
                   .sort((a, b) => a.order - b.order)
                   .map((stack) => {
-                    const status = stackStatuses[stack.stackName] || 'pending';
+                    const status = store.stackStatuses[stack.stackName] || 'pending';
                     return (
                       <div
                         key={stack.stackName}
@@ -393,14 +219,14 @@ export default function RetryProduct() {
               {/* Connection Status */}
               <div className="mt-6 flex items-center justify-center gap-2 text-xs text-gray-500 dark:text-gray-400">
                 <span className={`w-2 h-2 rounded-full ${
-                  connectionState === 'connected' ? 'bg-green-500' :
-                  connectionState === 'connecting' ? 'bg-yellow-500' :
-                  connectionState === 'reconnecting' ? 'bg-yellow-500' :
+                  store.connectionState === 'connected' ? 'bg-green-500' :
+                  store.connectionState === 'connecting' ? 'bg-yellow-500' :
+                  store.connectionState === 'reconnecting' ? 'bg-yellow-500' :
                   'bg-red-500'
                 }`} />
-                {connectionState === 'connected' ? 'Live updates' :
-                 connectionState === 'connecting' ? 'Connecting...' :
-                 connectionState === 'reconnecting' ? 'Reconnecting...' :
+                {store.connectionState === 'connected' ? 'Live updates' :
+                 store.connectionState === 'connecting' ? 'Connecting...' :
+                 store.connectionState === 'reconnecting' ? 'Reconnecting...' :
                  'Updates unavailable'}
               </div>
             </div>
@@ -411,17 +237,17 @@ export default function RetryProduct() {
   }
 
   // --- Error state (with deployment loaded, e.g. partial failure) ---
-  if (state === 'error' && deployment) {
-    const errorDisplayResults: DeployProductStackResult[] = stackResults.length > 0
-      ? stackResults
-      : (deployment.stacks
+  if (store.state === 'error' && store.deployment) {
+    const errorDisplayResults: DeployProductStackResult[] = store.stackResults.length > 0
+      ? store.stackResults
+      : (store.deployment.stacks
           .filter(s => s.status !== 'Running')
           .map(s => ({
             stackName: s.stackName,
             stackDisplayName: s.stackDisplayName,
             serviceCount: s.serviceCount,
-            success: stackStatuses[s.stackName] === 'running',
-            errorMessage: stackStatuses[s.stackName] === 'failed' ? 'Retry failed' : undefined,
+            success: store.stackStatuses[s.stackName] === 'running',
+            errorMessage: store.stackStatuses[s.stackName] === 'failed' ? 'Retry failed' : undefined,
           })));
     const successCount = errorDisplayResults.filter(r => r.success).length;
     const failedCount = errorDisplayResults.filter(r => !r.success).length;
@@ -430,7 +256,7 @@ export default function RetryProduct() {
       <div className="mx-auto max-w-screen-xl p-4 md:p-6 2xl:p-10">
         <div className="mb-6">
           <Link
-            to={`/product-deployments/${deployment.productDeploymentId}`}
+            to={`/product-deployments/${store.deployment.productDeploymentId}`}
             className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200"
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -452,7 +278,7 @@ export default function RetryProduct() {
               Retry Completed with Errors
             </h1>
             <p className="text-gray-600 dark:text-gray-400 mb-2">
-              {error}
+              {store.error}
             </p>
             {errorDisplayResults.length > 0 && (
               <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
@@ -502,7 +328,7 @@ export default function RetryProduct() {
 
             <div className="flex gap-4">
               <Link
-                to={`/product-deployments/${deployment.productDeploymentId}`}
+                to={`/product-deployments/${store.deployment.productDeploymentId}`}
                 className="inline-flex items-center justify-center gap-2 rounded-md bg-brand-600 px-6 py-3 text-center font-medium text-white hover:bg-brand-700"
               >
                 View Deployment
@@ -526,7 +352,7 @@ export default function RetryProduct() {
       {/* Breadcrumb */}
       <div className="mb-6">
         <Link
-          to={`/product-deployments/${deployment?.productDeploymentId}`}
+          to={`/product-deployments/${store.deployment?.productDeploymentId}`}
           className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200"
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -550,11 +376,11 @@ export default function RetryProduct() {
             Retry Failed Stacks
           </h1>
           <p className="text-gray-600 dark:text-gray-400 mb-2 text-center">
-            Retry failed stacks of <strong className="text-gray-900 dark:text-white">{deployment?.productDisplayName}</strong>?
+            Retry failed stacks of <strong className="text-gray-900 dark:text-white">{store.deployment?.productDisplayName}</strong>?
           </p>
           <p className="text-sm text-gray-500 dark:text-gray-400 mb-6 text-center max-w-md">
-            This will re-deploy {failedStacks.length} failed stack{failedStacks.length !== 1 ? 's' : ''} using the original configuration.
-            {runningStacks.length > 0 && ` ${runningStacks.length} already running stack${runningStacks.length !== 1 ? 's' : ''} will be skipped.`}
+            This will re-deploy {store.failedStacks.length} failed stack{store.failedStacks.length !== 1 ? 's' : ''} using the original configuration.
+            {store.runningStacks.length > 0 && ` ${store.runningStacks.length} already running stack${store.runningStacks.length !== 1 ? 's' : ''} will be skipped.`}
           </p>
 
           {/* Deployment Info */}
@@ -563,11 +389,11 @@ export default function RetryProduct() {
             <div className="space-y-2 text-sm mb-4">
               <div className="flex justify-between">
                 <span className="text-gray-600 dark:text-gray-400">Product:</span>
-                <span className="font-medium text-gray-900 dark:text-white">{deployment?.productDisplayName}</span>
+                <span className="font-medium text-gray-900 dark:text-white">{store.deployment?.productDisplayName}</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-gray-600 dark:text-gray-400">Version:</span>
-                <span className="font-medium text-gray-900 dark:text-white">v{deployment?.productVersion}</span>
+                <span className="font-medium text-gray-900 dark:text-white">v{store.deployment?.productVersion}</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-gray-600 dark:text-gray-400">Environment:</span>
@@ -575,22 +401,22 @@ export default function RetryProduct() {
               </div>
               <div className="flex justify-between">
                 <span className="text-gray-600 dark:text-gray-400">Failed Stacks:</span>
-                <span className="font-medium text-red-600 dark:text-red-400">{failedStacks.length} of {deployment?.totalStacks}</span>
+                <span className="font-medium text-red-600 dark:text-red-400">{store.failedStacks.length} of {store.deployment?.totalStacks}</span>
               </div>
               <div className="flex justify-between">
                 <span className="text-gray-600 dark:text-gray-400">Running Stacks:</span>
-                <span className="font-medium text-green-600 dark:text-green-400">{runningStacks.length} (skipped)</span>
+                <span className="font-medium text-green-600 dark:text-green-400">{store.runningStacks.length} (skipped)</span>
               </div>
             </div>
 
             {/* Stacks to Retry */}
-            {failedStacks.length > 0 && (
+            {store.failedStacks.length > 0 && (
               <>
                 <h4 className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">
                   Stacks to retry
                 </h4>
                 <div className="space-y-1 mb-3">
-                  {failedStacks
+                  {store.failedStacks
                     .sort((a, b) => a.order - b.order)
                     .map((stack) => (
                       <div key={stack.stackName} className="flex items-center justify-between py-1">
@@ -612,13 +438,13 @@ export default function RetryProduct() {
             )}
 
             {/* Running Stacks (skipped) */}
-            {runningStacks.length > 0 && (
+            {store.runningStacks.length > 0 && (
               <>
                 <h4 className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">
                   Already running (will be skipped)
                 </h4>
                 <div className="space-y-1">
-                  {runningStacks
+                  {store.runningStacks
                     .sort((a, b) => a.order - b.order)
                     .map((stack) => (
                       <div key={stack.stackName} className="flex items-center justify-between py-1">
@@ -641,23 +467,23 @@ export default function RetryProduct() {
           </div>
 
           {/* Error Display */}
-          {error && (
+          {store.error && (
             <div className="w-full max-w-lg mb-6 p-4 text-sm text-red-800 bg-red-100 rounded-lg dark:bg-red-900/30 dark:text-red-400">
               <p className="font-medium mb-1">Error</p>
-              <p>{error}</p>
+              <p>{store.error}</p>
             </div>
           )}
 
           {/* Action Buttons */}
           <div className="flex gap-4">
             <Link
-              to={`/product-deployments/${deployment?.productDeploymentId}`}
+              to={`/product-deployments/${store.deployment?.productDeploymentId}`}
               className="inline-flex items-center justify-center gap-2 rounded-md bg-gray-100 px-6 py-3 text-center font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
             >
               Cancel
             </Link>
             <button
-              onClick={handleRetry}
+              onClick={store.handleRetry}
               className="inline-flex items-center justify-center gap-2 rounded-md bg-yellow-500 px-6 py-3 text-center font-medium text-white hover:bg-yellow-600"
             >
               <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary

- Created 3 new store hooks in `@rsgo/core/hooks/` for product operations:
  - `useRemoveProductStore` — product removal with multi-stack progress tracking
  - `useRetryProductStore` — retry failed stacks with selective retry support
  - `useRedeployProductStore` — redeploy product with progress tracking
- Refactored `RemoveProduct`, `RetryProduct`, and `RedeployProduct` pages to use store hooks
- Pages become purely presentational, delegating all state management to core hooks

## Test plan

- [ ] Remove a product deployment — verify multi-stack progress and completion
- [ ] Retry failed stacks in a product — verify selective retry and progress
- [ ] Redeploy a product — verify progress tracking and completion
- [ ] Verify error states display correctly for all three operations