### PR TITLE
Add container control documentation and landing page highlight

### DIFF
--- a/src/ReadyStackGo.PublicWeb/src/components/Features.astro
+++ b/src/ReadyStackGo.PublicWeb/src/components/Features.astro
@@ -69,6 +69,13 @@ const highlightedFeatures = [
 		badge: 'NEW',
 		link: `/${lang}/docs/product-redeploy`,
 	},
+	{
+		icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.636 18.364a9 9 0 010-12.728m12.728 0a9 9 0 010 12.728M12 8v4m0 4h.01M12 3a9 9 0 100 18A9 9 0 0012 3z"></path>`,
+		titleKey: 'features.containercontrol.title' as const,
+		descKey: 'features.containercontrol.desc' as const,
+		badge: 'NEW',
+		link: `/${lang}/docs/container-control`,
+	},
 ];
 
 const features = [

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/container-control.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/container-control.md
@@ -1,0 +1,128 @@
+---
+title: Container stoppen & neustarten
+description: Container eines Product Deployments gezielt stoppen, neustarten oder wiederherstellen — mit Bestätigungsscreen und Echtzeit-Fortschritt.
+---
+
+**Container Control** ermöglicht es, die Docker-Container eines Product Deployments gezielt zu stoppen oder neu zu starten — ohne das Deployment zu entfernen. Alle Aktionen durchlaufen einen Bestätigungsscreen und zeigen den Fortschritt in Echtzeit.
+
+## Übersicht
+
+| Aktion | Beschreibung |
+|--------|-------------|
+| **Stop Containers** | Alle Container des Produkts stoppen (Deployment bleibt erhalten) |
+| **Restart Containers** | Gestoppte Container neu starten (Restore-Funktion) |
+
+---
+
+## Schritt für Schritt: Container stoppen
+
+### Schritt 1: Product Deployment Detail
+
+Öffne die Detailseite eines laufenden Product Deployments. Im Status **Running** oder **PartiallyRunning** sind die Links **Stop Containers** und **Restart Containers** sichtbar.
+
+![Product Deployment Detail mit Stop/Restart-Buttons](/images/docs/container-control-01-buttons.png)
+
+---
+
+### Schritt 2: Stop-Bestätigung
+
+Ein Klick auf **Stop Containers** öffnet den Bestätigungsscreen:
+
+- **Product Details** — Name, Version, Environment
+- **Stacks to stop** — Liste aller Stacks mit Service-Anzahl
+- **Cancel** — zurück zur Deployment-Detailseite
+- **Stop All Containers** — startet den Stop-Vorgang
+
+![Stop Containers Bestätigungsscreen](/images/docs/container-control-02-stop-confirm.png)
+
+:::note[Kein Datenverlust]
+Beim Stoppen werden nur die Container angehalten. Das Deployment und alle Konfigurationen bleiben erhalten. Container können jederzeit über **Restart Containers** wieder gestartet werden.
+:::
+
+---
+
+### Schritt 3: Stop-Fortschritt
+
+Während des Stoppens zeigt die Seite einen Fortschritts-Spinner.
+
+![Container Stop in progress](/images/docs/container-control-03-stop-loading.png)
+
+---
+
+### Schritt 4: Stop-Ergebnis
+
+Nach Abschluss erscheint das Ergebnis mit dem Status jedes Stacks.
+
+![Container Stop Ergebnis](/images/docs/container-control-04-stop-result.png)
+
+**Erfolgreich gestoppt:**
+- Heading: „Containers Stopped Successfully!"
+- Liste aller Stacks mit Ergebnis
+
+**Mit Fehlern:**
+- Heading: „Stop Completed with Errors"
+- Fehlermeldungen pro Stack
+
+---
+
+### Schritt 5: Stopped-Status im Deployment
+
+Nach dem Stoppen zeigt die Deployment-Detailseite den Status **Stopped**.
+
+![Product Deployment im Stopped-Status](/images/docs/container-control-05-stopped-status.png)
+
+Von hier aus kann das Produkt über **Restart Containers** wieder gestartet werden.
+
+---
+
+## Schritt für Schritt: Container neustarten
+
+### Schritt 1: Restart-Bestätigung
+
+Über **Restart Containers** (auf der Deployment-Detailseite oder direkt über `/restart-product/:id`) öffnet sich der Restart-Bestätigungsscreen:
+
+- **Product Details**
+- **Stacks to restart**
+- **Restart All Containers** — startet die Container neu
+
+![Restart Containers Bestätigungsscreen](/images/docs/container-control-06-restart-confirm.png)
+
+---
+
+### Schritt 2: Restart-Ergebnis
+
+Nach dem Neustart zeigt die Seite das Ergebnis.
+
+![Container Restart Ergebnis](/images/docs/container-control-07-restart-result.png)
+
+**Erfolgreich neugestartet:** Heading „Containers Restarted Successfully!" — das Produkt ist wieder im Status **Running**.
+
+---
+
+## Wann welche Aktion verwenden?
+
+| Szenario | Empfohlene Aktion |
+|----------|-------------------|
+| Wartungsfenster | **Stop** → Wartung → **Restart** |
+| Container hängen | **Restart Containers** |
+| Ressourcen freigeben | **Stop Containers** |
+| Produkt dauerhaft entfernen | [Remove Product](/de/docs/product-remove/) |
+
+---
+
+## API-Endpunkte
+
+| Methode | Endpunkt | Beschreibung | Permission |
+|---------|----------|-------------|------------|
+| `POST` | `/api/environments/{envId}/product-deployments/{id}/stop-containers` | Container stoppen | `Deployments.Update` |
+| `POST` | `/api/environments/{envId}/product-deployments/{id}/restart-containers` | Container neustarten | `Deployments.Update` |
+
+---
+
+## Fehlerbehandlung
+
+| Situation | Verhalten |
+|-----------|-----------|
+| Produkt nicht stoppbar | Fehler-Screen statt Bestätigungsscreen |
+| Einzelner Stack schlägt fehl | Andere Stacks werden weiter gestoppt/gestartet |
+| Bereits gestoppt | `canRestart: false` → Fehler-Screen beim Öffnen von `/restart-product/:id` |

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/index.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/index.md
@@ -18,3 +18,4 @@ Hier finden Sie detaillierte Anleitungen zur Nutzung von ReadyStackGo.
 - [Volume Management](/de/docs/volume-management/) - Docker Volumes verwalten und verwaiste Volumes bereinigen
 - [Container Management](/de/docs/container-management/) - Alle Docker-Container überwachen, steuern und Logs einsehen
 - [Produkt entfernen](/de/docs/product-remove/) - Product Deployment mit allen Stacks und Containern vollständig entfernen
+- [Container stoppen & neustarten](/de/docs/container-control/) - Container eines Produkts stoppen, neustarten oder wiederherstellen

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/container-control.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/container-control.md
@@ -1,0 +1,128 @@
+---
+title: Stop & Restart Containers
+description: Stop, restart, or restore containers of a product deployment — with a confirmation screen and real-time progress.
+---
+
+**Container Control** lets you stop or restart the Docker containers of a product deployment without removing it. All actions go through a confirmation screen and show real-time progress.
+
+## Overview
+
+| Action | Description |
+|--------|-------------|
+| **Stop Containers** | Stop all containers of the product (deployment is retained) |
+| **Restart Containers** | Restart stopped containers (restore function) |
+
+---
+
+## Step by Step: Stop Containers
+
+### Step 1: Product Deployment Detail
+
+Open the detail page of a running product deployment. When the status is **Running** or **PartiallyRunning**, the **Stop Containers** and **Restart Containers** links are visible.
+
+![Product deployment detail with Stop/Restart buttons](/images/docs/container-control-01-buttons.png)
+
+---
+
+### Step 2: Stop Confirmation
+
+Clicking **Stop Containers** opens the confirmation screen:
+
+- **Product Details** — name, version, environment
+- **Stacks to stop** — list of all stacks with service count
+- **Cancel** — returns to the deployment detail page
+- **Stop All Containers** — starts the stop operation
+
+![Stop containers confirmation screen](/images/docs/container-control-02-stop-confirm.png)
+
+:::note[No data loss]
+Stopping only halts the containers. The deployment and all configuration are retained. Containers can be started again at any time via **Restart Containers**.
+:::
+
+---
+
+### Step 3: Stop Progress
+
+While stopping, the page shows a progress spinner.
+
+![Container stop in progress](/images/docs/container-control-03-stop-loading.png)
+
+---
+
+### Step 4: Stop Result
+
+When complete, the result screen shows the status of each stack.
+
+![Container stop result](/images/docs/container-control-04-stop-result.png)
+
+**Successfully stopped:**
+- Heading: "Containers Stopped Successfully!"
+- List of all stacks with result
+
+**With errors:**
+- Heading: "Stop Completed with Errors"
+- Error messages per stack
+
+---
+
+### Step 5: Stopped Status in Deployment
+
+After stopping, the deployment detail page shows **Stopped** status.
+
+![Product deployment in Stopped status](/images/docs/container-control-05-stopped-status.png)
+
+From here the product can be started again via **Restart Containers**.
+
+---
+
+## Step by Step: Restart Containers
+
+### Step 1: Restart Confirmation
+
+Via **Restart Containers** (on the deployment detail page or directly at `/restart-product/:id`) the restart confirmation screen opens:
+
+- **Product Details**
+- **Stacks to restart**
+- **Restart All Containers** — restarts the containers
+
+![Restart containers confirmation screen](/images/docs/container-control-06-restart-confirm.png)
+
+---
+
+### Step 2: Restart Result
+
+After the restart the page shows the result.
+
+![Container restart result](/images/docs/container-control-07-restart-result.png)
+
+**Successfully restarted:** Heading "Containers Restarted Successfully!" — the product is back in **Running** status.
+
+---
+
+## When to Use Which Action
+
+| Scenario | Recommended action |
+|----------|--------------------|
+| Maintenance window | **Stop** → maintenance → **Restart** |
+| Containers are unresponsive | **Restart Containers** |
+| Free up resources | **Stop Containers** |
+| Permanently remove product | [Remove Product](/en/docs/product-remove/) |
+
+---
+
+## API Endpoints
+
+| Method | Endpoint | Description | Permission |
+|--------|----------|-------------|------------|
+| `POST` | `/api/environments/{envId}/product-deployments/{id}/stop-containers` | Stop containers | `Deployments.Update` |
+| `POST` | `/api/environments/{envId}/product-deployments/{id}/restart-containers` | Restart containers | `Deployments.Update` |
+
+---
+
+## Error Handling
+
+| Situation | Behavior |
+|-----------|----------|
+| Product cannot be stopped | Error screen instead of confirmation screen |
+| Individual stack fails | Other stacks continue to be stopped/started |
+| Already stopped | `canRestart: false` → error screen when opening `/restart-product/:id` |

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/index.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/index.md
@@ -18,3 +18,4 @@ Here you'll find detailed guides for using ReadyStackGo.
 - [Volume Management](/en/docs/volume-management/) - Manage Docker Volumes and clean up orphaned volumes
 - [Container Management](/en/docs/container-management/) - Monitor, control, and view logs for all Docker containers
 - [Remove Product](/en/docs/product-remove/) - Completely remove a product deployment with all stacks and containers
+- [Stop & Restart Containers](/en/docs/container-control/) - Stop, restart, or restore containers of a product deployment

--- a/src/ReadyStackGo.PublicWeb/src/i18n/translations.ts
+++ b/src/ReadyStackGo.PublicWeb/src/i18n/translations.ts
@@ -67,6 +67,8 @@ export const translations = {
 		'features.productdeploy.desc': 'Deploye ganze Produkte mit allen Stacks in einem Vorgang — mit Shared Variables und koordiniertem Lifecycle.',
 		'features.redeploy.title': 'Rich Deployment Progress',
 		'features.redeploy.desc': 'Echtzeit-Einblick in jeden Deployment-Schritt — pro Stack, Service und Init-Container.',
+		'features.containercontrol.title': 'Product Container Control',
+		'features.containercontrol.desc': 'Container eines Produkts gezielt stoppen und neu starten — ohne das Deployment zu entfernen.',
 
 		// Feature Pages
 		'featurepage.multistack.subtitle': 'Definiere komplexe Anwendungen mit mehreren Docker Stacks und gemeinsamen Variablen in einem einzigen Manifest.',
@@ -162,6 +164,8 @@ export const translations = {
 		'features.productdeploy.desc': 'Deploy entire products with all stacks in one operation — with shared variables and coordinated lifecycle.',
 		'features.redeploy.title': 'Rich Deployment Progress',
 		'features.redeploy.desc': 'Real-time insight into every deployment step — per stack, service and init container.',
+		'features.containercontrol.title': 'Product Container Control',
+		'features.containercontrol.desc': 'Stop and restart product containers on demand — without removing the deployment.',
 
 		// Feature Pages
 		'featurepage.multistack.subtitle': 'Define complex applications with multiple Docker Stacks and shared variables in a single manifest.',


### PR DESCRIPTION
## Summary

- Add DE + EN documentation for Stop & Restart Containers feature with 7 screenshots
- Covers: stop confirm screen, progress, result, stopped status, restart confirm, restart result
- Register docs in index files for both languages
- Add 'Product Container Control' as highlighted feature on landing page (NEW badge)
- Add `features.containercontrol.*` translation keys in DE + EN
- Reuses screenshots from existing `container-control.spec.ts` (already captured)
- PublicWeb builds to 76 pages with 0 errors

## Test plan

- [x] PublicWeb builds without errors (76 pages)
- [x] DE + EN docs complete with 7 screenshots each
- [x] Landing page shows new highlight feature card
- [x] Translation keys added in both languages