### PR TITLE
Fix self-update progress bar jumping back and forth

### DIFF
--- a/src/ReadyStackGo.WebUi/packages/core/src/hooks/useUpdateStore.ts
+++ b/src/ReadyStackGo.WebUi/packages/core/src/hooks/useUpdateStore.ts
@@ -77,7 +77,7 @@ export function useUpdateStore(targetVersion: string): UseUpdateStoreReturn {
     switch (progress.phase) {
       case 'pulling':
         setPhase('pulling');
-        setPullPercent(progress.progressPercent ?? 0);
+        setPullPercent(prev => Math.max(prev, progress.progressPercent ?? 0));
         break;
       case 'creating':
         setPhase('creating');


### PR DESCRIPTION
## Summary

- Ensure pull progress percentage only increases, never decreases
- Docker discovers new layers mid-pull, increasing the total size denominator and causing the percentage to drop temporarily
- Use `Math.max(prev, newValue)` in the React state updater to enforce monotonic progress