### PR TITLE
Fix health dashboard slow load caused by inefficient snapshot query

### DIFF
--- a/src/ReadyStackGo.Api/BackgroundServices/HealthCollectorBackgroundService.cs
+++ b/src/ReadyStackGo.Api/BackgroundServices/HealthCollectorBackgroundService.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Options;
 using ReadyStackGo.Application.Services;
+using ReadyStackGo.Domain.Deployment.Health;
 
 namespace ReadyStackGo.Api.BackgroundServices;
 
@@ -11,6 +12,7 @@ public class HealthCollectorBackgroundService : BackgroundService
     private readonly IServiceProvider _serviceProvider;
     private readonly ILogger<HealthCollectorBackgroundService> _logger;
     private readonly HealthCollectorOptions _options;
+    private DateTime _lastCleanup = DateTime.MinValue;
 
     public HealthCollectorBackgroundService(
         IServiceProvider serviceProvider,
@@ -25,8 +27,8 @@ public class HealthCollectorBackgroundService : BackgroundService
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         _logger.LogInformation(
-            "Health Collector Background Service starting. Interval: {Interval}s",
-            _options.CollectionIntervalSeconds);
+            "Health Collector Background Service starting. Interval: {Interval}s, Retention: {Retention} days",
+            _options.CollectionIntervalSeconds, _options.RetentionDays);
 
         // Initial delay to let the application start up
         await Task.Delay(TimeSpan.FromSeconds(_options.InitialDelaySeconds), stoppingToken);
@@ -36,6 +38,7 @@ public class HealthCollectorBackgroundService : BackgroundService
             try
             {
                 await CollectHealthAsync(stoppingToken);
+                CleanupOldSnapshots();
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
@@ -74,6 +77,33 @@ public class HealthCollectorBackgroundService : BackgroundService
 
         _logger.LogDebug("Health collection cycle completed");
     }
+
+    private void CleanupOldSnapshots()
+    {
+        // Run cleanup once per hour
+        if (DateTime.UtcNow - _lastCleanup < TimeSpan.FromHours(1))
+            return;
+
+        _lastCleanup = DateTime.UtcNow;
+
+        try
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var repository = scope.ServiceProvider.GetRequiredService<IHealthSnapshotRepository>();
+
+            var deleted = repository.RemoveOlderThan(TimeSpan.FromDays(_options.RetentionDays));
+            if (deleted > 0)
+            {
+                _logger.LogInformation(
+                    "Cleaned up {Count} health snapshots older than {Days} days",
+                    deleted, _options.RetentionDays);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to cleanup old health snapshots");
+        }
+    }
 }
 
 /// <summary>
@@ -101,4 +131,11 @@ public class HealthCollectorOptions
     /// Default: true.
     /// </summary>
     public bool Enabled { get; set; } = true;
+
+    /// <summary>
+    /// Number of days to retain health snapshots.
+    /// Snapshots older than this are automatically deleted.
+    /// Default: 30 days.
+    /// </summary>
+    public int RetentionDays { get; set; } = 30;
 }

--- a/src/ReadyStackGo.Domain/Deployment/Health/IHealthSnapshotRepository.cs
+++ b/src/ReadyStackGo.Domain/Deployment/Health/IHealthSnapshotRepository.cs
@@ -40,8 +40,9 @@ public interface IHealthSnapshotRepository
 
     /// <summary>
     /// Removes old snapshots older than the specified age.
+    /// Returns the number of deleted rows.
     /// </summary>
-    void RemoveOlderThan(TimeSpan age);
+    int RemoveOlderThan(TimeSpan age);
 
     /// <summary>
     /// Saves changes to the repository.

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Repositories/HealthSnapshotRepository.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Repositories/HealthSnapshotRepository.cs
@@ -43,15 +43,26 @@ public class HealthSnapshotRepository : IHealthSnapshotRepository
 
     public IEnumerable<HealthSnapshot> GetLatestForEnvironment(EnvironmentId environmentId)
     {
-        // Get the latest snapshot for each deployment in the environment
-        // Using a subquery to get the max CapturedAtUtc per deployment
-        var latestSnapshots = _context.HealthSnapshots
-            .Where(h => h.EnvironmentId == environmentId)
-            .GroupBy(h => h.DeploymentId)
-            .Select(g => g.OrderByDescending(h => h.CapturedAtUtc).First())
-            .ToList();
+        // Use raw SQL to efficiently get the latest snapshot per deployment.
+        // The EF GroupBy+First pattern causes client-side evaluation, loading ALL rows.
+        var envId = environmentId.Value.ToString().ToUpperInvariant();
 
-        return latestSnapshots;
+        return _context.HealthSnapshots
+            .FromSqlRaw(
+                """
+                SELECT h.*
+                FROM "HealthSnapshots" h
+                INNER JOIN (
+                    SELECT "DeploymentId", MAX("CapturedAtUtc") AS "MaxDate"
+                    FROM "HealthSnapshots"
+                    WHERE UPPER("EnvironmentId") = {0}
+                    GROUP BY "DeploymentId"
+                ) latest ON h."DeploymentId" = latest."DeploymentId"
+                    AND h."CapturedAtUtc" = latest."MaxDate"
+                WHERE UPPER(h."EnvironmentId") = {0}
+                """,
+                envId)
+            .ToList();
     }
 
     public IEnumerable<HealthSnapshot> GetHistory(DeploymentId deploymentId, int limit = 10)
@@ -63,14 +74,16 @@ public class HealthSnapshotRepository : IHealthSnapshotRepository
             .ToList();
     }
 
-    public void RemoveOlderThan(TimeSpan age)
+    public int RemoveOlderThan(TimeSpan age)
     {
         var cutoff = DateTime.UtcNow - age;
-        var oldSnapshots = _context.HealthSnapshots
-            .Where(h => h.CapturedAtUtc < cutoff)
-            .ToList();
 
-        _context.HealthSnapshots.RemoveRange(oldSnapshots);
+        // Use ExecuteSql to delete directly in the database without loading entities.
+        // EF Core's interpolated SQL handles DateTime parameter formatting for SQLite.
+        return _context.Database.ExecuteSql(
+            $"""
+            DELETE FROM "HealthSnapshots" WHERE "CapturedAtUtc" < {cutoff}
+            """);
     }
 
     public void SaveChanges()


### PR DESCRIPTION
## Summary

- **Root cause**: `GetLatestForEnvironment` used EF Core `GroupBy` + `OrderByDescending` + `First()` which SQLite cannot translate to SQL — EF evaluates it client-side, loading all 500k+ rows into memory
- **Fix**: Replace with raw SQL using `INNER JOIN` on `MAX(CapturedAtUtc)` per deployment, returning only the ~15 needed rows
- **Retention**: Add automatic cleanup of snapshots older than 30 days (configurable via `HealthCollector:RetentionDays`), running hourly in the existing `HealthCollectorBackgroundService`
- **Bulk delete**: `RemoveOlderThan` now uses `ExecuteSql` instead of loading all old entities into memory

## Test plan

- [x] All 16 `HealthSnapshotRepository` integration tests pass
- [ ] Deploy and verify health page loads instantly instead of 30-60 seconds
- [ ] Verify retention cleanup runs (check logs for "Cleaned up X health snapshots")