### PR TITLE
Update roadmap: add v0.45 release

### DIFF
--- a/docs/Plans/PLAN-licenses-ui.md
+++ b/docs/Plans/PLAN-licenses-ui.md
@@ -30,17 +30,17 @@ Nutzer und Betreiber sollen die lizenzierten Drittanbieter-Pakete (npm + .NET) d
 
 Reihenfolge basierend auf Abhängigkeiten:
 
-- [ ] **Feature 1: License-JSONs in Docker-Image bundeln** — In Dockerfile nach dem `COPY --from=frontend-build` Schritt die JSON-Dateien aus `licenses/` nach `wwwroot/licenses/` kopieren
+- [x] **Feature 1: License-JSONs in Docker-Image bundeln** — In Dockerfile nach dem `COPY --from=frontend-build` Schritt die JSON-Dateien aus `licenses/` nach `wwwroot/licenses/` kopieren
   - Betroffene Dateien: `Dockerfile`
   - Hinweis: `dotnet-licenses.json` muss ggf. per CI-Workflow generiert werden bevor es im Build vorhanden ist
   - Abhängig von: -
 
-- [ ] **Feature 2: Licenses-Seite** — Neue React-Seite `Settings/Licenses/Licenses.tsx`; fetcht die drei JSON-Dateien von `/licenses/*.json`; zeigt alle Pakete mit Name, Version, Lizenztyp, Repository-Link; Suchfeld + Lizenztyp-Filter; Badge mit Paket-Anzahl pro Kategorie (npm WebUI / npm PublicWeb / .NET)
+- [x] **Feature 2: Licenses-Seite** — Neue React-Seite `Settings/Licenses/Licenses.tsx`; fetcht die drei JSON-Dateien von `/licenses/*.json`; zeigt alle Pakete mit Name, Version, Lizenztyp, Repository-Link; Suchfeld + Lizenztyp-Filter; Badge mit Paket-Anzahl pro Kategorie (npm WebUI / npm PublicWeb / .NET)
   - Betroffene Dateien: `src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Settings/Licenses/Licenses.tsx` (neu), `Settings/index.ts` (export)
   - Pattern-Vorlage: `Settings/System/SystemInfo.tsx` für Seiten-Layout
   - Abhängig von: Feature 1
 
-- [ ] **Feature 3: Settings-Integration** — Card in `SettingsIndex.tsx` (Icon: DocsIcon oder ähnliches); Route `/settings/licenses` in `App.tsx`; Import in `apps/rsgo-generic/src/App.tsx`
+- [x] **Feature 3: Settings-Integration** — Card in `SettingsIndex.tsx` (Icon: DocsIcon oder ähnliches); Route `/settings/licenses` in `App.tsx`; Import in `apps/rsgo-generic/src/App.tsx`
   - Betroffene Dateien: `SettingsIndex.tsx`, `apps/rsgo-generic/src/App.tsx`
   - Abhängig von: Feature 2
 
@@ -52,8 +52,8 @@ Reihenfolge basierend auf Abhängigkeiten:
 
 ## Offene Punkte
 
-- [ ] Prüfen ob `dotnet-licenses.json` aktuell im Repo vorhanden ist; ggf. CI-Workflow manuell triggern
-- [ ] Entscheiden ob fehlende JSON-Datei (z.B. dotnet) silently ignoriert wird oder einen Fehler zeigt
+- [x] Prüfen ob `dotnet-licenses.json` aktuell im Repo vorhanden ist — Ja, lokal generiert und committed
+- [x] Entscheiden ob fehlende JSON-Datei (z.B. dotnet) silently ignoriert wird oder einen Fehler zeigt — Silently ignoriert (graceful degradation)
 
 ## Entscheidungen
 

--- a/docs/Reference/Roadmap.md
+++ b/docs/Reference/Roadmap.md
@@ -304,20 +304,18 @@ Release version numbers are assigned when an Epic ships, not during planning.
   - Fix container list showing stale unhealthy status from removed deployments by filtering to active deployments only
 - **v0.44** – Bugfix: Self-Update Progress Jumping (2026-03-13)
   - Fix progress bar jumping back and forth during self-update by enforcing monotonic progress percentage
+- **v0.45** – Third-Party Licenses UI, Documentation Link & CI Fix (2026-03-13)
+  - Settings > Licenses page listing all bundled npm and .NET packages with license types and links
+  - License JSON files (npm-webui, npm-publicweb, dotnet) bundled into Docker image via Dockerfile
+  - Search and filter by license type, category badges with package counts
+  - Sidebar "Documentation" link opening online docs in new tab
+  - Fix CI license generation workflow (migrate from deprecated dotnet-project-licenses to nuget-license)
 
 ---
 
 ## Planned
 
 Epics are listed in priority order. Top = next.
-
-### Epic: Documentation Link
-- Sidebar "Documentation" link opening online docs (readystackgo.pages.dev) in new tab
-
-### Epic: Third-Party Licenses UI
-- Settings > Licenses page listing all bundled npm and .NET packages with license types and links
-- License JSON files (npm-webui, npm-publicweb, dotnet) bundled into Docker image via Dockerfile
-- Search and filter by license type, grouped by category
 
 ### Epic: OCI Stack Bundles
 


### PR DESCRIPTION
## Summary
- Add v0.45 release entry (Third-Party Licenses UI, Documentation Link, CI license workflow fix)
- Remove completed epics (Documentation Link, Third-Party Licenses UI) from Planned section
- Mark all features and open points in PLAN-licenses-ui.md as completed
- Supersedes #252