### PR TITLE
Add maintenance observer documentation to manifest schema

### DIFF
--- a/docs/specs/rsgo-distributions/RSGO-DISTRIBUTION-SETUP.md
+++ b/docs/specs/rsgo-distributions/RSGO-DISTRIBUTION-SETUP.md
@@ -342,6 +342,52 @@ Der Core kennt:
 
 ---
 
+## 5.2 Maintenance Observer für ams.project
+
+Die ams.project Stack-Manifeste sollen den **SQL Extended Property Observer** konfigurieren, damit ReadyStackGo den Maintenance-Modus der ams.erp-Datenbank automatisch erkennt.
+
+**Zu überwachende Extended Property:** `ams-MaintenanceMode`
+
+Im Product-Manifest (`rsgo.yaml`) des ams.project Products wird die `maintenance`-Sektion auf Product-Ebene definiert — sie gilt dann für alle Stacks des Products:
+
+```yaml
+metadata:
+  name: ams.project
+  productVersion: "1.0.0"
+
+maintenance:
+  observer:
+    type: sqlExtendedProperty
+    connectionName: AMS_ERP_DB         # Referenz auf die Variable mit der Verbindungszeichenfolge
+    propertyName: ams-MaintenanceMode
+    maintenanceValue: "1"
+    normalValue: "0"
+    pollingInterval: 30s
+
+sharedVariables:
+  AMS_ERP_DB:
+    label: ams.erp Datenbank
+    type: SqlServerConnectionString
+    required: true
+    group: Database
+
+stacks:
+  identityaccess:
+    include: IdentityAccess/identityaccess.yaml
+  business-services:
+    include: BusinessServices/business-services.yaml
+  # ...
+```
+
+**Wichtig:**
+
+- Die `maintenance`-Sektion steht im **Product-Manifest** (nicht in Fragment-Manifesten der einzelnen Stacks).
+- `connectionName: AMS_ERP_DB` referenziert die Manifest-Variable — der tatsächliche Connection String wird beim Deployment vom Benutzer eingegeben.
+- ReadyStackGo prüft alle 30 Sekunden die Extended Property `ams-MaintenanceMode` in der ams.erp-Datenbank.
+- Wert `"1"` → Maintenance-Modus aktiv, Wert `"0"` → Normalbetrieb.
+
+---
+
 ## 6. Docker-Images & Deployments
 
 ### 6.1 Generic Image (GitHub)

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/de/reference/manifest-format.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/de/reference/manifest-format.md
@@ -30,6 +30,11 @@ stacks:                           # Stack-Definitionen (nur Multi-Stack)
 services:                         # Service-Definitionen (Single-Stack oder Fragment)
   app: ...
 
+maintenance:                      # Maintenance Observer (optional)
+  observer:
+    type: sqlExtendedProperty
+    ...
+
 volumes:                          # Volume-Definitionen
   data: {}
 
@@ -348,6 +353,105 @@ networks:
   # Externes Netzwerk (existiert bereits)
   proxy:
     external: true
+```
+
+---
+
+## Maintenance
+
+Die optionale `maintenance`-Sektion konfiguriert die automatische Maintenance-Mode-Erkennung. ReadyStackGo prüft periodisch ein externes System und schaltet das Product in den Maintenance-Modus, wenn die konfigurierte Bedingung erfüllt ist.
+
+### Observer-Konfiguration
+
+| Property | Typ | Pflicht | Beschreibung |
+|----------|-----|---------|--------------|
+| `type` | string | **Ja** | Observer-Typ: `sqlExtendedProperty`, `sqlQuery`, `http` oder `file` |
+| `maintenanceValue` | string | **Ja** | Wert, der den aktiven Maintenance-Modus anzeigt |
+| `normalValue` | string | Nein | Wert für Normalbetrieb. Wenn nicht gesetzt, wird jeder Wert außer `maintenanceValue` als normal behandelt |
+| `pollingInterval` | string | Nein | Prüf-Intervall (Standard: `30s`). Unterstützt `s`, `m`, `h` Suffixe |
+
+#### SQL Extended Property (`sqlExtendedProperty`)
+
+Liest eine SQL Server Extended Property auf Datenbankebene.
+
+| Property | Typ | Pflicht | Beschreibung |
+|----------|-----|---------|--------------|
+| `connectionString` | string | **Ja*** | Direkte Verbindungszeichenfolge (unterstützt `${VAR}` Substitution) |
+| `connectionName` | string | **Ja*** | Name einer Manifest-Variable mit der Verbindungszeichenfolge |
+| `propertyName` | string | **Ja** | Name der zu lesenden Extended Property |
+
+*Entweder `connectionString` oder `connectionName` ist erforderlich.
+
+```yaml
+maintenance:
+  observer:
+    type: sqlExtendedProperty
+    connectionName: BACKEND_DB
+    propertyName: ams-MaintenanceMode
+    maintenanceValue: "1"
+    normalValue: "0"
+    pollingInterval: 30s
+```
+
+#### SQL Query (`sqlQuery`)
+
+Führt eine benutzerdefinierte SQL-Abfrage aus, die einen einzelnen Skalarwert zurückgibt.
+
+| Property | Typ | Pflicht | Beschreibung |
+|----------|-----|---------|--------------|
+| `connectionString` | string | **Ja*** | Direkte Verbindungszeichenfolge |
+| `connectionName` | string | **Ja*** | Variablenname mit Verbindungszeichenfolge |
+| `query` | string | **Ja** | SQL-Abfrage, die einen Skalarwert zurückgibt |
+
+```yaml
+maintenance:
+  observer:
+    type: sqlQuery
+    connectionString: ${DB_CONNECTION}
+    query: "SELECT Value FROM dbo.Config WHERE [Key] = 'MaintenanceMode'"
+    maintenanceValue: "true"
+    pollingInterval: 1m
+```
+
+#### HTTP (`http`)
+
+Ruft einen HTTP-Endpoint auf und wertet die Antwort aus.
+
+| Property | Typ | Pflicht | Beschreibung |
+|----------|-----|---------|--------------|
+| `url` | string | **Ja** | Aufzurufende URL |
+| `method` | string | Nein | HTTP-Methode (Standard: `GET`) |
+| `timeout` | string | Nein | Request-Timeout (Standard: `10s`) |
+| `jsonPath` | string | Nein | JSONPath-Ausdruck zum Extrahieren des Werts aus dem Response Body |
+
+```yaml
+maintenance:
+  observer:
+    type: http
+    url: https://api.example.com/status
+    jsonPath: $.maintenanceMode
+    maintenanceValue: "true"
+    pollingInterval: 1m
+```
+
+#### File (`file`)
+
+Überwacht eine Datei auf Existenz oder Inhalt.
+
+| Property | Typ | Pflicht | Beschreibung |
+|----------|-----|---------|--------------|
+| `path` | string | **Ja** | Pfad zur Datei |
+| `mode` | string | Nein | `exists` (Standard) oder `content` |
+| `contentPattern` | string | Nein | Regex zum Extrahieren des Werts aus dem Dateiinhalt (erste Capture Group) |
+
+```yaml
+maintenance:
+  observer:
+    type: file
+    path: /var/maintenance.flag
+    mode: exists
+    maintenanceValue: "true"
+    normalValue: "false"
 ```
 
 ---

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/en/reference/manifest-format.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/en/reference/manifest-format.md
@@ -30,6 +30,11 @@ stacks:                           # Stack definitions (Multi-Stack only)
 services:                         # Service definitions (Single-Stack or Fragment)
   app: ...
 
+maintenance:                      # Maintenance observer (optional)
+  observer:
+    type: sqlExtendedProperty
+    ...
+
 volumes:                          # Volume definitions
   data: {}
 
@@ -407,6 +412,105 @@ networks:
   # External network (already exists)
   proxy:
     external: true
+```
+
+---
+
+## Maintenance
+
+The optional `maintenance` section configures automatic maintenance mode detection. ReadyStackGo periodically checks an external system and switches the product to maintenance mode when the configured condition is met.
+
+### Observer Configuration
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `type` | string | **Yes** | Observer type: `sqlExtendedProperty`, `sqlQuery`, `http`, or `file` |
+| `maintenanceValue` | string | **Yes** | Value that indicates maintenance mode is active |
+| `normalValue` | string | No | Value that indicates normal operation. If not set, any value other than `maintenanceValue` is treated as normal |
+| `pollingInterval` | string | No | Check frequency (default: `30s`). Supports `s`, `m`, `h` suffixes |
+
+#### SQL Extended Property (`sqlExtendedProperty`)
+
+Reads a SQL Server extended property at the database level.
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `connectionString` | string | **Yes*** | Direct connection string (supports `${VAR}` substitution) |
+| `connectionName` | string | **Yes*** | Name of a manifest variable containing the connection string |
+| `propertyName` | string | **Yes** | Name of the extended property to read |
+
+*Either `connectionString` or `connectionName` is required.
+
+```yaml
+maintenance:
+  observer:
+    type: sqlExtendedProperty
+    connectionName: BACKEND_DB
+    propertyName: ams-MaintenanceMode
+    maintenanceValue: "1"
+    normalValue: "0"
+    pollingInterval: 30s
+```
+
+#### SQL Query (`sqlQuery`)
+
+Executes a custom SQL query that returns a single scalar value.
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `connectionString` | string | **Yes*** | Direct connection string |
+| `connectionName` | string | **Yes*** | Variable name with connection string |
+| `query` | string | **Yes** | SQL query returning a scalar value |
+
+```yaml
+maintenance:
+  observer:
+    type: sqlQuery
+    connectionString: ${DB_CONNECTION}
+    query: "SELECT Value FROM dbo.Config WHERE [Key] = 'MaintenanceMode'"
+    maintenanceValue: "true"
+    pollingInterval: 1m
+```
+
+#### HTTP (`http`)
+
+Calls an HTTP endpoint and evaluates the response.
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `url` | string | **Yes** | URL to call |
+| `method` | string | No | HTTP method (default: `GET`) |
+| `timeout` | string | No | Request timeout (default: `10s`) |
+| `jsonPath` | string | No | JSONPath expression to extract the value from the response body |
+
+```yaml
+maintenance:
+  observer:
+    type: http
+    url: https://api.example.com/status
+    jsonPath: $.maintenanceMode
+    maintenanceValue: "true"
+    pollingInterval: 1m
+```
+
+#### File (`file`)
+
+Monitors a file for existence or content.
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `path` | string | **Yes** | Path to the file |
+| `mode` | string | No | `exists` (default) or `content` |
+| `contentPattern` | string | No | Regex to extract value from file content (first capture group) |
+
+```yaml
+maintenance:
+  observer:
+    type: file
+    path: /var/maintenance.flag
+    mode: exists
+    maintenanceValue: "true"
+    normalValue: "false"
 ```
 
 ---


### PR DESCRIPTION
## Summary
- Add `maintenance` section documentation to RSGo Manifest Schema (EN + DE) covering all four observer types: `sqlExtendedProperty`, `sqlQuery`, `http`, `file`
- Add maintenance observer configuration guidance for ams.project to distribution setup spec (section 5.2)
- Document `ams-MaintenanceMode` extended property as primary example

## Test plan
- [ ] Verify manifest-format.md (EN) renders correctly on public website
- [ ] Verify manifest-format.md (DE) renders correctly on public website
- [ ] Verify RSGO-DISTRIBUTION-SETUP.md YAML examples match actual code (RsgoMaintenanceObserver properties)