### PR TITLE
Fix redeploy UI notification order

### DIFF
--- a/src/ReadyStackGo.Application/UseCases/Deployments/RedeployProduct/RedeployProductHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/RedeployProduct/RedeployProductHandler.cs
@@ -111,11 +111,6 @@ public class RedeployProductHandler : IRequestHandler<RedeployProductCommand, De
                 continue;
             }
 
-            // Send product-level progress
-            await NotifyProductProgressAsync(
-                sessionId, stack.StackName, stack.StackDisplayName, i, stacks.Count,
-                productDeployment.CompletedStacks, cancellationToken);
-
             _logger.LogInformation(
                 "Redeploying stack {StackIndex}/{TotalStacks}: {StackName} for product {ProductName}",
                 i + 1, stacks.Count, stack.StackDisplayName, productDeployment.ProductName);
@@ -150,6 +145,11 @@ public class RedeployProductHandler : IRequestHandler<RedeployProductCommand, De
                 await _deploymentService.MarkDeploymentAsRemovedAsync(
                     request.EnvironmentId, stackDeploymentName);
             }
+
+            // Transition UI from 'removing' → 'deploying'
+            await NotifyProductProgressAsync(
+                sessionId, stack.StackName, stack.StackDisplayName, i, stacks.Count,
+                productDeployment.CompletedStacks, cancellationToken);
 
             DeployStackResponse deployResult;
             try


### PR DESCRIPTION
## Summary

The redeploy progress UI was stuck showing 'removing' for the entire deploy phase because the notifications were sent in the wrong order.

**Before (broken):**
1. Notify "Redeploying stack" → UI: deploying
2. Notify "Removing stack" → UI: removing  ← overwrites
3. RemoveDeploymentAsync
4. DeployStackCommand ← no notification, UI stays stuck at 'removing'
5. Notify "redeployed successfully" → UI: running

**After (fixed):**
1. Notify "Removing stack" → UI: removing
2. RemoveDeploymentAsync
3. Notify "Redeploying stack" → UI: deploying
4. DeployStackCommand
5. Notify "redeployed successfully" → UI: running

## Test plan
- [ ] Trigger redeploy — verify UI transitions: pending → removing → deploying → running