### PR TITLE
Add backend extension points for downstream distributions

### DIFF
--- a/ReadyStackGo.sln
+++ b/ReadyStackGo.sln
@@ -25,6 +25,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReadyStackGo.Infrastructure
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReadyStackGo.Infrastructure.Docker", "src\ReadyStackGo.Infrastructure.Docker\ReadyStackGo.Infrastructure.Docker.csproj", "{C99E8561-DB3E-44FC-81CA-EA1DDCCAC542}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ReadyStackGo.Core", "src\ReadyStackGo.Core\ReadyStackGo.Core.csproj", "{89EE341C-85BF-4C44-95E0-A6236AAAF3BB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -143,6 +145,18 @@ Global
 		{C99E8561-DB3E-44FC-81CA-EA1DDCCAC542}.Release|x64.Build.0 = Release|Any CPU
 		{C99E8561-DB3E-44FC-81CA-EA1DDCCAC542}.Release|x86.ActiveCfg = Release|Any CPU
 		{C99E8561-DB3E-44FC-81CA-EA1DDCCAC542}.Release|x86.Build.0 = Release|Any CPU
+		{89EE341C-85BF-4C44-95E0-A6236AAAF3BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89EE341C-85BF-4C44-95E0-A6236AAAF3BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89EE341C-85BF-4C44-95E0-A6236AAAF3BB}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{89EE341C-85BF-4C44-95E0-A6236AAAF3BB}.Debug|x64.Build.0 = Debug|Any CPU
+		{89EE341C-85BF-4C44-95E0-A6236AAAF3BB}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{89EE341C-85BF-4C44-95E0-A6236AAAF3BB}.Debug|x86.Build.0 = Debug|Any CPU
+		{89EE341C-85BF-4C44-95E0-A6236AAAF3BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{89EE341C-85BF-4C44-95E0-A6236AAAF3BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{89EE341C-85BF-4C44-95E0-A6236AAAF3BB}.Release|x64.ActiveCfg = Release|Any CPU
+		{89EE341C-85BF-4C44-95E0-A6236AAAF3BB}.Release|x64.Build.0 = Release|Any CPU
+		{89EE341C-85BF-4C44-95E0-A6236AAAF3BB}.Release|x86.ActiveCfg = Release|Any CPU
+		{89EE341C-85BF-4C44-95E0-A6236AAAF3BB}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -157,5 +171,6 @@ Global
 		{2F14FA1F-7220-4545-8DC5-4B37B52DF712} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{E3B00D56-B68B-48F9-A58A-5CCE046F779C} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{C99E8561-DB3E-44FC-81CA-EA1DDCCAC542} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
+		{89EE341C-85BF-4C44-95E0-A6236AAAF3BB} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 	EndGlobalSection
 EndGlobal

--- a/docs/Architecture/Distribution-Architecture.md
+++ b/docs/Architecture/Distribution-Architecture.md
@@ -1,0 +1,201 @@
+# Distribution Architecture
+
+ReadyStackGo unterstützt **downstream Distributionen**: separate Docker-Images mit eigenem Branding, Wizard-Flow und vorkonfigurierten Defaults — aufgebaut auf dem gleichen Core.
+
+## Übersicht
+
+```
+ReadyStackGo (GitHub, OSS)
+├── ReadyStackGo.Core           Meta-Package (Domain + Application + Infrastructure)
+├── ReadyStackGo.Api            Generischer ASP.NET Host
+└── @rsgo/core + @rsgo/ui-generic   Frontend (pnpm Monorepo)
+
+ReadyStackGo.Ams (Azure DevOps, privat)
+├── ReadyStackGo.WebHost.Ams    ASP.NET Host → referenziert ReadyStackGo.Core
+└── @rsgo/ui-ams                Eigenes Frontend-Package
+```
+
+## Extension Points
+
+### 1. ISetupWizardDefinitionProvider
+
+Definiert die Onboarding-Schritte nach dem Admin-Login (Phase 2). Der Wizard (Phase 1 — Admin-Erstellung mit 5-Minuten-Timeout) bleibt unverändert.
+
+```csharp
+// Interface in ReadyStackGo.Application.Services
+public interface ISetupWizardDefinitionProvider
+{
+    SetupWizardDefinition GetDefinition();
+}
+```
+
+**Generic-Implementierung** (`GenericSetupWizardDefinitionProvider`): 4 Schritte — Organization, Environment, Stack Sources, Registries.
+
+**Eigene Implementierung registrieren:**
+
+```csharp
+// In der Distribution's Program.cs — VOR AddApplication()
+builder.Services.AddSingleton<ISetupWizardDefinitionProvider, AmsSetupWizardDefinitionProvider>();
+builder.Services.AddApplication();   // TryAddSingleton wird übersprungen
+builder.Services.AddInfrastructure(config);
+```
+
+**API Endpunkt:** `GET /api/wizard/definition` — liefert die Step-Definitionen als JSON.
+
+### 2. IBootstrapper
+
+Distributionsspezifische Initialisierung beim Start. Muss idempotent sein (läuft bei jedem Start).
+
+```csharp
+public interface IBootstrapper
+{
+    Task BootstrapAsync(CancellationToken cancellationToken = default);
+}
+```
+
+**Generic-Implementierung** (`GenericBootstrapper`): No-Op.
+
+**Beispiel für eine ams-Distribution:**
+
+```csharp
+public sealed class AmsBootstrapper : IBootstrapper
+{
+    private readonly IStackSourceRepository _sources;
+    private readonly IRegistryRepository _registries;
+
+    public AmsBootstrapper(IStackSourceRepository sources, IRegistryRepository registries)
+    {
+        _sources = sources;
+        _registries = registries;
+    }
+
+    public async Task BootstrapAsync(CancellationToken ct)
+    {
+        // Seed ams-spezifische Stack Source (idempotent)
+        if (!await _sources.ExistsByNameAsync("ams-stacks", ct))
+        {
+            var source = StackSource.CreateGitRepository(
+                StackSourceId.NewId(), "ams-stacks", "https://github.com/amssolution/rsgo-stacks");
+            await _sources.AddAsync(source, ct);
+        }
+    }
+}
+```
+
+**Registrierung:** Wie bei `ISetupWizardDefinitionProvider` — vor `AddApplication()` registrieren.
+
+### 3. Multi-Assembly FastEndpoints
+
+FastEndpoints ist auf explizite Assembly-Discovery konfiguriert. Downstream-Distributionen fügen ihre Endpoint-Assemblies hinzu:
+
+```csharp
+builder.Services.AddFastEndpoints(o =>
+{
+    o.Assemblies = [
+        typeof(Program).Assembly,                    // Generische Endpoints
+        typeof(AmsSpecificEndpoint).Assembly          // Distribution-spezifische Endpoints
+    ];
+});
+```
+
+### 4. ReadyStackGo.Core Meta-Package
+
+Konvenienzbaustein für downstream Projekte — referenziert Domain, Application und Infrastructure in einem Projekt:
+
+```xml
+<!-- In der Distribution's .csproj -->
+<ItemGroup>
+  <ProjectReference Include="path/to/ReadyStackGo.Core.csproj" />
+</ItemGroup>
+```
+
+Später als NuGet-Package veröffentlichbar (`ReadyStackGo.Core`).
+
+## Eigene Distribution erstellen
+
+### 1. Projekt-Struktur
+
+```
+MyDistribution/
+  src/
+    MyDistribution.WebHost/
+      MyDistribution.WebHost.csproj   → referenziert ReadyStackGo.Core
+      Program.cs
+      MyBootstrapper.cs
+      MySetupWizardDefinitionProvider.cs
+      Endpoints/                      → Optionale eigene Endpoints
+    MyDistribution.Ui/                → Eigenes Frontend (optional)
+  Dockerfile
+```
+
+### 2. Program.cs
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+// 1. Eigene Extension Points registrieren (VOR AddApplication!)
+builder.Services.AddSingleton<ISetupWizardDefinitionProvider, MyWizardProvider>();
+builder.Services.AddScoped<IBootstrapper, MyBootstrapper>();
+
+// 2. Core Services registrieren
+builder.Services.AddApplication();
+builder.Services.AddInfrastructure(builder.Configuration);
+
+// 3. FastEndpoints mit eigenen Assemblies
+builder.Services.AddFastEndpoints(o =>
+{
+    o.Assemblies = [typeof(Program).Assembly];
+});
+
+// ... Rest wie in ReadyStackGo.Api/Program.cs
+```
+
+### 3. Dockerfile
+
+```dockerfile
+FROM mcr.microsoft.com/dotnet/aspnet:9.0
+WORKDIR /app
+COPY publish/ .
+ENTRYPOINT ["dotnet", "MyDistribution.WebHost.dll"]
+```
+
+## DI-Reihenfolge
+
+Die Reihenfolge der Service-Registrierung ist wichtig:
+
+1. **Distribution-spezifische Services** (eigene `ISetupWizardDefinitionProvider`, `IBootstrapper`)
+2. `AddApplication()` — registriert MediatR, Domain Events und **generische Defaults** via `TryAdd`
+3. `AddInfrastructure(config)` — registriert Infrastruktur-Services
+4. `AddFastEndpoints(...)` — mit expliziter Assembly-Liste
+
+`TryAdd` in `AddApplication()` garantiert: Wenn die Distribution ihre Implementierung zuerst registriert, wird die generische übersprungen.
+
+## Onboarding-Status API
+
+`GET /api/onboarding/status` enthält jetzt zusätzlich:
+
+```json
+{
+  "isComplete": true,
+  "isDismissed": false,
+  "organization": { "done": true, "count": 1, "name": "My Corp" },
+  "environment": { "done": true, "count": 2 },
+  "stackSources": { "done": true, "count": 3 },
+  "registries": { "done": false, "count": 0 },
+  "distributionId": "generic",
+  "steps": [
+    {
+      "id": "organization",
+      "title": "Set Up Organization",
+      "description": "Create your organization...",
+      "componentType": "OrganizationStep",
+      "required": true,
+      "order": 1,
+      "done": true,
+      "count": 1
+    }
+  ]
+}
+```
+
+Die fixen Properties (`organization`, `environment`, etc.) bleiben für Abwärtskompatibilität. Das neue `steps`-Array ist datengetrieben und stammt aus der `ISetupWizardDefinitionProvider`-Implementierung.

--- a/docs/Plans/PLAN-webui-headless-refactoring.md
+++ b/docs/Plans/PLAN-webui-headless-refactoring.md
@@ -211,6 +211,16 @@ Reihenfolge basierend auf Abhängigkeiten — von innen nach außen:
   - Build passes clean (tsc + vite)
   - Abhängig von: Feature 1-5
 
+- [x] **Feature 7: Backend Extension Points** — Interfaces und Patterns für downstream Distributionen
+  - `ISetupWizardDefinitionProvider` + `GenericSetupWizardDefinitionProvider` — datengetriebene Onboarding-Schritte
+  - `IBootstrapper` + `GenericBootstrapper` — distributionsspezifische Initialisierung beim Start
+  - `ReadyStackGo.Core` Meta-Package (Domain + Application + Infrastructure)
+  - Multi-Assembly FastEndpoints Discovery (explizite Assembly-Konfiguration)
+  - `GET /api/wizard/definition` Endpoint für Step-Definitionen
+  - Data-driven `steps` Array in `GET /api/onboarding/status` Response
+  - Distribution Architecture Dokumentation (`docs/Architecture/Distribution-Architecture.md`)
+  - Abhängig von: Feature 1-6
+
 - [ ] **Phase abschließen** — Alle Tests grün, PR gegen main
 
 ## Offene Punkte

--- a/src/ReadyStackGo.Api/Endpoints/Onboarding/GetOnboardingStatusEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Onboarding/GetOnboardingStatusEndpoint.cs
@@ -33,7 +33,19 @@ public class GetOnboardingStatusEndpoint : EndpointWithoutRequest<OnboardingStat
             Organization = MapItem(result.Organization),
             Environment = MapItem(result.Environment),
             StackSources = MapItem(result.StackSources),
-            Registries = MapItem(result.Registries)
+            Registries = MapItem(result.Registries),
+            DistributionId = result.DistributionId,
+            Steps = result.Steps?.Select(s => new OnboardingStepDto
+            {
+                Id = s.Id,
+                Title = s.Title,
+                Description = s.Description,
+                ComponentType = s.ComponentType,
+                Required = s.Required,
+                Order = s.Order,
+                Done = s.Done,
+                Count = s.Count
+            }).ToList()
         };
     }
 
@@ -53,6 +65,8 @@ public class OnboardingStatusResponse
     public required OnboardingItemDto Environment { get; set; }
     public required OnboardingItemDto StackSources { get; set; }
     public required OnboardingItemDto Registries { get; set; }
+    public string DistributionId { get; set; } = "generic";
+    public List<OnboardingStepDto>? Steps { get; set; }
 }
 
 public class OnboardingItemDto
@@ -60,4 +74,16 @@ public class OnboardingItemDto
     public bool Done { get; set; }
     public int Count { get; set; }
     public string? Name { get; set; }
+}
+
+public class OnboardingStepDto
+{
+    public required string Id { get; set; }
+    public required string Title { get; set; }
+    public required string Description { get; set; }
+    public required string ComponentType { get; set; }
+    public bool Required { get; set; }
+    public int Order { get; set; }
+    public bool Done { get; set; }
+    public int Count { get; set; }
 }

--- a/src/ReadyStackGo.Api/Endpoints/Wizard/GetWizardDefinitionEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Wizard/GetWizardDefinitionEndpoint.cs
@@ -1,0 +1,63 @@
+using FastEndpoints;
+using ReadyStackGo.Application.Services;
+
+namespace ReadyStackGo.API.Endpoints.Wizard;
+
+/// <summary>
+/// GET /api/wizard/definition - Get the setup wizard step definitions for the current distribution
+/// </summary>
+public class GetWizardDefinitionEndpoint : EndpointWithoutRequest<WizardDefinitionResponse>
+{
+    private readonly ISetupWizardDefinitionProvider _provider;
+
+    public GetWizardDefinitionEndpoint(ISetupWizardDefinitionProvider provider)
+    {
+        _provider = provider;
+    }
+
+    public override void Configure()
+    {
+        Get("/api/wizard/definition");
+        Description(b => b.WithTags("Wizard"));
+    }
+
+    public override Task HandleAsync(CancellationToken ct)
+    {
+        var definition = _provider.GetDefinition();
+
+        Response = new WizardDefinitionResponse
+        {
+            DistributionId = definition.Id,
+            Steps = definition.Steps
+                .OrderBy(s => s.Order)
+                .Select(s => new WizardStepDto
+                {
+                    Id = s.Id,
+                    Title = s.Title,
+                    Description = s.Description,
+                    ComponentType = s.ComponentType,
+                    Required = s.Required,
+                    Order = s.Order
+                })
+                .ToList()
+        };
+
+        return Task.CompletedTask;
+    }
+}
+
+public class WizardDefinitionResponse
+{
+    public required string DistributionId { get; set; }
+    public required List<WizardStepDto> Steps { get; set; }
+}
+
+public class WizardStepDto
+{
+    public required string Id { get; set; }
+    public required string Title { get; set; }
+    public required string Description { get; set; }
+    public required string ComponentType { get; set; }
+    public bool Required { get; set; }
+    public int Order { get; set; }
+}

--- a/src/ReadyStackGo.Api/Program.cs
+++ b/src/ReadyStackGo.Api/Program.cs
@@ -26,7 +26,12 @@ public class Program
         // Add services to the container
         builder.Services.AddApplication();
         builder.Services.AddInfrastructure(builder.Configuration);
-        builder.Services.AddFastEndpoints();
+        builder.Services.AddFastEndpoints(o =>
+        {
+            // Explicit assembly specification for multi-assembly endpoint discovery.
+            // Downstream distributions add their own endpoint assemblies here.
+            o.Assemblies = [typeof(Program).Assembly];
+        });
 
         // Add Authentication with multi-scheme support (JWT + API Key)
         var jwtSettings = builder.Configuration.GetSection("Jwt");
@@ -138,6 +143,9 @@ public class Program
         // Initialize SQLite database
         app.Services.EnsureDatabaseCreated();
 
+        // Run distribution-specific bootstrap (idempotent, safe on every startup)
+        await RunBootstrapperAsync(app);
+
         // Bootstrap: Generate TLS certificate if not exists
         await BootstrapTlsCertificateAsync(app);
 
@@ -232,6 +240,28 @@ public class Program
         });
 
         await app.RunAsync();
+    }
+
+    /// <summary>
+    /// Run the distribution bootstrapper to seed default data on startup.
+    /// Operations must be idempotent (safe to run on every startup).
+    /// </summary>
+    private static async Task RunBootstrapperAsync(WebApplication app)
+    {
+        using var scope = app.Services.CreateScope();
+        var bootstrapper = scope.ServiceProvider.GetRequiredService<ReadyStackGo.Application.Services.IBootstrapper>();
+        var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+
+        try
+        {
+            logger.LogInformation("Running distribution bootstrapper: {Type}", bootstrapper.GetType().Name);
+            await bootstrapper.BootstrapAsync();
+            logger.LogInformation("Distribution bootstrapper completed successfully");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Distribution bootstrapper failed. The application will continue.");
+        }
     }
 
     /// <summary>

--- a/src/ReadyStackGo.Api/ReadyStackGo.Api.csproj
+++ b/src/ReadyStackGo.Api/ReadyStackGo.Api.csproj
@@ -14,8 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ReadyStackGo.Application\ReadyStackGo.Application.csproj" />
-    <ProjectReference Include="..\ReadyStackGo.Infrastructure\ReadyStackGo.Infrastructure.csproj" />
+    <ProjectReference Include="..\ReadyStackGo.Core\ReadyStackGo.Core.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ReadyStackGo.Application/DependencyInjection.cs
+++ b/src/ReadyStackGo.Application/DependencyInjection.cs
@@ -1,7 +1,9 @@
 namespace ReadyStackGo.Application;
 
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using ReadyStackGo.Application.Services;
+using ReadyStackGo.Application.Services.Impl;
 
 public static class DependencyInjection
 {
@@ -12,6 +14,10 @@ public static class DependencyInjection
 
         // Domain event dispatch through MediatR
         services.AddScoped<IDomainEventDispatcher, MediatRDomainEventDispatcher>();
+
+        // Distribution extension points (TryAdd: downstream distributions can register their own before calling AddApplication)
+        services.TryAddSingleton<ISetupWizardDefinitionProvider, GenericSetupWizardDefinitionProvider>();
+        services.TryAddScoped<IBootstrapper, GenericBootstrapper>();
 
         return services;
     }

--- a/src/ReadyStackGo.Application/Services/IBootstrapper.cs
+++ b/src/ReadyStackGo.Application/Services/IBootstrapper.cs
@@ -1,0 +1,14 @@
+namespace ReadyStackGo.Application.Services;
+
+/// <summary>
+/// Distribution-specific initialization logic that runs on application startup.
+/// All operations must be idempotent (safe to run on every startup).
+/// </summary>
+public interface IBootstrapper
+{
+    /// <summary>
+    /// Execute bootstrap operations (seed data, create defaults, etc.).
+    /// Called during application startup after database creation.
+    /// </summary>
+    Task BootstrapAsync(CancellationToken cancellationToken = default);
+}

--- a/src/ReadyStackGo.Application/Services/ISetupWizardDefinitionProvider.cs
+++ b/src/ReadyStackGo.Application/Services/ISetupWizardDefinitionProvider.cs
@@ -1,0 +1,63 @@
+namespace ReadyStackGo.Application.Services;
+
+/// <summary>
+/// Provides the setup wizard (onboarding) step definitions for the current distribution.
+/// Distributions implement this to customize which onboarding steps appear after admin login.
+/// The admin-creation wizard (Phase 1) remains unchanged — this controls Phase 2 (post-login onboarding).
+/// </summary>
+public interface ISetupWizardDefinitionProvider
+{
+    SetupWizardDefinition GetDefinition();
+}
+
+/// <summary>
+/// Defines the onboarding wizard for a specific distribution.
+/// </summary>
+public sealed class SetupWizardDefinition
+{
+    /// <summary>
+    /// Distribution identifier, e.g. "generic", "ams-project".
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Ordered list of onboarding steps for this distribution.
+    /// </summary>
+    public required IReadOnlyList<WizardStepDefinition> Steps { get; init; }
+}
+
+/// <summary>
+/// Defines a single step in the onboarding wizard.
+/// </summary>
+public sealed class WizardStepDefinition
+{
+    /// <summary>
+    /// Unique step identifier, e.g. "organization", "environment", "stack-sources", "registries".
+    /// </summary>
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Display title for the step.
+    /// </summary>
+    public required string Title { get; init; }
+
+    /// <summary>
+    /// Display description for the step.
+    /// </summary>
+    public required string Description { get; init; }
+
+    /// <summary>
+    /// UI component type that renders this step, e.g. "OrganizationStep", "RegistryTokenStep".
+    /// </summary>
+    public required string ComponentType { get; init; }
+
+    /// <summary>
+    /// Whether this step is required before onboarding can be dismissed.
+    /// </summary>
+    public bool Required { get; init; }
+
+    /// <summary>
+    /// Display order (lower = first).
+    /// </summary>
+    public int Order { get; init; }
+}

--- a/src/ReadyStackGo.Application/Services/Impl/GenericBootstrapper.cs
+++ b/src/ReadyStackGo.Application/Services/Impl/GenericBootstrapper.cs
@@ -1,0 +1,12 @@
+namespace ReadyStackGo.Application.Services.Impl;
+
+/// <summary>
+/// Default bootstrapper for the generic RSGO distribution.
+/// No-op: the generic distribution requires no pre-seeded data.
+/// All configuration is done through the wizard/onboarding flow.
+/// </summary>
+public sealed class GenericBootstrapper : IBootstrapper
+{
+    public Task BootstrapAsync(CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+}

--- a/src/ReadyStackGo.Application/Services/Impl/GenericSetupWizardDefinitionProvider.cs
+++ b/src/ReadyStackGo.Application/Services/Impl/GenericSetupWizardDefinitionProvider.cs
@@ -1,0 +1,52 @@
+namespace ReadyStackGo.Application.Services.Impl;
+
+/// <summary>
+/// Default wizard definition for the generic RSGO distribution.
+/// Mirrors the 4 existing hardcoded onboarding steps.
+/// </summary>
+public sealed class GenericSetupWizardDefinitionProvider : ISetupWizardDefinitionProvider
+{
+    public SetupWizardDefinition GetDefinition() => new()
+    {
+        Id = "generic",
+        Steps =
+        [
+            new()
+            {
+                Id = "organization",
+                Title = "Set Up Organization",
+                Description = "Create your organization to manage environments and deployments.",
+                ComponentType = "OrganizationStep",
+                Required = true,
+                Order = 1
+            },
+            new()
+            {
+                Id = "environment",
+                Title = "Configure Environment",
+                Description = "Set up a Docker environment for deployments.",
+                ComponentType = "EnvironmentStep",
+                Required = false,
+                Order = 2
+            },
+            new()
+            {
+                Id = "stack-sources",
+                Title = "Add Stack Sources",
+                Description = "Add stack sources to browse and deploy stacks.",
+                ComponentType = "StackSourcesStep",
+                Required = false,
+                Order = 3
+            },
+            new()
+            {
+                Id = "registries",
+                Title = "Container Registries",
+                Description = "Configure container registry credentials for image pulls.",
+                ComponentType = "RegistriesStep",
+                Required = false,
+                Order = 4
+            }
+        ]
+    };
+}

--- a/src/ReadyStackGo.Application/UseCases/Onboarding/GetOnboardingStatus/GetOnboardingStatusHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Onboarding/GetOnboardingStatus/GetOnboardingStatusHandler.cs
@@ -15,19 +15,22 @@ public class GetOnboardingStatusHandler : IRequestHandler<GetOnboardingStatusQue
     private readonly IStackSourceRepository _stackSourceRepository;
     private readonly IRegistryRepository _registryRepository;
     private readonly IOnboardingStateService _onboardingStateService;
+    private readonly ISetupWizardDefinitionProvider _wizardDefinitionProvider;
 
     public GetOnboardingStatusHandler(
         IOrganizationRepository organizationRepository,
         IEnvironmentRepository environmentRepository,
         IStackSourceRepository stackSourceRepository,
         IRegistryRepository registryRepository,
-        IOnboardingStateService onboardingStateService)
+        IOnboardingStateService onboardingStateService,
+        ISetupWizardDefinitionProvider wizardDefinitionProvider)
     {
         _organizationRepository = organizationRepository;
         _environmentRepository = environmentRepository;
         _stackSourceRepository = stackSourceRepository;
         _registryRepository = registryRepository;
         _onboardingStateService = onboardingStateService;
+        _wizardDefinitionProvider = wizardDefinitionProvider;
     }
 
     public async Task<OnboardingStatusResult> Handle(GetOnboardingStatusQuery request, CancellationToken cancellationToken)
@@ -52,12 +55,35 @@ public class GetOnboardingStatusHandler : IRequestHandler<GetOnboardingStatusQue
 
         var isDismissed = await _onboardingStateService.IsDismissedAsync(cancellationToken);
 
+        // Build data-driven steps from wizard definition provider
+        var definition = _wizardDefinitionProvider.GetDefinition();
+        var stepStatusLookup = new Dictionary<string, (bool Done, int Count)>
+        {
+            ["organization"] = (hasOrg, hasOrg ? 1 : 0),
+            ["environment"] = (envCount > 0, envCount),
+            ["stack-sources"] = (sourceCount > 0, sourceCount),
+            ["registries"] = (registryCount > 0, registryCount)
+        };
+
+        var steps = definition.Steps
+            .OrderBy(s => s.Order)
+            .Select(s =>
+            {
+                var (done, count) = stepStatusLookup.GetValueOrDefault(s.Id);
+                return new OnboardingStepStatus(
+                    s.Id, s.Title, s.Description, s.ComponentType,
+                    s.Required, s.Order, done, count);
+            })
+            .ToList();
+
         return new OnboardingStatusResult(
             IsComplete: hasOrg,
             IsDismissed: isDismissed,
             Organization: new OnboardingItemStatus(hasOrg, hasOrg ? 1 : 0, organization?.Name),
             Environment: new OnboardingItemStatus(envCount > 0, envCount),
             StackSources: new OnboardingItemStatus(sourceCount > 0, sourceCount),
-            Registries: new OnboardingItemStatus(registryCount > 0, registryCount));
+            Registries: new OnboardingItemStatus(registryCount > 0, registryCount),
+            DistributionId: definition.Id,
+            Steps: steps);
     }
 }

--- a/src/ReadyStackGo.Application/UseCases/Onboarding/GetOnboardingStatus/GetOnboardingStatusQuery.cs
+++ b/src/ReadyStackGo.Application/UseCases/Onboarding/GetOnboardingStatus/GetOnboardingStatusQuery.cs
@@ -6,10 +6,25 @@ public record GetOnboardingStatusQuery : IRequest<OnboardingStatusResult>;
 
 public record OnboardingItemStatus(bool Done, int Count, string? Name = null);
 
+/// <summary>
+/// A single step from the wizard definition provider, enriched with completion status.
+/// </summary>
+public record OnboardingStepStatus(
+    string Id,
+    string Title,
+    string Description,
+    string ComponentType,
+    bool Required,
+    int Order,
+    bool Done,
+    int Count);
+
 public record OnboardingStatusResult(
     bool IsComplete,
     bool IsDismissed,
     OnboardingItemStatus Organization,
     OnboardingItemStatus Environment,
     OnboardingItemStatus StackSources,
-    OnboardingItemStatus Registries);
+    OnboardingItemStatus Registries,
+    string DistributionId = "generic",
+    IReadOnlyList<OnboardingStepStatus>? Steps = null);

--- a/src/ReadyStackGo.Core/ReadyStackGo.Core.csproj
+++ b/src/ReadyStackGo.Core/ReadyStackGo.Core.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <Description>ReadyStackGo Core - Domain, Application, and Infrastructure meta-package for downstream distributions</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ReadyStackGo.Domain\ReadyStackGo.Domain.csproj" />
+    <ProjectReference Include="..\ReadyStackGo.Application\ReadyStackGo.Application.csproj" />
+    <ProjectReference Include="..\ReadyStackGo.Infrastructure\ReadyStackGo.Infrastructure.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ReadyStackGo.WebUi/packages/core/src/api/onboarding.ts
+++ b/src/ReadyStackGo.WebUi/packages/core/src/api/onboarding.ts
@@ -6,6 +6,17 @@ export interface OnboardingItemDto {
   name?: string;
 }
 
+export interface OnboardingStepDto {
+  id: string;
+  title: string;
+  description: string;
+  componentType: string;
+  required: boolean;
+  order: number;
+  done: boolean;
+  count: number;
+}
+
 export interface OnboardingStatusResponse {
   isComplete: boolean;
   isDismissed: boolean;
@@ -13,6 +24,8 @@ export interface OnboardingStatusResponse {
   environment: OnboardingItemDto;
   stackSources: OnboardingItemDto;
   registries: OnboardingItemDto;
+  distributionId: string;
+  steps?: OnboardingStepDto[];
 }
 
 export async function getOnboardingStatus(): Promise<OnboardingStatusResponse> {

--- a/src/ReadyStackGo.WebUi/packages/core/src/api/wizard.ts
+++ b/src/ReadyStackGo.WebUi/packages/core/src/api/wizard.ts
@@ -166,7 +166,26 @@ export interface InstallStackResponse {
   errors: string[];
 }
 
+// Wizard definition (distribution extension point)
+export interface WizardStepDefinition {
+  id: string;
+  title: string;
+  description: string;
+  componentType: string;
+  required: boolean;
+  order: number;
+}
+
+export interface WizardDefinitionResponse {
+  distributionId: string;
+  steps: WizardStepDefinition[];
+}
+
 // API functions
+export async function getWizardDefinition(): Promise<WizardDefinitionResponse> {
+  return apiGet<WizardDefinitionResponse>('/api/wizard/definition');
+}
+
 export async function getWizardStatus(): Promise<WizardStatusResponse> {
   return apiGet<WizardStatusResponse>('/api/wizard/status');
 }

--- a/tests/ReadyStackGo.UnitTests/Application/Onboarding/GetOnboardingStatusHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Onboarding/GetOnboardingStatusHandlerTests.cs
@@ -18,6 +18,7 @@ public class GetOnboardingStatusHandlerTests
     private readonly Mock<IStackSourceRepository> _sourceRepoMock = new();
     private readonly Mock<IRegistryRepository> _registryRepoMock = new();
     private readonly Mock<IOnboardingStateService> _onboardingStateMock = new();
+    private readonly ISetupWizardDefinitionProvider _wizardDefinitionProvider = new ReadyStackGo.Application.Services.Impl.GenericSetupWizardDefinitionProvider();
 
     public GetOnboardingStatusHandlerTests()
     {
@@ -34,7 +35,8 @@ public class GetOnboardingStatusHandlerTests
         _envRepoMock.Object,
         _sourceRepoMock.Object,
         _registryRepoMock.Object,
-        _onboardingStateMock.Object);
+        _onboardingStateMock.Object,
+        _wizardDefinitionProvider);
 
     private Organization SetupOrganization(string name = "Test Org")
     {


### PR DESCRIPTION
## Summary

- **ISetupWizardDefinitionProvider** + **GenericSetupWizardDefinitionProvider** — data-driven onboarding steps, distributions override via TryAdd pattern
- **IBootstrapper** + **GenericBootstrapper** — idempotent distribution-specific startup initialization (seed data, defaults)
- **ReadyStackGo.Core** meta-package — convenience project referencing Domain + Application + Infrastructure for downstream distributions
- **Multi-assembly FastEndpoints** — explicit assembly configuration for endpoint discovery across distribution assemblies
- **GET /api/wizard/definition** — new endpoint returning step definitions from the active distribution
- **Data-driven onboarding status** — `steps` array + `distributionId` added to `GET /api/onboarding/status` (backward-compatible, existing fixed properties preserved)
- **Distribution Architecture documentation** — `docs/Architecture/Distribution-Architecture.md`

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test tests/ReadyStackGo.UnitTests/` — all 2551 tests pass (including 21 onboarding tests)
- [x] `pnpm build` — frontend builds clean
- [ ] `docker compose build && docker compose up -d` — container starts on http://localhost:8080
- [ ] Manual: verify `GET /api/wizard/definition` returns 4 steps
- [ ] Manual: verify `GET /api/onboarding/status` includes `steps` array and `distributionId`