### PR TITLE
Exclude removed deployments from health snapshot enrichment

### DIFF
--- a/src/ReadyStackGo.Infrastructure.DataAccess/Repositories/HealthSnapshotRepository.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Repositories/HealthSnapshotRepository.cs
@@ -47,6 +47,9 @@ public class HealthSnapshotRepository : IHealthSnapshotRepository
         // The EF GroupBy+First pattern causes client-side evaluation, loading ALL rows.
         var envId = environmentId.Value.ToString().ToUpperInvariant();
 
+        // Only include snapshots for deployments that have not been removed (Status != 4).
+        // Removed deployments can still have stale snapshots with container names that
+        // match currently running containers, which would cause false unhealthy status.
         return _context.HealthSnapshots
             .FromSqlRaw(
                 """
@@ -59,6 +62,8 @@ public class HealthSnapshotRepository : IHealthSnapshotRepository
                     GROUP BY "DeploymentId"
                 ) latest ON h."DeploymentId" = latest."DeploymentId"
                     AND h."CapturedAtUtc" = latest."MaxDate"
+                INNER JOIN "Deployments" d ON d."Id" = h."DeploymentId"
+                    AND d."Status" != 4
                 WHERE UPPER(h."EnvironmentId") = {0}
                 """,
                 envId)

--- a/tests/ReadyStackGo.IntegrationTests/DataAccess/HealthSnapshotRepositoryIntegrationTests.cs
+++ b/tests/ReadyStackGo.IntegrationTests/DataAccess/HealthSnapshotRepositoryIntegrationTests.cs
@@ -7,6 +7,7 @@ using ReadyStackGo.Domain.Deployment.Environments;
 using ReadyStackGo.Domain.Deployment.Health;
 using ReadyStackGo.Infrastructure.DataAccess.Repositories;
 using ReadyStackGo.IntegrationTests.Infrastructure;
+using UserId = ReadyStackGo.Domain.Deployment.UserId;
 
 /// <summary>
 /// Integration tests for HealthSnapshotRepository with real SQLite database.
@@ -26,6 +27,20 @@ public class HealthSnapshotRepositoryIntegrationTests : IDisposable
     }
 
     public void Dispose() => _fixture.Dispose();
+
+    private void AddActiveDeployment(DeploymentId deploymentId, EnvironmentId? environmentId = null)
+    {
+        var deployment = Deployment.StartInstallation(
+            deploymentId,
+            environmentId ?? _envId,
+            "stack-id",
+            "stack-name",
+            "rsgo-stack-name",
+            UserId.NewId());
+        deployment.MarkAsRunning();
+        _fixture.Context.Set<Deployment>().Add(deployment);
+        _fixture.Context.SaveChanges();
+    }
 
     private HealthSnapshot CreateSnapshot(
         string stackName,
@@ -192,6 +207,8 @@ public class HealthSnapshotRepositoryIntegrationTests : IDisposable
         // Arrange
         var deployment1Id = DeploymentId.NewId();
         var deployment2Id = DeploymentId.NewId();
+        AddActiveDeployment(deployment1Id);
+        AddActiveDeployment(deployment2Id);
 
         // Add older snapshot for deployment 1
         var snapshot1Old = CreateSnapshot("stack-1", deployment1Id);
@@ -220,6 +237,36 @@ public class HealthSnapshotRepositoryIntegrationTests : IDisposable
     }
 
     [Fact]
+    public void GetLatestForEnvironment_ShouldExcludeRemovedDeployments()
+    {
+        // Arrange
+        var activeDeploymentId = DeploymentId.NewId();
+        var removedDeploymentId = DeploymentId.NewId();
+        AddActiveDeployment(activeDeploymentId);
+
+        // Removed deployment: create, complete, then mark removed
+        var removedDeployment = Deployment.StartInstallation(
+            removedDeploymentId, _envId, "stack-id", "stack-name", "rsgo-stack-name", UserId.NewId());
+        removedDeployment.MarkAsRunning();
+        removedDeployment.MarkAsRemoved();
+        _fixture.Context.Set<Deployment>().Add(removedDeployment);
+        _fixture.Context.SaveChanges();
+
+        var snapshotActive = CreateSnapshot("active-stack", activeDeploymentId);
+        _repository.Add(snapshotActive);
+        var snapshotRemoved = CreateSnapshot("removed-stack", removedDeploymentId);
+        _repository.Add(snapshotRemoved);
+        _repository.SaveChanges();
+
+        // Act
+        var results = _repository.GetLatestForEnvironment(_envId).ToList();
+
+        // Assert
+        results.Should().HaveCount(1);
+        results.Single().DeploymentId.Should().Be(activeDeploymentId);
+    }
+
+    [Fact]
     public void GetLatestForEnvironment_ShouldReturnEmptyForNoSnapshots()
     {
         // Act
@@ -234,11 +281,15 @@ public class HealthSnapshotRepositoryIntegrationTests : IDisposable
     {
         // Arrange
         var otherEnvId = EnvironmentId.NewId();
+        var deployment1Id = DeploymentId.NewId();
+        var deployment2Id = DeploymentId.NewId();
+        AddActiveDeployment(deployment1Id, _envId);
+        AddActiveDeployment(deployment2Id, otherEnvId);
 
-        var snapshot1 = CreateSnapshot("stack-1");
+        var snapshot1 = CreateSnapshot("stack-1", deployment1Id);
         _repository.Add(snapshot1);
 
-        var snapshot2 = CreateSnapshot("stack-2", environmentId: otherEnvId);
+        var snapshot2 = CreateSnapshot("stack-2", deployment2Id, environmentId: otherEnvId);
         _repository.Add(snapshot2);
 
         _repository.SaveChanges();


### PR DESCRIPTION
## Summary

- `GetLatestForEnvironment` now JOINs with `Deployments` and excludes `Status=4` (Removed)
- Root cause: removed deployments had stale health snapshots with real container names (e.g. `discussions-api`, `cachedata`) that matched currently running containers, causing false unhealthy status in the container management view
- These snapshots from 2026-03-05 were the last known health state before the containers were renamed/removed during a product upgrade

## Test plan
- [ ] Container management view no longer shows unhealthy status for containers whose deployments have been removed
- [ ] Active deployments still show correct health status from RSGO monitoring