### PR TITLE
Add Custom Distributions feature to landing page and docs

### DIFF
--- a/src/ReadyStackGo.PublicWeb/src/components/Features.astro
+++ b/src/ReadyStackGo.PublicWeb/src/components/Features.astro
@@ -76,6 +76,13 @@ const highlightedFeatures = [
 		badge: 'NEW',
 		link: `/${lang}/docs/container-control`,
 	},
+	{
+		icon: `<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"></path>`,
+		titleKey: 'features.distributions.title' as const,
+		descKey: 'features.distributions.desc' as const,
+		badge: 'NEW',
+		link: `/${lang}/docs/distributions`,
+	},
 ];
 
 const features = [

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/distributions.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/distributions.md
@@ -1,0 +1,126 @@
+---
+title: Custom Distributions
+description: RSGO mit eigenem Corporate Design betreiben — Unternehmen können eine vollständig gebrandete Deployment-Plattform auf Basis von RSGO aufbauen.
+---
+
+**Custom Distributions** ermöglichen es Unternehmen, ReadyStackGo als Basis für eine vollständig gebrandete Deployment-Plattform zu nutzen. Statt ein generisches Tool zu betreiben, entsteht so eine maßgeschneiderte Lösung im eigenen Corporate Design — mit eigenem Logo, eigenen Farben und individuellem Erscheinungsbild.
+
+:::tip[Für Softwareanbieter und Systemintegratoren]
+Custom Distributions sind ideal für Unternehmen, die RSGO als Grundlage für ihr eigenes Produkt nutzen möchten — ohne dabei auf die bewährte Infrastruktur und Funktionalität von RSGO verzichten zu müssen.
+:::
+
+---
+
+## Was ist eine Custom Distribution?
+
+Eine RSGO Distribution ist eine angepasste Version von ReadyStackGo, die:
+
+- **Vollständig gebrandet** ist — eigenes Logo, eigene Farben, eigener Produktname
+- **Technisch identisch** mit RSGO ist — gleiche Kernfunktionalität, gleiche APIs, gleiche Stabilität
+- **Unabhängig deployed** wird — als eigenständiger Docker-Container mit eigenem Image
+
+Das Konzept ist vergleichbar mit Enterprise-Produkten, die auf Open-Source-Basis aufbauen: Die Technologie kommt von RSGO, die Präsentation und das Branding kommen vom Unternehmen.
+
+---
+
+## Architektur
+
+RSGO ist intern als Monorepo mit klar getrennten Packages aufgebaut:
+
+| Package | Beschreibung |
+|---------|-------------|
+| `@rsgo/core` | Gemeinsame Hooks, API-Layer, State Management — unverändert in jeder Distribution |
+| `@rsgo/ui-generic` | React/Tailwind Referenz-Implementation (die Standard-RSGO-Oberfläche) |
+| `@rsgo/ui-[distribution]` | Distributionsspezifische UI auf Basis von `@rsgo/core` — z.B. mit ConsistentUI/Lit |
+
+Eine Distribution implementiert das `IBootstrapper`-Interface aus `@rsgo/core`, um sich in den RSGO-Start-Lifecycle einzuklinken, sowie optional `ISetupWizardDefinitionProvider` für einen angepassten Setup-Wizard.
+
+---
+
+## Warum eine eigene Distribution?
+
+### Für Softwareanbieter
+
+Als Softwareanbieter oder IT-Dienstleister können Sie Ihren Kunden eine professionelle Deployment-Plattform anbieten, die:
+
+- **Ihr Unternehmensdesign** trägt — nicht das von ReadyStackGo
+- **Unter Ihrer Marke** läuft — eigener Produktname, eigenes Logo
+- **Auf bewährter Technologie** basiert — ohne eigene Infrastruktur von Grund auf entwickeln zu müssen
+- **Vollständig Self-Hosted** betrieben werden kann — Kundendaten verlassen nie deren Infrastruktur
+
+### Für große Unternehmen
+
+Unternehmen mit zentraler IT können eine interne Deployment-Plattform betreiben, die:
+
+- **In die CI/CD-Landschaft** integriert ist
+- **Unternehmensrichtlinien** für Branding und UX einhält
+- **Zentral gepflegt** wird und auf RSGO-Updates aufbaut
+
+---
+
+## Setup Wizard anpassen
+
+Jede Distribution kann einen eigenen Setup Wizard definieren. Über `ISetupWizardDefinitionProvider` lassen sich die Schritte und das Erscheinungsbild des ersten Einrichtungsassistenten anpassen — beispielsweise mit Unternehmenslogo, angepassten Texten und distributionsspezifischen Konfigurationsschritten.
+
+---
+
+## Beispiel: AMS Distribution
+
+Die **AMS Distribution** ist ein reales Beispiel für eine Custom Distribution:
+
+- Basiert auf RSGO Core (`@rsgo/core`)
+- Verwendet [ConsistentUI](https://github.com/consistentui/web-components) als Design-System (Lit Web Components)
+- Stellt eine vollständig gebrandete Oberfläche im AMS Corporate Design bereit
+- Wird als eigenständiges Docker-Image gebaut und deployed
+
+---
+
+## Distribution erstellen
+
+Eine neue Distribution basiert auf dem RSGO-Monorepo und implementiert folgende Interfaces:
+
+### 1. `IBootstrapper`
+
+```typescript
+export class MyDistributionBootstrapper implements IBootstrapper {
+  bootstrap(app: Application): void {
+    // Distribution-spezifische Initialisierung
+    // z.B. Theme-Konfiguration, Custom-Components registrieren
+  }
+}
+```
+
+### 2. `ISetupWizardDefinitionProvider` (optional)
+
+```typescript
+export class MySetupWizardProvider implements ISetupWizardDefinitionProvider {
+  getDefinition(): SetupWizardDefinition {
+    return {
+      steps: [
+        // Angepasste Wizard-Schritte
+      ],
+      branding: {
+        logoUrl: '/assets/my-logo.svg',
+        productName: 'My Deployment Platform',
+      },
+    };
+  }
+}
+```
+
+### 3. Docker-Image bauen
+
+Das Distribution-Package wird beim Docker-Build eingebunden. Das resultierende Image enthält RSGO Core, die Distribution-UI und den ASP.NET-Backend — alles in einem Container.
+
+```dockerfile
+FROM rsgo-base AS distribution-build
+# Distribution-spezifische Build-Steps
+COPY packages/ui-my-distribution ./packages/ui-my-distribution
+RUN pnpm build
+```
+
+---
+
+## Interesse an einer eigenen Distribution?
+
+Wenn Sie eine Custom Distribution auf Basis von RSGO aufbauen möchten, melden Sie sich gerne über [GitHub Issues](https://github.com/Wiesenwischer/ReadyStackGo/issues) — wir unterstützen Sie beim Einstieg.

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/index.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/index.md
@@ -19,3 +19,4 @@ Hier finden Sie detaillierte Anleitungen zur Nutzung von ReadyStackGo.
 - [Container Management](/de/docs/container-management/) - Alle Docker-Container überwachen, steuern und Logs einsehen
 - [Produkt entfernen](/de/docs/product-remove/) - Product Deployment mit allen Stacks und Containern vollständig entfernen
 - [Container stoppen & neustarten](/de/docs/container-control/) - Container eines Produkts stoppen, neustarten oder wiederherstellen
+- [Custom Distributions](/de/docs/distributions/) - RSGO mit eigenem Corporate Design betreiben — gebrandete Deployment-Plattform für Unternehmen

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/distributions.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/distributions.md
@@ -1,0 +1,126 @@
+---
+title: Custom Distributions
+description: Run RSGO with your own corporate design — companies can build a fully branded deployment platform on top of RSGO.
+---
+
+**Custom Distributions** allow companies to use ReadyStackGo as the foundation for a fully branded deployment platform. Instead of running a generic tool, you get a tailored solution in your own corporate design — with your logo, your colors, and your individual look and feel.
+
+:::tip[For Software Vendors and System Integrators]
+Custom Distributions are ideal for companies that want to use RSGO as the foundation for their own product — without giving up the proven infrastructure and functionality of RSGO.
+:::
+
+---
+
+## What is a Custom Distribution?
+
+An RSGO Distribution is a customized version of ReadyStackGo that is:
+
+- **Fully branded** — your own logo, colors, and product name
+- **Technically identical** to RSGO — same core functionality, same APIs, same stability
+- **Independently deployed** — as a standalone Docker container with its own image
+
+The concept is similar to enterprise products built on open-source foundations: the technology comes from RSGO, the presentation and branding come from your company.
+
+---
+
+## Architecture
+
+RSGO is built as a monorepo with clearly separated packages:
+
+| Package | Description |
+|---------|-------------|
+| `@rsgo/core` | Shared hooks, API layer, state management — unchanged in every distribution |
+| `@rsgo/ui-generic` | React/Tailwind reference implementation (the standard RSGO interface) |
+| `@rsgo/ui-[distribution]` | Distribution-specific UI based on `@rsgo/core` — e.g. using ConsistentUI/Lit |
+
+A distribution implements the `IBootstrapper` interface from `@rsgo/core` to hook into the RSGO startup lifecycle, and optionally `ISetupWizardDefinitionProvider` for a customized setup wizard.
+
+---
+
+## Why Build Your Own Distribution?
+
+### For Software Vendors
+
+As a software vendor or IT service provider, you can offer your customers a professional deployment platform that:
+
+- **Carries your corporate design** — not ReadyStackGo's
+- **Runs under your brand** — your own product name, your own logo
+- **Is built on proven technology** — without having to develop your own infrastructure from scratch
+- **Can be fully self-hosted** — customer data never leaves their own infrastructure
+
+### For Enterprise Organizations
+
+Companies with centralized IT can operate an internal deployment platform that:
+
+- **Integrates with the CI/CD landscape**
+- **Complies with corporate branding and UX guidelines**
+- **Is centrally maintained** and builds on RSGO updates
+
+---
+
+## Customizing the Setup Wizard
+
+Each distribution can define its own setup wizard. Through `ISetupWizardDefinitionProvider`, the steps and appearance of the initial setup assistant can be customized — for example with a company logo, custom texts, and distribution-specific configuration steps.
+
+---
+
+## Example: AMS Distribution
+
+The **AMS Distribution** is a real-world example of a Custom Distribution:
+
+- Based on RSGO Core (`@rsgo/core`)
+- Uses [ConsistentUI](https://github.com/consistentui/web-components) as the design system (Lit Web Components)
+- Provides a fully branded interface in the AMS corporate design
+- Built and deployed as a standalone Docker image
+
+---
+
+## Creating a Distribution
+
+A new distribution is based on the RSGO monorepo and implements the following interfaces:
+
+### 1. `IBootstrapper`
+
+```typescript
+export class MyDistributionBootstrapper implements IBootstrapper {
+  bootstrap(app: Application): void {
+    // Distribution-specific initialization
+    // e.g. theme configuration, registering custom components
+  }
+}
+```
+
+### 2. `ISetupWizardDefinitionProvider` (optional)
+
+```typescript
+export class MySetupWizardProvider implements ISetupWizardDefinitionProvider {
+  getDefinition(): SetupWizardDefinition {
+    return {
+      steps: [
+        // Customized wizard steps
+      ],
+      branding: {
+        logoUrl: '/assets/my-logo.svg',
+        productName: 'My Deployment Platform',
+      },
+    };
+  }
+}
+```
+
+### 3. Building the Docker Image
+
+The distribution package is included in the Docker build. The resulting image contains RSGO Core, the distribution UI, and the ASP.NET backend — all in a single container.
+
+```dockerfile
+FROM rsgo-base AS distribution-build
+# Distribution-specific build steps
+COPY packages/ui-my-distribution ./packages/ui-my-distribution
+RUN pnpm build
+```
+
+---
+
+## Interested in Your Own Distribution?
+
+If you want to build a Custom Distribution on top of RSGO, feel free to reach out via [GitHub Issues](https://github.com/Wiesenwischer/ReadyStackGo/issues) — we'll help you get started.

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/index.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/index.md
@@ -19,3 +19,4 @@ Here you'll find detailed guides for using ReadyStackGo.
 - [Container Management](/en/docs/container-management/) - Monitor, control, and view logs for all Docker containers
 - [Remove Product](/en/docs/product-remove/) - Completely remove a product deployment with all stacks and containers
 - [Stop & Restart Containers](/en/docs/container-control/) - Stop, restart, or restore containers of a product deployment
+- [Custom Distributions](/en/docs/distributions/) - Run RSGO with your own corporate design — build a branded deployment platform for your company

--- a/src/ReadyStackGo.PublicWeb/src/i18n/translations.ts
+++ b/src/ReadyStackGo.PublicWeb/src/i18n/translations.ts
@@ -69,6 +69,8 @@ export const translations = {
 		'features.redeploy.desc': 'Echtzeit-Einblick in jeden Deployment-Schritt — pro Stack, Service und Init-Container.',
 		'features.containercontrol.title': 'Product Container Control',
 		'features.containercontrol.desc': 'Container eines Produkts gezielt stoppen und neu starten — ohne das Deployment zu entfernen.',
+		'features.distributions.title': 'Custom Distributions',
+		'features.distributions.desc': 'Betreibe RSGO mit deinem eigenen Corporate Design — Unternehmen können eine vollständig gebrandete Deployment-Plattform auf Basis von RSGO aufbauen.',
 
 		// Feature Pages
 		'featurepage.multistack.subtitle': 'Definiere komplexe Anwendungen mit mehreren Docker Stacks und gemeinsamen Variablen in einem einzigen Manifest.',
@@ -166,6 +168,8 @@ export const translations = {
 		'features.redeploy.desc': 'Real-time insight into every deployment step — per stack, service and init container.',
 		'features.containercontrol.title': 'Product Container Control',
 		'features.containercontrol.desc': 'Stop and restart product containers on demand — without removing the deployment.',
+		'features.distributions.title': 'Custom Distributions',
+		'features.distributions.desc': 'Run RSGO with your own corporate design — companies can build a fully branded deployment platform on top of RSGO.',
 
 		// Feature Pages
 		'featurepage.multistack.subtitle': 'Define complex applications with multiple Docker Stacks and shared variables in a single manifest.',


### PR DESCRIPTION
## Summary

- Add **Custom Distributions** highlight tile to the landing page Features section with NEW badge and paint-brush/branding icon
- Add translation keys `features.distributions.title` + `features.distributions.desc` in DE and EN
- Create documentation for both languages explaining the distribution architecture, use cases for software vendors and enterprise organizations, and the `IBootstrapper` / `ISetupWizardDefinitionProvider` interfaces
- Update docs index pages with link to the new distributions guide