### PR TITLE
Delete health snapshots when a deployment is removed

### DIFF
--- a/src/ReadyStackGo.Domain/Deployment/Health/IHealthSnapshotRepository.cs
+++ b/src/ReadyStackGo.Domain/Deployment/Health/IHealthSnapshotRepository.cs
@@ -39,6 +39,12 @@ public interface IHealthSnapshotRepository
     IEnumerable<HealthSnapshot> GetHistory(DeploymentId deploymentId, int limit = 10);
 
     /// <summary>
+    /// Removes all snapshots for a specific deployment.
+    /// Called when a deployment is removed to avoid stale health data.
+    /// </summary>
+    void RemoveForDeployment(DeploymentId deploymentId);
+
+    /// <summary>
     /// Removes old snapshots older than the specified age.
     /// Returns the number of deleted rows.
     /// </summary>

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Repositories/HealthSnapshotRepository.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Repositories/HealthSnapshotRepository.cs
@@ -45,11 +45,10 @@ public class HealthSnapshotRepository : IHealthSnapshotRepository
     {
         // Use raw SQL to efficiently get the latest snapshot per deployment.
         // The EF GroupBy+First pattern causes client-side evaluation, loading ALL rows.
+        // Stale snapshots from removed deployments are cleaned up at the source
+        // (DeploymentService calls RemoveForDeployment when marking a deployment as removed).
         var envId = environmentId.Value.ToString().ToUpperInvariant();
 
-        // Only include snapshots for deployments that have not been removed (Status != 4).
-        // Removed deployments can still have stale snapshots with container names that
-        // match currently running containers, which would cause false unhealthy status.
         return _context.HealthSnapshots
             .FromSqlRaw(
                 """
@@ -62,12 +61,19 @@ public class HealthSnapshotRepository : IHealthSnapshotRepository
                     GROUP BY "DeploymentId"
                 ) latest ON h."DeploymentId" = latest."DeploymentId"
                     AND h."CapturedAtUtc" = latest."MaxDate"
-                INNER JOIN "Deployments" d ON d."Id" = h."DeploymentId"
-                    AND d."Status" != 4
                 WHERE UPPER(h."EnvironmentId") = {0}
                 """,
                 envId)
             .ToList();
+    }
+
+    public void RemoveForDeployment(DeploymentId deploymentId)
+    {
+        var id = deploymentId.Value.ToString().ToUpperInvariant();
+        _context.Database.ExecuteSql(
+            $"""
+            DELETE FROM "HealthSnapshots" WHERE UPPER("DeploymentId") = {id}
+            """);
     }
 
     public IEnumerable<HealthSnapshot> GetHistory(DeploymentId deploymentId, int limit = 10)

--- a/src/ReadyStackGo.Infrastructure/Services/Deployment/DeploymentService.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Deployment/DeploymentService.cs
@@ -5,6 +5,7 @@ using ReadyStackGo.Application.UseCases.Deployments.DeployStack;
 using ReadyStackGo.Domain.Deployment;
 using ReadyStackGo.Domain.Deployment.Deployments;
 using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.Deployment.Health;
 using ReadyStackGo.Domain.IdentityAccess.Users;
 using StackManagement = ReadyStackGo.Domain.StackManagement.Stacks;
 using DeploymentUserId = ReadyStackGo.Domain.Deployment.UserId;
@@ -24,6 +25,7 @@ public class DeploymentService : IDeploymentService
     private readonly IDeploymentRepository _deploymentRepository;
     private readonly IEnvironmentRepository _environmentRepository;
     private readonly IUserRepository _userRepository;
+    private readonly IHealthSnapshotRepository _healthSnapshotRepository;
     private readonly ILogger<DeploymentService> _logger;
 
     public DeploymentService(
@@ -32,6 +34,7 @@ public class DeploymentService : IDeploymentService
         IDeploymentRepository deploymentRepository,
         IEnvironmentRepository environmentRepository,
         IUserRepository userRepository,
+        IHealthSnapshotRepository healthSnapshotRepository,
         ILogger<DeploymentService> logger)
     {
         _manifestParser = manifestParser;
@@ -39,6 +42,7 @@ public class DeploymentService : IDeploymentService
         _deploymentRepository = deploymentRepository;
         _environmentRepository = environmentRepository;
         _userRepository = userRepository;
+        _healthSnapshotRepository = healthSnapshotRepository;
         _logger = logger;
     }
 
@@ -473,6 +477,9 @@ public class DeploymentService : IDeploymentService
                     _deploymentRepository.SaveChanges();
                     _logger.LogInformation("Marked deployment {DeploymentId} as removed", deployment.Id);
                 }
+
+                _healthSnapshotRepository.RemoveForDeployment(deployment.Id);
+                _logger.LogInformation("Removed health snapshots for deployment {DeploymentId}", deployment.Id);
             }
             else
             {
@@ -505,13 +512,19 @@ public class DeploymentService : IDeploymentService
             return Task.CompletedTask;
 
         var deployment = _deploymentRepository.GetByStackName(new EnvironmentId(envGuid), stackName);
-        if (deployment != null && deployment.Status != Domain.Deployment.Deployments.DeploymentStatus.Removed)
+        if (deployment != null)
         {
-            deployment.MarkAsRemoved();
-            _deploymentRepository.SaveChanges();
-            _logger.LogInformation(
-                "Marked deployment {DeploymentId} (stack: {StackName}) as removed without Docker removal",
-                deployment.Id, stackName);
+            if (deployment.Status != Domain.Deployment.Deployments.DeploymentStatus.Removed)
+            {
+                deployment.MarkAsRemoved();
+                _deploymentRepository.SaveChanges();
+                _logger.LogInformation(
+                    "Marked deployment {DeploymentId} (stack: {StackName}) as removed without Docker removal",
+                    deployment.Id, stackName);
+            }
+
+            _healthSnapshotRepository.RemoveForDeployment(deployment.Id);
+            _logger.LogInformation("Removed health snapshots for deployment {DeploymentId}", deployment.Id);
         }
 
         return Task.CompletedTask;

--- a/tests/ReadyStackGo.IntegrationTests/DataAccess/HealthSnapshotRepositoryIntegrationTests.cs
+++ b/tests/ReadyStackGo.IntegrationTests/DataAccess/HealthSnapshotRepositoryIntegrationTests.cs
@@ -7,7 +7,6 @@ using ReadyStackGo.Domain.Deployment.Environments;
 using ReadyStackGo.Domain.Deployment.Health;
 using ReadyStackGo.Infrastructure.DataAccess.Repositories;
 using ReadyStackGo.IntegrationTests.Infrastructure;
-using UserId = ReadyStackGo.Domain.Deployment.UserId;
 
 /// <summary>
 /// Integration tests for HealthSnapshotRepository with real SQLite database.
@@ -27,20 +26,6 @@ public class HealthSnapshotRepositoryIntegrationTests : IDisposable
     }
 
     public void Dispose() => _fixture.Dispose();
-
-    private void AddActiveDeployment(DeploymentId deploymentId, EnvironmentId? environmentId = null)
-    {
-        var deployment = Deployment.StartInstallation(
-            deploymentId,
-            environmentId ?? _envId,
-            "stack-id",
-            "stack-name",
-            "rsgo-stack-name",
-            UserId.NewId());
-        deployment.MarkAsRunning();
-        _fixture.Context.Set<Deployment>().Add(deployment);
-        _fixture.Context.SaveChanges();
-    }
 
     private HealthSnapshot CreateSnapshot(
         string stackName,
@@ -207,8 +192,6 @@ public class HealthSnapshotRepositoryIntegrationTests : IDisposable
         // Arrange
         var deployment1Id = DeploymentId.NewId();
         var deployment2Id = DeploymentId.NewId();
-        AddActiveDeployment(deployment1Id);
-        AddActiveDeployment(deployment2Id);
 
         // Add older snapshot for deployment 1
         var snapshot1Old = CreateSnapshot("stack-1", deployment1Id);
@@ -237,20 +220,13 @@ public class HealthSnapshotRepositoryIntegrationTests : IDisposable
     }
 
     [Fact]
-    public void GetLatestForEnvironment_ShouldExcludeRemovedDeployments()
+    public void GetLatestForEnvironment_ShouldNotReturnSnapshotsAfterRemoveForDeployment()
     {
+        // When a deployment is removed, DeploymentService calls RemoveForDeployment.
+        // After that, GetLatestForEnvironment must not return those snapshots.
         // Arrange
         var activeDeploymentId = DeploymentId.NewId();
         var removedDeploymentId = DeploymentId.NewId();
-        AddActiveDeployment(activeDeploymentId);
-
-        // Removed deployment: create, complete, then mark removed
-        var removedDeployment = Deployment.StartInstallation(
-            removedDeploymentId, _envId, "stack-id", "stack-name", "rsgo-stack-name", UserId.NewId());
-        removedDeployment.MarkAsRunning();
-        removedDeployment.MarkAsRemoved();
-        _fixture.Context.Set<Deployment>().Add(removedDeployment);
-        _fixture.Context.SaveChanges();
 
         var snapshotActive = CreateSnapshot("active-stack", activeDeploymentId);
         _repository.Add(snapshotActive);
@@ -258,7 +234,9 @@ public class HealthSnapshotRepositoryIntegrationTests : IDisposable
         _repository.Add(snapshotRemoved);
         _repository.SaveChanges();
 
-        // Act
+        // Act — simulate what DeploymentService does when a deployment is removed
+        _repository.RemoveForDeployment(removedDeploymentId);
+
         var results = _repository.GetLatestForEnvironment(_envId).ToList();
 
         // Assert
@@ -283,8 +261,6 @@ public class HealthSnapshotRepositoryIntegrationTests : IDisposable
         var otherEnvId = EnvironmentId.NewId();
         var deployment1Id = DeploymentId.NewId();
         var deployment2Id = DeploymentId.NewId();
-        AddActiveDeployment(deployment1Id, _envId);
-        AddActiveDeployment(deployment2Id, otherEnvId);
 
         var snapshot1 = CreateSnapshot("stack-1", deployment1Id);
         _repository.Add(snapshot1);
@@ -398,6 +374,53 @@ public class HealthSnapshotRepositoryIntegrationTests : IDisposable
         _repository.SaveChanges();
 
         // Assert
+        using var verifyContext = _fixture.CreateNewContext();
+        verifyContext.HealthSnapshots.Should().HaveCount(1);
+    }
+
+    #endregion
+
+    #region RemoveForDeployment
+
+    [Fact]
+    public void RemoveForDeployment_ShouldDeleteAllSnapshotsForDeployment()
+    {
+        // Arrange
+        var deploymentId = DeploymentId.NewId();
+        var otherId = DeploymentId.NewId();
+
+        for (int i = 0; i < 3; i++)
+        {
+            _repository.Add(CreateSnapshot("stack", deploymentId));
+        }
+        _repository.Add(CreateSnapshot("other", otherId));
+        _repository.SaveChanges();
+
+        // Act
+        _repository.RemoveForDeployment(deploymentId);
+
+        // Assert
+        using var verifyContext = _fixture.CreateNewContext();
+        verifyContext.HealthSnapshots
+            .Where(h => h.DeploymentId == deploymentId)
+            .Should().BeEmpty();
+        verifyContext.HealthSnapshots
+            .Where(h => h.DeploymentId == otherId)
+            .Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void RemoveForDeployment_ShouldBeNoOpForNonExistentDeployment()
+    {
+        // Arrange
+        var deploymentId = DeploymentId.NewId();
+        _repository.Add(CreateSnapshot("stack", DeploymentId.NewId()));
+        _repository.SaveChanges();
+
+        // Act — should not throw
+        _repository.RemoveForDeployment(deploymentId);
+
+        // Assert — other snapshots untouched
         using var verifyContext = _fixture.CreateNewContext();
         verifyContext.HealthSnapshots.Should().HaveCount(1);
     }


### PR DESCRIPTION
## Summary

- Add `RemoveForDeployment(DeploymentId)` to `IHealthSnapshotRepository` — deletes all snapshots for a deployment via direct SQL DELETE
- `DeploymentService` now calls `RemoveForDeployment` in both `RemoveDeploymentAsync` and `MarkDeploymentAsRemovedAsync`
- Revert the JOIN in `GetLatestForEnvironment` — no longer needs to filter by deployment status since stale snapshots are cleaned up at the source
- Update integration tests: `ShouldExcludeRemovedDeployments` now tests via `RemoveForDeployment` directly; add `RemoveForDeployment` test section

## Why

The previous fix (v0.36.8) added an `INNER JOIN "Deployments"` to every `GetLatestForEnvironment` call to exclude snapshots from removed deployments. This is unnecessary overhead on every container list request. The correct fix is to delete snapshots when a deployment is removed, so the read path stays simple.