### PR TITLE
Fix false unhealthy status by ignoring Docker HEALTHCHECK

### DIFF
--- a/src/ReadyStackGo.Application/Services/Impl/HealthMonitoringService.cs
+++ b/src/ReadyStackGo.Application/Services/Impl/HealthMonitoringService.cs
@@ -415,24 +415,13 @@ public class HealthMonitoringService : IHealthMonitoringService
     }
 
     /// <summary>
-    /// Determines the health status based on Docker container state and health check.
-    /// Note: Init containers are filtered out before reaching this method.
+    /// Determines the health status based on Docker container state.
+    /// Docker's native HEALTHCHECK is ignored because it depends on tools (curl/wget)
+    /// that may not be available in the container image, leading to false "unhealthy" reports.
+    /// RSGO performs its own HTTP health checks via configured health endpoints instead.
     /// </summary>
     private static HealthStatus DetermineHealthStatusFromDocker(ContainerDto container)
     {
-        // First check Docker health status if available
-        if (!string.IsNullOrEmpty(container.HealthStatus) && container.HealthStatus != "none")
-        {
-            return container.HealthStatus.ToLowerInvariant() switch
-            {
-                "healthy" => HealthStatus.Healthy,
-                "unhealthy" => HealthStatus.Unhealthy,
-                "starting" => HealthStatus.Degraded,
-                _ => HealthStatus.Unknown
-            };
-        }
-
-        // Fall back to container state
         return container.State.ToLowerInvariant() switch
         {
             "running" => HealthStatus.Healthy,

--- a/src/ReadyStackGo.Application/UseCases/Containers/ListContainers/ListContainersHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Containers/ListContainers/ListContainersHandler.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using MediatR;
 using ReadyStackGo.Application.Services;
 using ReadyStackGo.Domain.Deployment.Environments;
@@ -9,11 +10,16 @@ public class ListContainersHandler : IRequestHandler<ListContainersQuery, ListCo
 {
     private readonly IDockerService _dockerService;
     private readonly IHealthSnapshotRepository _healthSnapshotRepository;
+    private readonly ILogger<ListContainersHandler> _logger;
 
-    public ListContainersHandler(IDockerService dockerService, IHealthSnapshotRepository healthSnapshotRepository)
+    public ListContainersHandler(
+        IDockerService dockerService,
+        IHealthSnapshotRepository healthSnapshotRepository,
+        ILogger<ListContainersHandler> logger)
     {
         _dockerService = dockerService;
         _healthSnapshotRepository = healthSnapshotRepository;
+        _logger = logger;
     }
 
     public async Task<ListContainersResult> Handle(ListContainersQuery request, CancellationToken cancellationToken)
@@ -21,9 +27,10 @@ public class ListContainersHandler : IRequestHandler<ListContainersQuery, ListCo
         try
         {
             var containers = await _dockerService.ListContainersAsync(request.EnvironmentId, cancellationToken);
+            var containerList = containers.ToList();
 
             // Enrich containers with RSGO health monitoring data
-            var enriched = EnrichWithHealthData(request.EnvironmentId, containers);
+            var enriched = EnrichWithHealthData(request.EnvironmentId, containerList);
 
             return new ListContainersResult(true, enriched);
         }
@@ -33,13 +40,22 @@ public class ListContainersHandler : IRequestHandler<ListContainersQuery, ListCo
         }
     }
 
-    private IEnumerable<ContainerDto> EnrichWithHealthData(string environmentId, IEnumerable<ContainerDto> containers)
+    private List<ContainerDto> EnrichWithHealthData(string environmentId, List<ContainerDto> containers)
     {
         if (!Guid.TryParse(environmentId, out var envGuid))
             return containers;
 
-        var snapshots = _healthSnapshotRepository.GetLatestForEnvironment(
-            EnvironmentId.FromGuid(envGuid));
+        IEnumerable<HealthSnapshot> snapshots;
+        try
+        {
+            snapshots = _healthSnapshotRepository.GetLatestForEnvironment(
+                EnvironmentId.FromGuid(envGuid));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load health snapshots for container enrichment");
+            return containers;
+        }
 
         // Build lookup: container name → RSGO health status
         var healthLookup = new Dictionary<string, HealthStatus>(StringComparer.OrdinalIgnoreCase);
@@ -64,6 +80,6 @@ public class ListContainersHandler : IRequestHandler<ListContainersQuery, ListCo
                 return c with { HealthStatus = rsgoStatus.Name.ToLowerInvariant() };
             }
             return c;
-        });
+        }).ToList();
     }
 }

--- a/tests/ReadyStackGo.UnitTests/Services/HealthMonitoringServiceTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Services/HealthMonitoringServiceTests.cs
@@ -100,11 +100,11 @@ public class HealthMonitoringServiceTests
     [Fact]
     public async Task CaptureHealthSnapshot_UnhealthyContainer_FetchesRestartCount()
     {
-        // Arrange
+        // Arrange - Docker HEALTHCHECK is ignored; only container state matters
         var containers = new[]
         {
-            CreateContainer("c1", "web", "running", "healthy"),
-            CreateContainer("c2", "api", "running", "unhealthy")  // Unhealthy!
+            CreateContainer("c1", "web", "running", "none"),
+            CreateContainer("c2", "api", "exited", "none")  // Unhealthy via state!
         };
 
         _dockerServiceMock
@@ -127,12 +127,12 @@ public class HealthMonitoringServiceTests
         _dockerServiceMock.Verify(
             d => d.GetContainerRestartCountAsync(_envId.Value.ToString(), "c2", It.IsAny<CancellationToken>()),
             Times.Once,
-            "RestartCount should be fetched for unhealthy container");
+            "RestartCount should be fetched for exited (unhealthy) container");
 
         _dockerServiceMock.Verify(
             d => d.GetContainerRestartCountAsync(_envId.Value.ToString(), "c1", It.IsAny<CancellationToken>()),
             Times.Never,
-            "RestartCount should NOT be fetched for healthy container");
+            "RestartCount should NOT be fetched for running (healthy) container");
 
         var unhealthyService = snapshot.Self.Services.Single(s => s.Name == "api");
         unhealthyService.RestartCount.Should().Be(5);
@@ -216,23 +216,20 @@ public class HealthMonitoringServiceTests
     [Fact]
     public async Task CaptureHealthSnapshot_MixedContainers_OnlyFetchesRestartCountForUnhealthy()
     {
-        // Arrange - Mix of healthy, unhealthy, and degraded
+        // Arrange - Docker HEALTHCHECK is ignored; only container state matters for fallback
         var containers = new[]
         {
-            CreateContainer("c1", "web", "running", "healthy"),      // Healthy - no fetch
-            CreateContainer("c2", "api", "running", "unhealthy"),    // Unhealthy - fetch
-            CreateContainer("c3", "worker", "running", "healthy"),   // Healthy - no fetch
-            CreateContainer("c4", "db", "exited", "none"),           // Unhealthy - fetch
-            CreateContainer("c5", "cache", "restarting", "none")     // Degraded - fetch
+            CreateContainer("c1", "web", "running", "none"),          // Healthy (running) - no fetch
+            CreateContainer("c2", "api", "running", "unhealthy"),     // Healthy (running, HEALTHCHECK ignored) - no fetch
+            CreateContainer("c3", "worker", "running", "none"),       // Healthy (running) - no fetch
+            CreateContainer("c4", "db", "exited", "none"),            // Unhealthy (exited) - fetch
+            CreateContainer("c5", "cache", "restarting", "none")      // Degraded (restarting) - fetch
         };
 
         _dockerServiceMock
             .Setup(d => d.ListContainersAsync(_envId.Value.ToString(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(containers);
 
-        _dockerServiceMock
-            .Setup(d => d.GetContainerRestartCountAsync(_envId.Value.ToString(), "c2", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(2);
         _dockerServiceMock
             .Setup(d => d.GetContainerRestartCountAsync(_envId.Value.ToString(), "c4", It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
@@ -248,15 +245,18 @@ public class HealthMonitoringServiceTests
         var snapshot = await _service.CaptureHealthSnapshotAsync(
             _orgId, _envId, _deploymentId, "test-stack", "1.0.0", serviceHealthConfigs: null);
 
-        // Assert - Only 3 calls for unhealthy/degraded containers
+        // Assert - Only 2 calls for truly unhealthy/degraded containers (exited + restarting)
         _dockerServiceMock.Verify(
             d => d.GetContainerRestartCountAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Exactly(3),
-            "RestartCount should only be fetched for 3 non-healthy containers");
+            Times.Exactly(2),
+            "RestartCount should only be fetched for 2 non-healthy containers (exited + restarting)");
 
-        // Verify specific containers
+        // Verify running containers (regardless of Docker HEALTHCHECK) don't trigger fetch
         _dockerServiceMock.Verify(
             d => d.GetContainerRestartCountAsync(_envId.Value.ToString(), "c1", It.IsAny<CancellationToken>()),
+            Times.Never);
+        _dockerServiceMock.Verify(
+            d => d.GetContainerRestartCountAsync(_envId.Value.ToString(), "c2", It.IsAny<CancellationToken>()),
             Times.Never);
         _dockerServiceMock.Verify(
             d => d.GetContainerRestartCountAsync(_envId.Value.ToString(), "c3", It.IsAny<CancellationToken>()),
@@ -264,28 +264,26 @@ public class HealthMonitoringServiceTests
 
         // Check RestartCount values
         snapshot.Self.Services.Single(s => s.Name == "web").RestartCount.Should().BeNull();
-        snapshot.Self.Services.Single(s => s.Name == "api").RestartCount.Should().Be(2);
+        snapshot.Self.Services.Single(s => s.Name == "api").RestartCount.Should().BeNull();
         snapshot.Self.Services.Single(s => s.Name == "worker").RestartCount.Should().BeNull();
         snapshot.Self.Services.Single(s => s.Name == "db").RestartCount.Should().Be(1);
         snapshot.Self.Services.Single(s => s.Name == "cache").RestartCount.Should().Be(7);
     }
 
     [Fact]
-    public async Task CaptureHealthSnapshot_StartingHealthCheck_FetchesRestartCount()
+    public async Task CaptureHealthSnapshot_RunningContainerWithDockerHealthCheck_IgnoresDockerHealthStatus()
     {
-        // Arrange - "starting" health status = Degraded
+        // Arrange - Docker HEALTHCHECK "starting"/"unhealthy" is ignored for running containers.
+        // RSGO uses its own HTTP health checks instead. Running state = Healthy.
         var containers = new[]
         {
-            CreateContainer("c1", "web", "running", "starting")
+            CreateContainer("c1", "web", "running", "starting"),
+            CreateContainer("c2", "api", "running", "unhealthy")
         };
 
         _dockerServiceMock
             .Setup(d => d.ListContainersAsync(_envId.Value.ToString(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(containers);
-
-        _dockerServiceMock
-            .Setup(d => d.GetContainerRestartCountAsync(_envId.Value.ToString(), "c1", It.IsAny<CancellationToken>()))
-            .ReturnsAsync(0);
 
         _deploymentRepoMock
             .Setup(r => r.Get(_deploymentId))
@@ -295,15 +293,14 @@ public class HealthMonitoringServiceTests
         var snapshot = await _service.CaptureHealthSnapshotAsync(
             _orgId, _envId, _deploymentId, "test-stack", "1.0.0", serviceHealthConfigs: null);
 
-        // Assert
+        // Assert - Both containers are Healthy because they are running
         _dockerServiceMock.Verify(
-            d => d.GetContainerRestartCountAsync(_envId.Value.ToString(), "c1", It.IsAny<CancellationToken>()),
-            Times.Once,
-            "RestartCount should be fetched for container with starting health check");
+            d => d.GetContainerRestartCountAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "RestartCount should NOT be fetched for running containers (Docker HEALTHCHECK ignored)");
 
-        var service = snapshot.Self.Services.Single();
-        service.RestartCount.Should().Be(0);
-        service.Status.Should().Be(HealthStatus.Degraded);
+        snapshot.Self.Services.Single(s => s.Name == "web").Status.Should().Be(HealthStatus.Healthy);
+        snapshot.Self.Services.Single(s => s.Name == "api").Status.Should().Be(HealthStatus.Healthy);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- Docker's native HEALTHCHECK uses `curl` inside the container, which fails when the tool is missing, causing false "unhealthy" reports
- Changed `DetermineHealthStatusFromDocker` to use only container state (running/exited/restarting) and ignore Docker HEALTHCHECK results
- RSGO's own HTTP health checks via `/hc` endpoints are the authoritative health source
- Improved `ListContainersHandler` with error handling and eager evaluation

## Root cause
Containers like `bom-api`, `bom-readmodelgenerator`, and `memo-web` have a Docker HEALTHCHECK in their image that uses `curl`. Since `curl` is not available in those containers, Docker reports them as "unhealthy". The health monitoring fallback (`DetermineHealthStatusFromDocker`) previously trusted this Docker HEALTHCHECK result, propagating the false negative into RSGO health snapshots and the container management page.

## Test plan
- [x] Updated unit tests for new behavior (2556 passing)
- [ ] Deploy and verify containers with missing curl show as healthy when running
- [ ] Verify truly unhealthy containers (exited, dead) still show correctly