### PR TITLE
Update DevStatus to v1.0 coming soon, remove AMS example from distributions docs

### DIFF
--- a/src/ReadyStackGo.PublicWeb/src/components/DevStatus.astro
+++ b/src/ReadyStackGo.PublicWeb/src/components/DevStatus.astro
@@ -7,24 +7,24 @@ const { lang } = Astro.props;
 
 const content = {
   de: {
-    badge: 'Frühe Entwicklungsphase',
-    title: 'Projekt in aktiver Entwicklung',
-    description: 'ReadyStackGo befindet sich aktuell in einer frühen Entwicklungsphase. Es gibt noch keinen offiziellen Release. Die Software kann sich jederzeit ändern und ist noch nicht für den produktiven Einsatz geeignet.',
+    badge: 'v1.0 Release in Vorbereitung',
+    title: 'Version 1.0 kommt bald',
+    description: 'ReadyStackGo befindet sich in der Endphase vor dem ersten offiziellen Release. Die Kernfunktionalität ist stabil und wird aktiv genutzt — v1.0 steht kurz bevor.',
     points: [
-      'Kein stabiler Release verfügbar',
-      'APIs und Features können sich ändern',
-      'Nicht für Produktivumgebungen empfohlen',
+      'Kernfunktionalität vollständig implementiert',
+      'Aktiv in Entwicklung und getestet',
+      'v1.0 Release steht kurz bevor',
       'Feedback und Beiträge sind willkommen',
     ],
   },
   en: {
-    badge: 'Early Development',
-    title: 'Project Under Active Development',
-    description: 'ReadyStackGo is currently in an early development phase. There is no official release yet. The software may change at any time and is not yet suitable for production use.',
+    badge: 'v1.0 Release Coming Soon',
+    title: 'Version 1.0 is Almost Here',
+    description: 'ReadyStackGo is in the final phase before its first official release. The core functionality is stable and actively used — v1.0 is just around the corner.',
     points: [
-      'No stable release available',
-      'APIs and features may change',
-      'Not recommended for production',
+      'Core functionality fully implemented',
+      'Actively developed and tested',
+      'v1.0 release coming soon',
       'Feedback and contributions welcome',
     ],
   },
@@ -33,24 +33,24 @@ const content = {
 const c = content[lang];
 ---
 
-<section class="py-16 bg-warning-50 dark:bg-warning-900/20 border-y border-warning-200 dark:border-warning-800">
+<section class="py-16 bg-brand-50 dark:bg-brand-900/20 border-y border-brand-200 dark:border-brand-800">
   <div class="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
     <div class="text-center">
       <!-- Badge -->
-      <span class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-warning-100 dark:bg-warning-900/40 text-warning-800 dark:text-warning-200 text-sm font-medium mb-6">
+      <span class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-brand-100 dark:bg-brand-900/40 text-brand-800 dark:text-brand-200 text-sm font-medium mb-6">
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
         </svg>
         {c.badge}
       </span>
 
       <!-- Title -->
-      <h2 class="text-2xl sm:text-3xl font-bold text-warning-900 dark:text-warning-100 mb-4">
+      <h2 class="text-2xl sm:text-3xl font-bold text-brand-900 dark:text-brand-100 mb-4">
         {c.title}
       </h2>
 
       <!-- Description -->
-      <p class="text-lg text-warning-800 dark:text-warning-200 max-w-3xl mx-auto mb-8">
+      <p class="text-lg text-brand-800 dark:text-brand-200 max-w-3xl mx-auto mb-8">
         {c.description}
       </p>
 
@@ -58,10 +58,10 @@ const c = content[lang];
       <div class="grid sm:grid-cols-2 gap-4 max-w-2xl mx-auto">
         {c.points.map((point) => (
           <div class="flex items-center gap-3 text-left bg-white/50 dark:bg-gray-800/50 rounded-lg px-4 py-3">
-            <svg class="w-5 h-5 text-warning-600 dark:text-warning-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+            <svg class="w-5 h-5 text-brand-600 dark:text-brand-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path>
             </svg>
-            <span class="text-warning-800 dark:text-warning-200">{point}</span>
+            <span class="text-brand-800 dark:text-brand-200">{point}</span>
           </div>
         ))}
       </div>

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/distributions.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/distributions.md
@@ -64,17 +64,6 @@ Jede Distribution kann einen eigenen Setup Wizard definieren. Über `ISetupWizar
 
 ---
 
-## Beispiel: AMS Distribution
-
-Die **AMS Distribution** ist ein reales Beispiel für eine Custom Distribution:
-
-- Basiert auf RSGO Core (`@rsgo/core`)
-- Verwendet [ConsistentUI](https://github.com/consistentui/web-components) als Design-System (Lit Web Components)
-- Stellt eine vollständig gebrandete Oberfläche im AMS Corporate Design bereit
-- Wird als eigenständiges Docker-Image gebaut und deployed
-
----
-
 ## Distribution erstellen
 
 Eine neue Distribution basiert auf dem RSGO-Monorepo und implementiert folgende Interfaces:

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/distributions.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/distributions.md
@@ -64,17 +64,6 @@ Each distribution can define its own setup wizard. Through `ISetupWizardDefiniti
 
 ---
 
-## Example: AMS Distribution
-
-The **AMS Distribution** is a real-world example of a Custom Distribution:
-
-- Based on RSGO Core (`@rsgo/core`)
-- Uses [ConsistentUI](https://github.com/consistentui/web-components) as the design system (Lit Web Components)
-- Provides a fully branded interface in the AMS corporate design
-- Built and deployed as a standalone Docker image
-
----
-
 ## Creating a Distribution
 
 A new distribution is based on the RSGO monorepo and implements the following interfaces:


### PR DESCRIPTION
- Replace early development warning (yellow) with v1.0 coming soon message (brand blue) with positive bullet points and checkmark icons
- Remove AMS Distribution example section from DE/EN distributions documentation