### PR TITLE
Remove stale deployments when product stacks are renamed or removed

### DIFF
--- a/src/ReadyStackGo.Application/Services/IDeploymentService.cs
+++ b/src/ReadyStackGo.Application/Services/IDeploymentService.cs
@@ -71,6 +71,12 @@ public interface IDeploymentService
     Task<DeployComposeResponse> RemoveDeploymentAsync(string environmentId, string stackName);
 
     /// <summary>
+    /// Marks a deployment as removed in the database without calling Docker.
+    /// Use as fallback when Docker removal fails but the DB record must still be cleaned up.
+    /// </summary>
+    Task MarkDeploymentAsRemovedAsync(string environmentId, string stackName);
+
+    /// <summary>
     /// Remove a deployed stack by deployment ID.
     /// </summary>
     Task<DeployComposeResponse> RemoveDeploymentByIdAsync(string environmentId, string deploymentId);

--- a/src/ReadyStackGo.Application/UseCases/Containers/ListContainers/ListContainersHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Containers/ListContainers/ListContainersHandler.cs
@@ -57,22 +57,14 @@ public class ListContainersHandler : IRequestHandler<ListContainersQuery, ListCo
             return containers;
         }
 
-        // Build lookup: container name → RSGO health status
-        // When multiple deployments monitor the same container (e.g. stale + current deployment),
-        // prefer the healthier status (lower Value = healthier: Healthy=0, Degraded=1, Unhealthy=2, etc.)
+        // Build lookup: container name → RSGO health status (latest snapshot wins)
         var healthLookup = new Dictionary<string, HealthStatus>(StringComparer.OrdinalIgnoreCase);
         foreach (var snapshot in snapshots)
         {
             foreach (var service in snapshot.Self.Services)
             {
                 if (!string.IsNullOrEmpty(service.ContainerName))
-                {
-                    if (!healthLookup.TryGetValue(service.ContainerName, out var existing) ||
-                        service.Status.Value < existing.Value)
-                    {
-                        healthLookup[service.ContainerName] = service.Status;
-                    }
-                }
+                    healthLookup[service.ContainerName] = service.Status;
             }
         }
 
@@ -81,7 +73,6 @@ public class ListContainersHandler : IRequestHandler<ListContainersQuery, ListCo
 
         return containers.Select(c =>
         {
-            // Match by container name (strip leading '/' from Docker names)
             var name = c.Name.TrimStart('/');
             if (healthLookup.TryGetValue(name, out var rsgoStatus))
             {

--- a/src/ReadyStackGo.Application/UseCases/Deployments/UpgradeProduct/UpgradeProductHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/UpgradeProduct/UpgradeProductHandler.cs
@@ -18,6 +18,7 @@ public class UpgradeProductHandler : IRequestHandler<UpgradeProductCommand, Upgr
     private readonly IProductSourceService _productSourceService;
     private readonly IProductDeploymentRepository _repository;
     private readonly IMediator _mediator;
+    private readonly IDeploymentService _deploymentService;
     private readonly IDeploymentNotificationService? _notificationService;
     private readonly INotificationService? _inAppNotificationService;
     private readonly ILogger<UpgradeProductHandler> _logger;
@@ -27,6 +28,7 @@ public class UpgradeProductHandler : IRequestHandler<UpgradeProductCommand, Upgr
         IProductSourceService productSourceService,
         IProductDeploymentRepository repository,
         IMediator mediator,
+        IDeploymentService deploymentService,
         ILogger<UpgradeProductHandler> logger,
         IDeploymentNotificationService? notificationService = null,
         INotificationService? inAppNotificationService = null,
@@ -35,6 +37,7 @@ public class UpgradeProductHandler : IRequestHandler<UpgradeProductCommand, Upgr
         _productSourceService = productSourceService;
         _repository = repository;
         _mediator = mediator;
+        _deploymentService = deploymentService;
         _logger = logger;
         _notificationService = notificationService;
         _inAppNotificationService = inAppNotificationService;
@@ -101,7 +104,6 @@ public class UpgradeProductHandler : IRequestHandler<UpgradeProductCommand, Upgr
             .ToDictionary(s => s.StackName, s => s, StringComparer.OrdinalIgnoreCase);
 
         var stackConfigs = new List<StackDeploymentConfig>();
-        var warnings = new List<string>();
 
         foreach (var reqStack in request.StackConfigs)
         {
@@ -129,14 +131,39 @@ public class UpgradeProductHandler : IRequestHandler<UpgradeProductCommand, Upgr
                 mergedVariables));
         }
 
-        // Check for stacks in existing deployment that are not in the target
+        // Remove stacks that exist in the current deployment but are not in the target version.
+        // A rename or removal of a stack means the old deployment is obsolete: remove it (Docker + DB).
         var targetStackNames = stackConfigs.Select(s => s.StackName).ToHashSet(StringComparer.OrdinalIgnoreCase);
-        foreach (var existingStack in existing.Stacks)
+        var stacksToRemove = existing.Stacks
+            .Where(s => !targetStackNames.Contains(s.StackName))
+            .ToList();
+
+        foreach (var oldStack in stacksToRemove)
         {
-            if (!targetStackNames.Contains(existingStack.StackName))
+            _logger.LogInformation(
+                "Stack '{StackName}' no longer in target version — removing as part of upgrade",
+                oldStack.StackName);
+            try
             {
-                warnings.Add(
-                    $"Stack '{existingStack.StackName}' exists in current deployment but not in target version. It will not be automatically removed.");
+                var removeResult = await _deploymentService.RemoveDeploymentAsync(
+                    request.EnvironmentId, oldStack.StackName);
+
+                if (!removeResult.Success)
+                {
+                    _logger.LogWarning(
+                        "Docker removal of old stack '{StackName}' failed ({Error}) — marking as removed in DB only",
+                        oldStack.StackName, removeResult.Message);
+                    await _deploymentService.MarkDeploymentAsRemovedAsync(
+                        request.EnvironmentId, oldStack.StackName);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Exception removing old stack '{StackName}' — marking as removed in DB only",
+                    oldStack.StackName);
+                await _deploymentService.MarkDeploymentAsRemovedAsync(
+                    request.EnvironmentId, oldStack.StackName);
             }
         }
 
@@ -312,7 +339,7 @@ public class UpgradeProductHandler : IRequestHandler<UpgradeProductCommand, Upgr
             Status = productDeployment.Status.ToString(),
             SessionId = sessionId,
             StackResults = stackResults,
-            Warnings = warnings.Count > 0 ? warnings : null
+            Warnings = null
         };
     }
 

--- a/src/ReadyStackGo.Infrastructure/Services/Deployment/DeploymentService.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Deployment/DeploymentService.cs
@@ -499,6 +499,24 @@ public class DeploymentService : IDeploymentService
         }
     }
 
+    public Task MarkDeploymentAsRemovedAsync(string environmentId, string stackName)
+    {
+        if (!Guid.TryParse(environmentId, out var envGuid))
+            return Task.CompletedTask;
+
+        var deployment = _deploymentRepository.GetByStackName(new EnvironmentId(envGuid), stackName);
+        if (deployment != null && deployment.Status != Domain.Deployment.Deployments.DeploymentStatus.Removed)
+        {
+            deployment.MarkAsRemoved();
+            _deploymentRepository.SaveChanges();
+            _logger.LogInformation(
+                "Marked deployment {DeploymentId} (stack: {StackName}) as removed without Docker removal",
+                deployment.Id, stackName);
+        }
+
+        return Task.CompletedTask;
+    }
+
     public async Task<DeployComposeResponse> RemoveDeploymentByIdAsync(string environmentId, string deploymentId)
     {
         try

--- a/tests/ReadyStackGo.UnitTests/Application/Deployments/UpgradeProductHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Deployments/UpgradeProductHandlerTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Time.Testing;
 using Moq;
 using ReadyStackGo.Application.Services;
+using ReadyStackGo.Application.UseCases.Deployments;
 using ReadyStackGo.Application.UseCases.Deployments.DeployStack;
 using ReadyStackGo.Application.UseCases.Deployments.UpgradeProduct;
 using ReadyStackGo.Domain.Deployment.Deployments;
@@ -19,6 +20,7 @@ public class UpgradeProductHandlerTests
     private readonly Mock<IProductSourceService> _productSourceMock;
     private readonly Mock<IProductDeploymentRepository> _repositoryMock;
     private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<IDeploymentService> _deploymentServiceMock;
     private readonly Mock<IDeploymentNotificationService> _notificationMock;
     private readonly Mock<INotificationService> _inAppNotificationMock;
     private readonly Mock<ILogger<UpgradeProductHandler>> _loggerMock;
@@ -33,6 +35,7 @@ public class UpgradeProductHandlerTests
         _productSourceMock = new Mock<IProductSourceService>();
         _repositoryMock = new Mock<IProductDeploymentRepository>();
         _mediatorMock = new Mock<IMediator>();
+        _deploymentServiceMock = new Mock<IDeploymentService>();
         _notificationMock = new Mock<IDeploymentNotificationService>();
         _inAppNotificationMock = new Mock<INotificationService>();
         _loggerMock = new Mock<ILogger<UpgradeProductHandler>>();
@@ -40,10 +43,16 @@ public class UpgradeProductHandlerTests
 
         _repositoryMock.Setup(r => r.NextIdentity()).Returns(ProductDeploymentId.NewId());
 
+        // Default: removal succeeds
+        _deploymentServiceMock
+            .Setup(d => d.RemoveDeploymentAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new DeployComposeResponse { Success = true });
+
         _handler = new UpgradeProductHandler(
             _productSourceMock.Object,
             _repositoryMock.Object,
             _mediatorMock.Object,
+            _deploymentServiceMock.Object,
             _loggerMock.Object,
             _notificationMock.Object,
             _inAppNotificationMock.Object,
@@ -838,8 +847,10 @@ public class UpgradeProductHandlerTests
     }
 
     [Fact]
-    public async Task Handle_MissingStacksInTarget_WarningGenerated()
+    public async Task Handle_StackRemovedFromTarget_RemovesOldDeployment()
     {
+        // When a stack is removed (or renamed) in the new version, the old deployment must be removed.
+        // This is the correct behavior: redeployment = remove old + deploy new.
         var currentProduct = CreateTestProduct(2, version: "1.0.0",
             stackNames: new List<string> { "stack-0", "old-stack" });
         var targetProduct = CreateTestProduct(1, version: "2.0.0",
@@ -854,8 +865,41 @@ public class UpgradeProductHandlerTests
             CreateUpgradeCommand(existing, targetProduct), CancellationToken.None);
 
         result.Success.Should().BeTrue();
-        result.Warnings.Should().NotBeNull();
-        result.Warnings.Should().ContainSingle(w => w.Contains("old-stack"));
+        result.Warnings.Should().BeNull("old stacks are removed, not just warned about");
+        _deploymentServiceMock.Verify(
+            d => d.RemoveDeploymentAsync(TestEnvironmentId, "old-stack"),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_StackRemovedFromTarget_DockerRemovalFails_FallsBackToDbOnly()
+    {
+        // If Docker removal fails (e.g. containers already moved to new compose project),
+        // the DB record must still be marked as Removed.
+        var currentProduct = CreateTestProduct(2, version: "1.0.0",
+            stackNames: new List<string> { "stack-0", "renamed-stack" });
+        var targetProduct = CreateTestProduct(1, version: "2.0.0",
+            stackNames: new List<string> { "stack-0" });
+        var existing = CreateExistingDeployment(currentProduct);
+
+        SetupExistingDeployment(existing);
+        SetupTargetProductFound(targetProduct);
+        SetupAllStacksSucceed();
+
+        _deploymentServiceMock
+            .Setup(d => d.RemoveDeploymentAsync(TestEnvironmentId, "renamed-stack"))
+            .ReturnsAsync(new DeployComposeResponse { Success = false, Message = "Stack not found in Docker" });
+        _deploymentServiceMock
+            .Setup(d => d.MarkDeploymentAsRemovedAsync(TestEnvironmentId, "renamed-stack"))
+            .Returns(Task.CompletedTask);
+
+        var result = await _handler.Handle(
+            CreateUpgradeCommand(existing, targetProduct), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        _deploymentServiceMock.Verify(
+            d => d.MarkDeploymentAsRemovedAsync(TestEnvironmentId, "renamed-stack"),
+            Times.Once);
     }
 
     [Fact]
@@ -967,6 +1011,7 @@ public class UpgradeProductHandlerTests
             _productSourceMock.Object,
             _repositoryMock.Object,
             _mediatorMock.Object,
+            _deploymentServiceMock.Object,
             _loggerMock.Object);
 
         var currentProduct = CreateTestProduct(1, version: "1.0.0");

--- a/tests/ReadyStackGo.UnitTests/UseCases/Containers/ListContainersHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/UseCases/Containers/ListContainersHandlerTests.cs
@@ -93,71 +93,31 @@ public class ListContainersHandlerTests
     }
 
     [Fact]
-    public async Task Handle_DuplicateDeployments_PrefersHealthyStatus()
+    public async Task Handle_MultipleSnapshots_LastWriteWins()
     {
-        // Arrange - Same container monitored by two deployments (stale + current)
-        var containers = new[]
-        {
-            CreateContainer("memo-web")
-        };
-
-        _dockerServiceMock
-            .Setup(d => d.ListContainersAsync(_envId.Value.ToString(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(containers);
-
-        // Current deployment: healthy via HTTP /hc check
-        var currentSnapshot = CreateSnapshot(_envId, "Memo",
-            ServiceHealth.Create("memo-web", HealthStatus.Healthy,
-                containerName: "memo-web", responseTimeMs: 2));
-
-        // Stale deployment: unhealthy (can't reach container on old network)
-        var staleSnapshot = CreateSnapshot(_envId, "ams-project-memo",
-            ServiceHealth.Create("memo-web", HealthStatus.Unhealthy,
-                containerName: "memo-web",
-                reason: "Connection failed: Resource temporarily unavailable"));
-
-        // Return stale snapshot AFTER current — simulates the bug where last writer wins
-        _healthSnapshotRepoMock
-            .Setup(r => r.GetLatestForEnvironment(_envId))
-            .Returns(new[] { currentSnapshot, staleSnapshot });
-
-        // Act
-        var result = await _handler.Handle(
-            new ListContainersQuery(_envId.Value.ToString()), CancellationToken.None);
-
-        // Assert - Should prefer healthy status despite stale unhealthy coming last
-        result.Success.Should().BeTrue();
-        var memoWeb = result.Containers.Single();
-        memoWeb.HealthStatus.Should().Be("healthy",
-            "healthy status from current deployment should take priority over unhealthy from stale deployment");
-    }
-
-    [Fact]
-    public async Task Handle_DuplicateDeployments_ReversedOrder_StillPrefersHealthy()
-    {
-        // Arrange - Same as above but stale snapshot comes first
+        // Stale deployments are removed during product upgrade (UpgradeProductHandler),
+        // so under normal operation only one active deployment monitors each container.
+        // When multiple snapshots exist, the last one in the iteration wins.
         var containers = new[] { CreateContainer("memo-web") };
 
         _dockerServiceMock
             .Setup(d => d.ListContainersAsync(_envId.Value.ToString(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(containers);
 
-        var staleSnapshot = CreateSnapshot(_envId, "ams-project-memo",
+        var firstSnapshot = CreateSnapshot(_envId, "Memo",
             ServiceHealth.Create("memo-web", HealthStatus.Unhealthy, containerName: "memo-web"));
-
-        var currentSnapshot = CreateSnapshot(_envId, "Memo",
+        var secondSnapshot = CreateSnapshot(_envId, "Memo",
             ServiceHealth.Create("memo-web", HealthStatus.Healthy, containerName: "memo-web"));
 
         _healthSnapshotRepoMock
             .Setup(r => r.GetLatestForEnvironment(_envId))
-            .Returns(new[] { staleSnapshot, currentSnapshot });
+            .Returns(new[] { firstSnapshot, secondSnapshot });
 
-        // Act
         var result = await _handler.Handle(
             new ListContainersQuery(_envId.Value.ToString()), CancellationToken.None);
 
-        // Assert
-        result.Containers.Single().HealthStatus.Should().Be("healthy");
+        result.Containers.Single().HealthStatus.Should().Be("healthy",
+            "last snapshot in the collection wins");
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

When a product is upgraded and a stack is renamed in the manifest (e.g. `ams-project-memo` → `Memo`), the old deployment record stayed alive with status `Running`. Its `HealthCollectorService` kept running health checks that failed with connection errors (containers moved to the new compose project), producing stale unhealthy snapshots that corrupted the container management view.

Root cause: `UpgradeProductHandler` detected renamed/removed stacks but only logged a warning instead of actually removing them.

## Fix

**Design principle:** redeployment = remove old + deploy new — using existing functionality.

When upgrading a product, stacks that no longer exist in the target version are now explicitly removed via `RemoveDeploymentAsync` (Docker down + DB `Removed`). If Docker removal fails (containers already taken over by the new compose project), `MarkDeploymentAsRemovedAsync` cleans up the DB record as fallback.

## Changes

- `UpgradeProductHandler`: injects `IDeploymentService`, removes stale stacks before deploying new version
- `IDeploymentService` + `DeploymentService`: new `MarkDeploymentAsRemovedAsync` fallback (DB-only removal)
- `ListContainersHandler`: reverts the "prefer healthier status" workaround from v0.36.5 — stale deployments are now prevented at the source
- Tests updated to verify removal behavior instead of the old warning behavior

## Tests

- `Handle_StackRemovedFromTarget_RemovesOldDeployment`: verifies `RemoveDeploymentAsync` is called for renamed/removed stacks
- `Handle_StackRemovedFromTarget_DockerRemovalFails_FallsBackToDbOnly`: verifies fallback to `MarkDeploymentAsRemovedAsync`