### PR TITLE
Replace health history chart with status transition step chart

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/Health/GetHealthTransitionsEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Health/GetHealthTransitionsEndpoint.cs
@@ -1,0 +1,48 @@
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using ReadyStackGo.Api.Authorization;
+using ReadyStackGo.Application.UseCases.Health;
+using ReadyStackGo.Application.UseCases.Health.GetHealthTransitions;
+
+namespace ReadyStackGo.API.Endpoints.Health;
+
+/// <summary>
+/// GET /api/health/deployments/{deploymentId}/transitions
+/// Get health status transitions for a specific deployment.
+/// Returns only snapshots where the overall status changed.
+/// </summary>
+[RequirePermission("Health", "Read")]
+public class GetHealthTransitionsEndpoint : Endpoint<GetHealthTransitionsRequest, GetHealthTransitionsResponse>
+{
+    private readonly IMediator _mediator;
+
+    public GetHealthTransitionsEndpoint(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Get("/api/health/deployments/{deploymentId}/transitions");
+        PreProcessor<RbacPreProcessor<GetHealthTransitionsRequest>>();
+    }
+
+    public override async Task HandleAsync(GetHealthTransitionsRequest req, CancellationToken ct)
+    {
+        var query = new GetHealthTransitionsQuery(req.DeploymentId);
+        var response = await _mediator.Send(query, ct);
+
+        if (!response.Success)
+        {
+            ThrowError(response.Message ?? "Deployment not found", StatusCodes.Status404NotFound);
+        }
+
+        Response = response;
+    }
+}
+
+public class GetHealthTransitionsRequest
+{
+    public string DeploymentId { get; set; } = string.Empty;
+}

--- a/src/ReadyStackGo.Application/Services/IHealthMonitoringService.cs
+++ b/src/ReadyStackGo.Application/Services/IHealthMonitoringService.cs
@@ -53,6 +53,13 @@ public interface IHealthMonitoringService
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets health status transitions for a deployment (only snapshots where status changed).
+    /// </summary>
+    Task<IEnumerable<HealthSnapshot>> GetHealthTransitionsAsync(
+        DeploymentId deploymentId,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Updates the operation mode for a deployment.
     /// </summary>
     Task UpdateOperationModeAsync(

--- a/src/ReadyStackGo.Application/Services/Impl/HealthMonitoringService.cs
+++ b/src/ReadyStackGo.Application/Services/Impl/HealthMonitoringService.cs
@@ -127,6 +127,14 @@ public class HealthMonitoringService : IHealthMonitoringService
         return Task.FromResult(history);
     }
 
+    public Task<IEnumerable<HealthSnapshot>> GetHealthTransitionsAsync(
+        DeploymentId deploymentId,
+        CancellationToken cancellationToken = default)
+    {
+        var transitions = _healthSnapshotRepository.GetTransitions(deploymentId);
+        return Task.FromResult(transitions);
+    }
+
     public Task UpdateOperationModeAsync(
         DeploymentId deploymentId,
         OperationMode newMode,

--- a/src/ReadyStackGo.Application/UseCases/Health/GetHealthTransitions/GetHealthTransitionsHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Health/GetHealthTransitions/GetHealthTransitionsHandler.cs
@@ -1,0 +1,54 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Domain.Deployment.Deployments;
+
+namespace ReadyStackGo.Application.UseCases.Health.GetHealthTransitions;
+
+/// <summary>
+/// Handler for GetHealthTransitionsQuery.
+/// Returns only the snapshots where overall health status changed.
+/// </summary>
+public class GetHealthTransitionsHandler
+    : IRequestHandler<GetHealthTransitionsQuery, GetHealthTransitionsResponse>
+{
+    private readonly IHealthMonitoringService _healthMonitoringService;
+    private readonly ILogger<GetHealthTransitionsHandler> _logger;
+
+    public GetHealthTransitionsHandler(
+        IHealthMonitoringService healthMonitoringService,
+        ILogger<GetHealthTransitionsHandler> logger)
+    {
+        _healthMonitoringService = healthMonitoringService;
+        _logger = logger;
+    }
+
+    public async Task<GetHealthTransitionsResponse> Handle(
+        GetHealthTransitionsQuery request,
+        CancellationToken cancellationToken)
+    {
+        _logger.LogDebug(
+            "Getting health transitions for deployment {DeploymentId}",
+            request.DeploymentId);
+
+        if (!Guid.TryParse(request.DeploymentId, out var deploymentGuid))
+        {
+            return GetHealthTransitionsResponse.Failure("Invalid deployment ID format");
+        }
+
+        var deploymentId = DeploymentId.FromGuid(deploymentGuid);
+
+        var transitions = await _healthMonitoringService.GetHealthTransitionsAsync(
+            deploymentId, cancellationToken);
+
+        var transitionDtos = transitions.Select(snapshot => new HealthTransitionDto
+        {
+            OverallStatus = snapshot.Overall.Name,
+            HealthyServices = snapshot.Self.HealthyCount,
+            TotalServices = snapshot.Self.TotalCount,
+            CapturedAtUtc = snapshot.CapturedAtUtc,
+        }).ToList();
+
+        return GetHealthTransitionsResponse.Ok(transitionDtos);
+    }
+}

--- a/src/ReadyStackGo.Application/UseCases/Health/GetHealthTransitions/GetHealthTransitionsQuery.cs
+++ b/src/ReadyStackGo.Application/UseCases/Health/GetHealthTransitions/GetHealthTransitionsQuery.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace ReadyStackGo.Application.UseCases.Health.GetHealthTransitions;
+
+/// <summary>
+/// Query to get health status transitions for a specific deployment.
+/// </summary>
+public record GetHealthTransitionsQuery(
+    string DeploymentId) : IRequest<GetHealthTransitionsResponse>;

--- a/src/ReadyStackGo.Application/UseCases/Health/HealthDtos.cs
+++ b/src/ReadyStackGo.Application/UseCases/Health/HealthDtos.cs
@@ -253,3 +253,30 @@ public class GetHealthHistoryResponse
     public static GetHealthHistoryResponse Failure(string message) =>
         new() { Success = false, Message = message };
 }
+
+/// <summary>
+/// Lightweight DTO for health status transitions (only fields needed for step chart).
+/// </summary>
+public class HealthTransitionDto
+{
+    public required string OverallStatus { get; init; }
+    public required int HealthyServices { get; init; }
+    public required int TotalServices { get; init; }
+    public required DateTime CapturedAtUtc { get; init; }
+}
+
+/// <summary>
+/// Response for getting health transitions.
+/// </summary>
+public class GetHealthTransitionsResponse
+{
+    public bool Success { get; set; }
+    public string? Message { get; set; }
+    public List<HealthTransitionDto> Transitions { get; set; } = new();
+
+    public static GetHealthTransitionsResponse Ok(List<HealthTransitionDto> transitions) =>
+        new() { Success = true, Transitions = transitions };
+
+    public static GetHealthTransitionsResponse Failure(string message) =>
+        new() { Success = false, Message = message };
+}

--- a/src/ReadyStackGo.Domain/Deployment/Health/IHealthSnapshotRepository.cs
+++ b/src/ReadyStackGo.Domain/Deployment/Health/IHealthSnapshotRepository.cs
@@ -39,6 +39,12 @@ public interface IHealthSnapshotRepository
     IEnumerable<HealthSnapshot> GetHistory(DeploymentId deploymentId, int limit = 10);
 
     /// <summary>
+    /// Gets only the snapshots where overall health status changed (transitions),
+    /// plus the first and latest snapshot. Ordered oldest first.
+    /// </summary>
+    IEnumerable<HealthSnapshot> GetTransitions(DeploymentId deploymentId);
+
+    /// <summary>
     /// Removes all snapshots for a specific deployment.
     /// Called when a deployment is removed to avoid stale health data.
     /// </summary>

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Repositories/HealthSnapshotRepository.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Repositories/HealthSnapshotRepository.cs
@@ -85,6 +85,35 @@ public class HealthSnapshotRepository : IHealthSnapshotRepository
             .ToList();
     }
 
+    public IEnumerable<HealthSnapshot> GetTransitions(DeploymentId deploymentId)
+    {
+        var id = deploymentId.Value.ToString().ToUpperInvariant();
+
+        // Use LAG() window function to find rows where OverallStatus changed.
+        // Also include first snapshot (PrevStatus IS NULL) and latest (RowDesc = 1).
+        return _context.HealthSnapshots
+            .FromSqlRaw(
+                """
+                WITH ranked AS (
+                    SELECT "Id",
+                           "OverallStatus",
+                           LAG("OverallStatus") OVER (ORDER BY "CapturedAtUtc") AS "PrevStatus",
+                           ROW_NUMBER() OVER (ORDER BY "CapturedAtUtc" DESC) AS "RowDesc"
+                    FROM "HealthSnapshots"
+                    WHERE UPPER("DeploymentId") = {0}
+                )
+                SELECT h.*
+                FROM "HealthSnapshots" h
+                INNER JOIN ranked r ON h."Id" = r."Id"
+                WHERE r."PrevStatus" IS NULL
+                   OR r."OverallStatus" != r."PrevStatus"
+                   OR r."RowDesc" = 1
+                ORDER BY h."CapturedAtUtc" ASC
+                """,
+                id)
+            .ToList();
+    }
+
     public int RemoveOlderThan(TimeSpan age)
     {
         var cutoff = DateTime.UtcNow - age;

--- a/src/ReadyStackGo.WebUi/packages/core/src/api/health.ts
+++ b/src/ReadyStackGo.WebUi/packages/core/src/api/health.ts
@@ -131,6 +131,19 @@ interface HistoryResponse {
   history: StackHealthSummaryDto[];
 }
 
+export interface HealthTransitionDto {
+  overallStatus: string;
+  healthyServices: number;
+  totalServices: number;
+  capturedAtUtc: string;
+}
+
+interface TransitionsResponse {
+  success: boolean;
+  message?: string;
+  transitions: HealthTransitionDto[];
+}
+
 // API functions
 export async function getStackHealth(
   environmentId: string,
@@ -198,6 +211,17 @@ export async function getHealthHistory(
     throw new Error(response.message || 'Failed to get health history');
   }
   return response.history;
+}
+
+export async function getHealthTransitions(
+  deploymentId: string
+): Promise<HealthTransitionDto[]> {
+  const url = `/api/health/deployments/${deploymentId}/transitions`;
+  const response = await apiGet<TransitionsResponse>(url);
+  if (!response.success) {
+    throw new Error(response.message || 'Failed to get health transitions');
+  }
+  return response.transitions;
 }
 
 // UI Presentation helpers - maps status/mode to visual presentation

--- a/src/ReadyStackGo.WebUi/packages/core/src/hooks/useHealthTransitionsStore.ts
+++ b/src/ReadyStackGo.WebUi/packages/core/src/hooks/useHealthTransitionsStore.ts
@@ -1,0 +1,42 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getHealthTransitions, type HealthTransitionDto } from '../api/health';
+
+export interface UseHealthTransitionsStoreReturn {
+  transitions: HealthTransitionDto[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+export function useHealthTransitionsStore(
+  deploymentId: string | undefined,
+): UseHealthTransitionsStoreReturn {
+  const [transitions, setTransitions] = useState<HealthTransitionDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTransitions = useCallback(async () => {
+    if (!deploymentId) {
+      setTransitions([]);
+      setLoading(false);
+      return;
+    }
+
+    try {
+      setLoading(true);
+      const data = await getHealthTransitions(deploymentId);
+      setTransitions(data);
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load transitions');
+    } finally {
+      setLoading(false);
+    }
+  }, [deploymentId]);
+
+  useEffect(() => {
+    fetchTransitions();
+  }, [fetchTransitions]);
+
+  return { transitions, loading, error, refresh: fetchTransitions };
+}

--- a/src/ReadyStackGo.WebUi/packages/core/src/index.ts
+++ b/src/ReadyStackGo.WebUi/packages/core/src/index.ts
@@ -89,6 +89,7 @@ export { useHealthWidgetStore, type UseHealthWidgetStoreReturn, type ProductHeal
 export { useSetupHintStore, type UseSetupHintStoreReturn } from './hooks/useSetupHintStore';
 export { useConnectionTestStore, type UseConnectionTestStoreReturn, type TestConnectionResponse } from './hooks/useConnectionTestStore';
 export { useHealthHistoryStore, type UseHealthHistoryStoreReturn } from './hooks/useHealthHistoryStore';
+export { useHealthTransitionsStore, type UseHealthTransitionsStoreReturn } from './hooks/useHealthTransitionsStore';
 export { useSetupOrganizationStore, type UseSetupOrganizationStoreReturn } from './hooks/useSetupOrganizationStore';
 
 // Services

--- a/src/ReadyStackGo.WebUi/packages/ui-generic/src/components/health/HealthHistoryChart.tsx
+++ b/src/ReadyStackGo.WebUi/packages/ui-generic/src/components/health/HealthHistoryChart.tsx
@@ -1,13 +1,15 @@
 import {
-  AreaChart,
-  Area,
+  LineChart,
+  Line,
   XAxis,
   YAxis,
   Tooltip,
   ResponsiveContainer,
   CartesianGrid,
+  ReferenceArea,
 } from 'recharts';
-import { useHealthHistoryStore } from '@rsgo/core';
+import { useHealthTransitionsStore } from '@rsgo/core';
+import type { HealthTransitionDto } from '@rsgo/core';
 
 interface HealthHistoryChartProps {
   deploymentId: string;
@@ -15,24 +17,44 @@ interface HealthHistoryChartProps {
 }
 
 interface ChartDataPoint {
-  time: string;
   timestamp: number;
   healthyPercent: number;
   status: string;
   statusLabel: string;
+  healthyServices: number;
+  totalServices: number;
 }
 
+const STATUS_COLORS: Record<string, string> = {
+  healthy: '#22c55e',
+  degraded: '#eab308',
+  unhealthy: '#ef4444',
+};
+
 function getStatusColor(status: string) {
-  switch (status.toLowerCase()) {
-    case 'healthy':
-      return '#22c55e'; // green-500
-    case 'degraded':
-      return '#eab308'; // yellow-500
-    case 'unhealthy':
-      return '#ef4444'; // red-500
-    default:
-      return '#6b7280'; // gray-500
+  return STATUS_COLORS[status.toLowerCase()] ?? '#6b7280';
+}
+
+function formatDuration(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainMinutes = minutes % 60;
+  if (hours < 24) return remainMinutes > 0 ? `${hours}h ${remainMinutes}m` : `${hours}h`;
+  const days = Math.floor(hours / 24);
+  const remainHours = hours % 24;
+  return remainHours > 0 ? `${days}d ${remainHours}h` : `${days}d`;
+}
+
+function formatTimestamp(timestamp: number, rangeMs: number): string {
+  const date = new Date(timestamp);
+  if (rangeMs > 24 * 60 * 60 * 1000) {
+    return date.toLocaleDateString([], { day: '2-digit', month: '2-digit' }) +
+      ' ' + date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   }
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
 function CustomTooltip({ active, payload }: { active?: boolean; payload?: Array<{ payload: ChartDataPoint }> }) {
@@ -41,10 +63,13 @@ function CustomTooltip({ active, payload }: { active?: boolean; payload?: Array<
     return (
       <div className="rounded-lg border border-gray-200 bg-white p-3 shadow-lg dark:border-gray-700 dark:bg-gray-800">
         <p className="text-sm font-medium text-gray-900 dark:text-white">
-          {data.time}
+          {new Date(data.timestamp).toLocaleString([], {
+            day: '2-digit', month: '2-digit', year: 'numeric',
+            hour: '2-digit', minute: '2-digit', second: '2-digit',
+          })}
         </p>
         <p className="text-sm text-gray-600 dark:text-gray-400">
-          Health: {data.healthyPercent}%
+          {data.healthyServices}/{data.totalServices} services healthy ({data.healthyPercent}%)
         </p>
         <p
           className="text-sm font-medium"
@@ -58,11 +83,52 @@ function CustomTooltip({ active, payload }: { active?: boolean; payload?: Array<
   return null;
 }
 
+function buildChartData(transitions: HealthTransitionDto[]): ChartDataPoint[] {
+  if (transitions.length === 0) return [];
+
+  const points: ChartDataPoint[] = transitions.map((t) => ({
+    timestamp: new Date(t.capturedAtUtc).getTime(),
+    healthyPercent:
+      t.totalServices > 0
+        ? Math.round((t.healthyServices / t.totalServices) * 100)
+        : 0,
+    status: t.overallStatus,
+    statusLabel:
+      t.overallStatus.charAt(0).toUpperCase() + t.overallStatus.slice(1),
+    healthyServices: t.healthyServices,
+    totalServices: t.totalServices,
+  }));
+
+  // Add a "now" point extending the last status to current time
+  const last = points[points.length - 1];
+  const now = Date.now();
+  if (now - last.timestamp > 30_000) {
+    points.push({ ...last, timestamp: now });
+  }
+
+  return points;
+}
+
+/** Build colored background areas between transitions */
+function buildReferenceAreas(chartData: ChartDataPoint[]) {
+  if (chartData.length < 2) return [];
+
+  const areas: Array<{ x1: number; x2: number; color: string }> = [];
+  for (let i = 0; i < chartData.length - 1; i++) {
+    areas.push({
+      x1: chartData[i].timestamp,
+      x2: chartData[i + 1].timestamp,
+      color: getStatusColor(chartData[i].status),
+    });
+  }
+  return areas;
+}
+
 export default function HealthHistoryChart({
   deploymentId,
   className = '',
 }: HealthHistoryChartProps) {
-  const { history, loading, error } = useHealthHistoryStore(deploymentId);
+  const { transitions, loading, error } = useHealthTransitionsStore(deploymentId);
 
   if (loading) {
     return (
@@ -86,7 +152,7 @@ export default function HealthHistoryChart({
     );
   }
 
-  if (history.length === 0) {
+  if (transitions.length === 0) {
     return (
       <div className={`rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-800 dark:bg-white/[0.03] ${className}`}>
         <h4 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
@@ -99,32 +165,22 @@ export default function HealthHistoryChart({
     );
   }
 
-  // Transform data for the chart
-  const chartData: ChartDataPoint[] = history
-    .map((snapshot) => {
-      const healthyPercent =
-        snapshot.totalServices > 0
-          ? Math.round((snapshot.healthyServices / snapshot.totalServices) * 100)
-          : 0;
+  const chartData = buildChartData(transitions);
+  const referenceAreas = buildReferenceAreas(chartData);
+  const rangeMs = chartData.length >= 2
+    ? chartData[chartData.length - 1].timestamp - chartData[0].timestamp
+    : 0;
 
-      return {
-        time: new Date(snapshot.capturedAtUtc).toLocaleTimeString([], {
-          hour: '2-digit',
-          minute: '2-digit',
-        }),
-        timestamp: new Date(snapshot.capturedAtUtc).getTime(),
-        healthyPercent,
-        status: snapshot.overallStatus,
-        statusLabel:
-          snapshot.overallStatus.charAt(0).toUpperCase() +
-          snapshot.overallStatus.slice(1),
-      };
-    })
-    .reverse(); // Oldest first for chart
+  // Count actual status changes (excluding first baseline and "now" extension)
+  const transitionCount = Math.max(0, transitions.length - 1);
 
-  // Determine chart color based on current (latest) status
-  const currentStatus = history[0]?.overallStatus || 'unknown';
-  const chartColor = getStatusColor(currentStatus);
+  const firstDate = new Date(chartData[0].timestamp);
+  const sinceLabel = rangeMs > 24 * 60 * 60 * 1000
+    ? firstDate.toLocaleDateString([], { day: '2-digit', month: '2-digit', year: 'numeric' })
+    : firstDate.toLocaleString([], {
+        day: '2-digit', month: '2-digit',
+        hour: '2-digit', minute: '2-digit',
+      });
 
   return (
     <div className={`rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-800 dark:bg-white/[0.03] ${className}`}>
@@ -150,19 +206,16 @@ export default function HealthHistoryChart({
 
       <div className="h-48">
         <ResponsiveContainer width="100%" height="100%">
-          <AreaChart
+          <LineChart
             data={chartData}
             margin={{ top: 5, right: 5, left: -20, bottom: 5 }}
           >
-            <defs>
-              <linearGradient id="healthGradient" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor={chartColor} stopOpacity={0.3} />
-                <stop offset="95%" stopColor={chartColor} stopOpacity={0} />
-              </linearGradient>
-            </defs>
             <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
             <XAxis
-              dataKey="time"
+              dataKey="timestamp"
+              type="number"
+              domain={['dataMin', 'dataMax']}
+              tickFormatter={(value) => formatTimestamp(value, rangeMs)}
               tick={{ fontSize: 10, fill: '#9ca3af' }}
               tickLine={false}
               axisLine={false}
@@ -175,19 +228,30 @@ export default function HealthHistoryChart({
               tickFormatter={(value) => `${value}%`}
             />
             <Tooltip content={<CustomTooltip />} />
-            <Area
-              type="monotone"
+            {referenceAreas.map((area, i) => (
+              <ReferenceArea
+                key={i}
+                x1={area.x1}
+                x2={area.x2}
+                fill={area.color}
+                fillOpacity={0.1}
+              />
+            ))}
+            <Line
+              type="stepAfter"
               dataKey="healthyPercent"
-              stroke={chartColor}
+              stroke="#6b7280"
               strokeWidth={2}
-              fill="url(#healthGradient)"
+              dot={{ r: 4, fill: '#fff', stroke: '#6b7280', strokeWidth: 2 }}
+              activeDot={{ r: 6 }}
             />
-          </AreaChart>
+          </LineChart>
         </ResponsiveContainer>
       </div>
 
       <p className="mt-2 text-xs text-gray-500 dark:text-gray-400 text-center">
-        Last {history.length} health checks
+        {transitionCount} status change{transitionCount !== 1 ? 's' : ''} since {sinceLabel}
+        {rangeMs > 0 && ` (${formatDuration(rangeMs)})`}
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
- Add `GET /api/health/deployments/{id}/transitions` endpoint returning only snapshots where overall status changed (using SQLite `LAG()` window function)
- Replace periodic AreaChart (last 100 snapshots, ~50min window) with a step chart showing all status transitions since deployment start
- Dynamic time scaling: covers full deployment lifetime with only transition data points (typically 5-50 instead of 100-2880)
- Colored `ReferenceArea` segments show healthy (green), degraded (yellow), unhealthy (red) periods
- Footer shows transition count and duration since first health check

## Test plan
- [ ] Build Docker container and deploy a stack
- [ ] Verify Health History shows step chart with green line for stable deployment
- [ ] Stop a container briefly to create an unhealthy transition, verify step-down appears
- [ ] Verify tooltip shows timestamp, service count, and status
- [ ] Verify chart covers full deployment lifetime (not limited to 50 minutes)