### PR TITLE
Fix redeploy completing prematurely after first stack

### DIFF
--- a/src/ReadyStackGo.Application/UseCases/Deployments/RedeployProduct/RedeployProductHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/RedeployProduct/RedeployProductHandler.cs
@@ -160,7 +160,7 @@ public class RedeployProductHandler : IRequestHandler<RedeployProductCommand, De
                     stackDeploymentName,
                     mergedVariables,
                     sessionId,
-                    SuppressNotification: false), cancellationToken);
+                    SuppressNotification: true), cancellationToken);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
## Summary

- `RedeployProductHandler` was passing `SuppressNotification: false` to `DeployStackCommand`
- After each stack deployed, `DeployStackHandler` sent `DeploymentCompleted` SignalR event on the shared session ID
- The frontend's `useRedeployProductStore` interprets `DeploymentCompleted` as the entire product redeploy being done → transitions to `success` state after the first stack
- Fixed by reverting to `SuppressNotification: true` — `RedeployProductHandler` already sends its own final `NotifyFinalResultAsync` after all stacks complete
- Per-service progress during each stack (via `progressCallback`) is unaffected by this flag

## Test plan

- [ ] Deploy a product with 2+ stacks
- [ ] Trigger redeploy — all stacks should be processed before success screen appears
- [ ] Verify per-stack progress (spinner, service-level progress) still works during redeploy