### PR TITLE
feat: Pass Docker HEALTHCHECK from stack definitions to containers

### DIFF
--- a/src/ReadyStackGo.Application/Services/IDockerService.cs
+++ b/src/ReadyStackGo.Application/Services/IDockerService.cs
@@ -225,6 +225,42 @@ public class CreateContainerRequest
     /// Restart policy (e.g., "no", "always", "unless-stopped", "on-failure").
     /// </summary>
     public string RestartPolicy { get; set; } = "unless-stopped";
+
+    /// <summary>
+    /// Docker HEALTHCHECK configuration. When set, Docker monitors container health natively.
+    /// </summary>
+    public ContainerHealthCheck? HealthCheck { get; set; }
+}
+
+/// <summary>
+/// Docker HEALTHCHECK configuration for a container.
+/// </summary>
+public class ContainerHealthCheck
+{
+    /// <summary>
+    /// Test command (e.g., ["CMD", "curl", "-f", "http://localhost:8080/hc"]).
+    /// </summary>
+    public required IReadOnlyList<string> Test { get; set; }
+
+    /// <summary>
+    /// Interval between health checks.
+    /// </summary>
+    public TimeSpan? Interval { get; set; }
+
+    /// <summary>
+    /// Timeout for each health check.
+    /// </summary>
+    public TimeSpan? Timeout { get; set; }
+
+    /// <summary>
+    /// Number of retries before marking unhealthy.
+    /// </summary>
+    public int? Retries { get; set; }
+
+    /// <summary>
+    /// Grace period before health checks start.
+    /// </summary>
+    public TimeSpan? StartPeriod { get; set; }
 }
 
 /// <summary>

--- a/src/ReadyStackGo.Application/UseCases/Deployments/DeploymentDtos.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/DeploymentDtos.cs
@@ -71,6 +71,43 @@ public class DeploymentStep
     /// Init containers run once before regular services and only restart on failure.
     /// </summary>
     public ServiceLifecycle Lifecycle { get; set; } = ServiceLifecycle.Service;
+
+    /// <summary>
+    /// Docker HEALTHCHECK configuration for this container.
+    /// When set, Docker monitors the container's health status natively.
+    /// </summary>
+    public DockerHealthCheck? HealthCheck { get; set; }
+}
+
+/// <summary>
+/// Docker HEALTHCHECK configuration to apply when creating a container.
+/// </summary>
+public class DockerHealthCheck
+{
+    /// <summary>
+    /// Test command (e.g., ["CMD", "curl", "-f", "http://localhost:8080/hc"]).
+    /// </summary>
+    public required IReadOnlyList<string> Test { get; set; }
+
+    /// <summary>
+    /// Interval between health checks.
+    /// </summary>
+    public TimeSpan? Interval { get; set; }
+
+    /// <summary>
+    /// Timeout for each health check.
+    /// </summary>
+    public TimeSpan? Timeout { get; set; }
+
+    /// <summary>
+    /// Number of retries before marking unhealthy.
+    /// </summary>
+    public int? Retries { get; set; }
+
+    /// <summary>
+    /// Grace period before health checks start.
+    /// </summary>
+    public TimeSpan? StartPeriod { get; set; }
 }
 
 /// <summary>

--- a/src/ReadyStackGo.Infrastructure.Docker/DockerService.cs
+++ b/src/ReadyStackGo.Infrastructure.Docker/DockerService.cs
@@ -230,6 +230,25 @@ public class DockerService : IDockerService, IDisposable
             NetworkingConfig = networkingConfig
         };
 
+        // Apply Docker HEALTHCHECK if configured
+        if (request.HealthCheck != null && request.HealthCheck.Test.Count > 0)
+        {
+            var healthConfig = new HealthConfig
+            {
+                Test = request.HealthCheck.Test.ToList(),
+                Retries = request.HealthCheck.Retries ?? 0
+            };
+
+            if (request.HealthCheck.Interval.HasValue)
+                healthConfig.Interval = request.HealthCheck.Interval.Value;
+            if (request.HealthCheck.Timeout.HasValue)
+                healthConfig.Timeout = request.HealthCheck.Timeout.Value;
+            if (request.HealthCheck.StartPeriod.HasValue)
+                healthConfig.StartPeriod = request.HealthCheck.StartPeriod.Value.Ticks * 100; // Convert to nanoseconds
+
+            createParams.Healthcheck = healthConfig;
+        }
+
         var response = await client.Containers.CreateContainerAsync(createParams, cancellationToken);
 
         // Connect to additional networks with aliases

--- a/src/ReadyStackGo.Infrastructure/Services/Deployment/DeploymentEngine.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Deployment/DeploymentEngine.cs
@@ -857,7 +857,15 @@ public class DeploymentEngine : IDeploymentEngine
                 ["rsgo.stack.name"] = stackDefinitionName ?? stackName,
                 ["rsgo.product"] = productGroupId ?? ""
             },
-            RestartPolicy = restartPolicy
+            RestartPolicy = restartPolicy,
+            HealthCheck = step.HealthCheck != null ? new ContainerHealthCheck
+            {
+                Test = step.HealthCheck.Test,
+                Interval = step.HealthCheck.Interval,
+                Timeout = step.HealthCheck.Timeout,
+                Retries = step.HealthCheck.Retries,
+                StartPeriod = step.HealthCheck.StartPeriod
+            } : null
         };
 
         var containerId = await _dockerService.CreateAndStartContainerAsync(environmentId, request);

--- a/src/ReadyStackGo.Infrastructure/Services/Deployment/DeploymentService.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Deployment/DeploymentService.cs
@@ -1051,7 +1051,8 @@ public class DeploymentService : IDeploymentService
                 ContainerName = resolvedContainerName,
                 Order = order++,
                 DependsOn = service.DependsOn.ToList(),
-                Lifecycle = service.Lifecycle
+                Lifecycle = service.Lifecycle,
+                HealthCheck = MapDockerHealthCheck(service.HealthCheck)
             };
 
             // Map ports - resolve ${VAR} placeholders in port mappings
@@ -1108,6 +1109,25 @@ public class DeploymentService : IDeploymentService
         ReorderStepsByDependencies(plan.Steps);
 
         return plan;
+    }
+
+    /// <summary>
+    /// Maps a ServiceHealthCheck to a DockerHealthCheck for container creation.
+    /// Only maps if the health check has a Docker test command defined.
+    /// </summary>
+    private static DockerHealthCheck? MapDockerHealthCheck(StackManagement.ServiceHealthCheck? healthCheck)
+    {
+        if (healthCheck == null || healthCheck.Test.Count == 0)
+            return null;
+
+        return new DockerHealthCheck
+        {
+            Test = healthCheck.Test.ToList(),
+            Interval = healthCheck.Interval,
+            Timeout = healthCheck.Timeout,
+            Retries = healthCheck.Retries,
+            StartPeriod = healthCheck.StartPeriod
+        };
     }
 
     /// <summary>

--- a/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Auth/Login.tsx
+++ b/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Auth/Login.tsx
@@ -117,12 +117,6 @@ export default function Login() {
                   </div>
                 </div>
               </form>
-
-              <div className="mt-5">
-                <p className="text-sm font-normal text-center text-gray-500 dark:text-gray-400 sm:text-start">
-                  Default credentials: <span className="font-medium text-gray-700 dark:text-gray-300">admin / admin</span>
-                </p>
-              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Containers deployed by RSGO now receive native Docker HEALTHCHECK configuration from stack definition `healthCheck.test` fields
- This enables Docker to report containers as "healthy" instead of just "running" in the Containers page
- Also removes default credentials hint from the login page

## Changes
- `DeploymentStep` extended with `DockerHealthCheck` property
- `CreateContainerRequest` extended with `ContainerHealthCheck` property  
- `DeploymentService` maps `ServiceHealthCheck` → `DockerHealthCheck` during plan creation
- `DeploymentEngine` passes health check config through to container creation
- `DockerService` applies `HealthConfig` when creating containers via Docker API

## Test plan
- [x] All 2965 tests pass (2556 unit + 409 integration)
- [ ] Deploy a stack with healthCheck definitions and verify containers show "healthy" status