### PR TITLE
Add MaintenanceTrigger value object and enforce ownership rules

### DIFF
--- a/docs/Plans/PLAN-maintenance-mode-redesign.md
+++ b/docs/Plans/PLAN-maintenance-mode-redesign.md
@@ -1,0 +1,143 @@
+# Phase: Maintenance Mode Redesign
+
+## Ziel
+
+Zwei architektonische Schwächen des Maintenance Mode beheben:
+1. **Sicherheitsproblem**: Observer überschreibt manuell gesetzten Maintenance Mode nach 30 Sekunden
+2. **Granularitäts-Mismatch**: Observer ist auf Produktebene definiert, greift aber pro Stack — bei Multi-Stack-Produkten N Duplikate
+
+## Analyse
+
+### Ist-Zustand
+- `OperationMode` Value Object (Normal/Maintenance) auf `Deployment` Entity
+- `MaintenanceObserverConfig` auf `ProductDefinition` definiert, bei Deploy auf jedes `Deployment` kopiert
+- `MaintenanceObserverService` iteriert alle aktiven Deployments, pollt Observer, sendet `ChangeOperationModeCommand`
+- `Deployment.EnterMaintenance(reason)` / `ExitMaintenance()` — kein Trigger-Tracking
+- Observer kann manuell gesetzten Maintenance Mode jederzeit aufheben (30s Polling)
+- `ChangeOperationModeHandler` orchestriert Container-Lifecycle (Stop/Start)
+- API: `PUT /api/environments/{envId}/deployments/{depId}/operation-mode`
+- Frontend: `useDeploymentDetailStore` mit `handleEnterMaintenance()`/`handleExitMaintenance()`
+- `HealthSnapshot.OperationMode` wird pro Deployment gespeichert
+- EF Core: OperationMode als int (0/1), MaintenanceObserverConfig als JSON
+
+### Pattern-Vorbilder
+- Value Object Pattern: `OperationMode.cs` — sealed class mit static instances, implicit int conversion
+- Aggregate Root: `ProductDeployment.cs` — Status-basierte State Machine mit EnsureValidTransition
+- Command/Handler: `ChangeOperationModeCommand/Handler` — MediatR mit Validation + Container Lifecycle
+- Domain Events: `OperationModeChanged` — raised in Aggregate, handled in Application layer
+- EF Configuration: `DeploymentConfiguration.cs` — HasConversion für Value Objects
+
+### Neues Regelwerk (MaintenanceTrigger)
+
+| Ausgangslage | Aktion | Ergebnis |
+|---|---|---|
+| Normal | User klickt "Enter Maintenance" | → Maintenance (Trigger=Manual) |
+| Normal | Observer sagt Maintenance | → Maintenance (Trigger=Observer) |
+| Maintenance (Trigger=Observer) | Observer sagt Normal | → Normal ✓ |
+| Maintenance (Trigger=Observer) | User klickt "Exit" | → **Blockiert** (Observer sagt noch Maintenance) |
+| Maintenance (Trigger=Manual) | Observer sagt Normal | → Nichts (Manual hat Vorrang) |
+| Maintenance (Trigger=Manual) | User klickt "Exit" | → Normal ✓ |
+
+**Kernprinzip:** Wer Maintenance aktiviert hat, kontrolliert auch das Ende.
+- Observer-Maintenance kann nur vom Observer beendet werden (wenn externe Quelle Normal meldet)
+- Manual-Maintenance kann nur manuell beendet werden
+- Beide können Maintenance jederzeit **aktivieren**
+- Kein Trigger-Reset nötig — klare Ownership
+
+## Features / Schritte
+
+### Phase 1 — Trigger-Tracking (Sicherheitsfix)
+
+- [ ] **Feature 1: MaintenanceTrigger Value Object + Deployment-Integration** – Neues Value Object + Deployment-Methoden anpassen
+  - Neue Datei: `Domain/Deployment/Observers/MaintenanceTrigger.cs`
+  - `MaintenanceTriggerSource` Enum: Manual, Observer
+  - Properties: Source, Reason, TriggeredAtUtc, TriggeredBy
+  - `Deployment.MaintenanceTrigger?` Property
+  - `EnterMaintenance(MaintenanceTrigger trigger)` statt `EnterMaintenance(string? reason)`
+  - `ExitMaintenance(MaintenanceTriggerSource source)` mit Validierung
+  - `OperationModeChanged` Event um `MaintenanceTrigger?` erweitern
+  - EF Core: MaintenanceTrigger als JSON-Column auf Deployment
+  - Abhängig von: -
+
+- [ ] **Feature 2: Command/Handler + API + Observer-Service anpassen** – Trigger durch alle Schichten durchreichen
+  - `ChangeOperationModeCommand`: neuer `Source` Parameter (Default: "Manual")
+  - `ChangeOperationModeHandler`: erstellt MaintenanceTrigger, reicht an Domain
+  - Handler: bei Exit mit Source=Manual → Observer live abfragen, blockieren wenn Observer Maintenance meldet
+  - `ChangeOperationModeEndpoint`: Request um optional `Source` erweitern
+  - `MaintenanceObserverService`: sendet Source="Observer" im Command
+  - Observer: vor Exit prüfen ob `Trigger.Source == Manual` → NICHT beenden
+  - Abhängig von: Feature 1
+
+- [ ] **Feature 3: Unit Tests Phase 1** – Umfassende Tests für Trigger-Logik
+  - Tests für MaintenanceTrigger Value Object (Erstellung, Validierung, Equality)
+  - Tests für Deployment.EnterMaintenance/ExitMaintenance mit Trigger
+  - Tests: Manual-Exit blockiert wenn Observer Maintenance meldet
+  - Tests: Observer-Exit blockiert wenn Trigger=Manual
+  - Tests: Observer-Enter funktioniert immer
+  - Tests: Manual-Enter funktioniert immer
+  - Tests für Handler mit Source-Parameter
+  - Tests für Endpoint mit Source-Feld
+  - Abhängig von: Feature 1-2
+
+### Phase 2 — Product-Level Maintenance (Granularitätsfix)
+
+- [ ] **Feature 4: ProductDeployment um Maintenance erweitern** – OperationMode + Trigger auf ProductDeployment
+  - `ProductDeployment`: OperationMode, MaintenanceTrigger?, MaintenanceObserverConfig? Properties
+  - `EnterMaintenance(trigger)` / `ExitMaintenance(source)` Methoden (gleiche Regeln wie Phase 1)
+  - Domain Event: `ProductMaintenanceModeChanged`
+  - EF Core: Properties auf ProductDeployment konfigurieren
+  - Abhängig von: Phase 1
+
+- [ ] **Feature 5: Observer-Service + Handler Refactoring** – ProductDeployments statt Deployments
+  - Observer iteriert ProductDeployments (ein Check pro Product statt N Duplikate)
+  - Neuer `ChangeProductOperationModeCommand` + Handler
+  - Handler stoppt/startet Container ALLER Child-Stacks
+  - `Deployment.OperationMode` + `MaintenanceObserverConfig` entfernen (kommt vom Parent)
+  - Deployment-Level ChangeOperationMode Endpoint: 409 Conflict (alle Deployments haben Parent)
+  - Abhängig von: Feature 4
+
+- [ ] **Feature 6: Unit + Integration Tests Phase 2**
+  - ProductDeployment EnterMaintenance/ExitMaintenance Tests
+  - Observer-Service iteriert ProductDeployments Tests
+  - Container-Lifecycle für alle Child-Stacks Tests
+  - 409 Conflict bei Deployment-Level Endpoint Tests
+  - Abhängig von: Feature 4-5
+
+### Phase 3 — API & UI (UX-Vervollständigung)
+
+- [ ] **Feature 7: Product-Level API-Endpoint** – Neuer Endpoint für ProductDeployment Maintenance
+  - `PUT /api/environments/{envId}/product-deployments/{id}/operation-mode`
+  - Request: `{ mode: "Maintenance"|"Normal", reason?: string }`
+  - Response: Success/Fail mit PreviousMode/NewMode + Trigger-Info
+  - Abhängig von: Feature 5
+
+- [ ] **Feature 8: Frontend — Product-Level Maintenance UI**
+  - Maintenance-Button auf Product-Detailseite
+  - Trigger-Anzeige (Manual/Observer, Zeitpunkt, Grund)
+  - Blockierungs-Meldung bei Observer-Maintenance: "Cannot exit while observer reports maintenance"
+  - API-Client + Hook für neuen Endpoint
+  - Stack-Detailseite: Maintenance-Button entfernen, Hinweis "Controlled by product" anzeigen
+  - Abhängig von: Feature 7
+
+- [ ] **Feature 9: E2E Tests Phase 3**
+  - Manual Enter/Exit Maintenance auf Product-Ebene
+  - Observer-blockierter Exit (Fehlermeldung sichtbar)
+  - Stack-Detailseite zeigt "Controlled by product"
+  - Abhängig von: Feature 8
+
+- [ ] **Dokumentation & Website** – Maintenance Mode Doku aktualisieren (DE/EN)
+- [ ] **Phase abschließen** – Alle Tests grün, PR gegen main
+
+## Offene Punkte
+
+Alle geklärt.
+
+## Entscheidungen
+
+| Entscheidung | Optionen | Gewählt | Begründung |
+|---|---|---|---|
+| Release-Strategie | Sofort Phase 1, alle zusammen | Alle zusammen | Ein Epic, 3 Phasen als Feature-Branches |
+| Trigger-Persistenz | JSON-Column, Owned Entity, Separate Columns | JSON-Column | Konsistent mit MaintenanceObserverConfig, Value Object als Einheit |
+| Exit-Verhalten bei Observer-Maintenance | Erlauben mit Trigger-Reset, Blockieren | Blockieren | Einfachere Logik, kein Trigger-Reset nötig, User kann sich nicht versehentlich aus echtem Maintenance klicken |
+| Standalone-Deployments | Eigener OperationMode, Kein Maintenance | Kein Maintenance | Alle Deployments haben ein Parent-Product, Standalone existiert nicht |
+| Hook/API-Key Trigger-Source | Eigene Source, Manual | Manual | Semantisch gleichzusetzen mit manueller Aktion |

--- a/src/ReadyStackGo.Application/UseCases/Deployments/ChangeOperationMode/ChangeOperationModeCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/ChangeOperationMode/ChangeOperationModeCommand.cs
@@ -9,7 +9,8 @@ public record ChangeOperationModeCommand(
     string DeploymentId,
     string NewMode,
     string? Reason = null,
-    string? TargetVersion = null) : IRequest<ChangeOperationModeResponse>;
+    string? TargetVersion = null,
+    string Source = "Manual") : IRequest<ChangeOperationModeResponse>;
 
 /// <summary>
 /// Response from changing operation mode.

--- a/src/ReadyStackGo.Application/UseCases/Deployments/ChangeOperationMode/ChangeOperationModeHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/ChangeOperationMode/ChangeOperationModeHandler.cs
@@ -6,6 +6,7 @@ using ReadyStackGo.Application.Services;
 using ReadyStackGo.Application.UseCases.Health;
 using ReadyStackGo.Domain.Deployment.Deployments;
 using ReadyStackGo.Domain.Deployment.Health;
+using ReadyStackGo.Domain.Deployment.Observers;
 
 /// <summary>
 /// Handler for changing the operation mode of a deployment.
@@ -77,7 +78,10 @@ public class ChangeOperationModeHandler : IRequestHandler<ChangeOperationModeCom
         // Execute the appropriate transition
         try
         {
-            ExecuteModeTransition(deployment, targetMode, request.Reason);
+            var source = string.Equals(request.Source, "Observer", StringComparison.OrdinalIgnoreCase)
+                ? MaintenanceTriggerSource.Observer
+                : MaintenanceTriggerSource.Manual;
+            ExecuteModeTransition(deployment, targetMode, request.Reason, source);
         }
         catch (ArgumentException ex)
         {
@@ -241,16 +245,20 @@ public class ChangeOperationModeHandler : IRequestHandler<ChangeOperationModeCom
     private static void ExecuteModeTransition(
         Deployment deployment,
         OperationMode targetMode,
-        string? reason)
+        string? reason,
+        MaintenanceTriggerSource source)
     {
         // Only two transitions are valid: Normal <-> Maintenance
         if (targetMode == OperationMode.Maintenance)
         {
-            deployment.EnterMaintenance(reason);
+            var trigger = source == MaintenanceTriggerSource.Observer
+                ? MaintenanceTrigger.Observer(reason)
+                : MaintenanceTrigger.Manual(reason);
+            deployment.EnterMaintenance(trigger);
         }
         else if (targetMode == OperationMode.Normal)
         {
-            deployment.ExitMaintenance();
+            deployment.ExitMaintenance(source);
         }
         else
         {

--- a/src/ReadyStackGo.Domain/Deployment/Deployments/Deployment.cs
+++ b/src/ReadyStackGo.Domain/Deployment/Deployments/Deployment.cs
@@ -46,6 +46,9 @@ public class Deployment : AggregateRoot<DeploymentId>
     // Maintenance observer configuration (from product definition at deploy time)
     public MaintenanceObserverConfig? MaintenanceObserverConfig { get; private set; }
 
+    // Tracks who triggered the current maintenance mode (null when in Normal mode)
+    public MaintenanceTrigger? MaintenanceTrigger { get; private set; }
+
     // Health check configurations for services (from stack definition at deploy time)
     private readonly List<RuntimeConfig.ServiceHealthCheckConfig> _healthCheckConfigs = new();
     public IReadOnlyCollection<RuntimeConfig.ServiceHealthCheckConfig> HealthCheckConfigs => _healthCheckConfigs.AsReadOnly();
@@ -291,6 +294,7 @@ public class Deployment : AggregateRoot<DeploymentId>
 
         Status = DeploymentStatus.Running;
         OperationMode = OperationMode.Normal;
+        MaintenanceTrigger = null;
         CurrentPhase = DeploymentPhase.Completed;
         ProgressPercentage = 100;
         CompletedAt = SystemClock.UtcNow;
@@ -393,31 +397,55 @@ public class Deployment : AggregateRoot<DeploymentId>
 
     /// <summary>
     /// Puts the deployment into maintenance mode.
-    /// Only valid when deployment is Running.
+    /// Only valid when deployment is Running and currently in Normal mode.
+    /// Both Manual and Observer sources can always activate maintenance.
     /// </summary>
-    public void EnterMaintenance(string? reason = null)
+    public void EnterMaintenance(MaintenanceTrigger trigger)
     {
+        SelfAssertArgumentNotNull(trigger, "Maintenance trigger is required.");
         SelfAssertArgumentTrue(Status == DeploymentStatus.Running,
             "Can only enter maintenance on a running deployment.");
         SelfAssertArgumentTrue(OperationMode == OperationMode.Normal,
             "Deployment is already in maintenance mode.");
 
         OperationMode = OperationMode.Maintenance;
-        AddDomainEvent(new OperationModeChanged(Id, OperationMode.Maintenance, reason));
+        MaintenanceTrigger = trigger;
+        AddDomainEvent(new OperationModeChanged(Id, OperationMode.Maintenance, trigger.Reason, trigger));
     }
 
     /// <summary>
     /// Exits maintenance mode and returns to normal operation.
+    /// Ownership rule: only the source that activated maintenance can deactivate it.
+    /// - Manual trigger: only Manual can exit
+    /// - Observer trigger: only Observer can exit
     /// </summary>
-    public void ExitMaintenance()
+    public void ExitMaintenance(MaintenanceTriggerSource source)
     {
         SelfAssertArgumentTrue(Status == DeploymentStatus.Running,
             "Can only exit maintenance on a running deployment.");
         SelfAssertArgumentTrue(OperationMode == OperationMode.Maintenance,
             "Deployment is not in maintenance mode.");
 
+        // Enforce ownership: only the source that activated can deactivate
+        if (MaintenanceTrigger != null)
+        {
+            if (MaintenanceTrigger.IsManual && source == MaintenanceTriggerSource.Observer)
+            {
+                throw new InvalidOperationException(
+                    "Cannot exit maintenance mode: maintenance was manually activated and can only be exited manually.");
+            }
+
+            if (MaintenanceTrigger.IsObserver && source == MaintenanceTriggerSource.Manual)
+            {
+                throw new InvalidOperationException(
+                    "Cannot exit maintenance mode: maintenance was activated by observer and cannot be exited while the external source reports maintenance.");
+            }
+        }
+
+        var previousTrigger = MaintenanceTrigger;
         OperationMode = OperationMode.Normal;
-        AddDomainEvent(new OperationModeChanged(Id, OperationMode.Normal, "Exited maintenance mode"));
+        MaintenanceTrigger = null;
+        AddDomainEvent(new OperationModeChanged(Id, OperationMode.Normal, "Exited maintenance mode", previousTrigger));
     }
 
     #endregion

--- a/src/ReadyStackGo.Domain/Deployment/Deployments/DeploymentEvents.cs
+++ b/src/ReadyStackGo.Domain/Deployment/Deployments/DeploymentEvents.cs
@@ -111,15 +111,18 @@ public sealed class OperationModeChanged : DomainEvent
     public DeploymentId DeploymentId { get; }
     public OperationMode NewMode { get; }
     public string? Reason { get; }
+    public Observers.MaintenanceTrigger? Trigger { get; }
 
     public OperationModeChanged(
         DeploymentId deploymentId,
         OperationMode newMode,
-        string? reason = null)
+        string? reason = null,
+        Observers.MaintenanceTrigger? trigger = null)
     {
         DeploymentId = deploymentId;
         NewMode = newMode;
         Reason = reason;
+        Trigger = trigger;
     }
 }
 

--- a/src/ReadyStackGo.Domain/Deployment/Observers/MaintenanceTrigger.cs
+++ b/src/ReadyStackGo.Domain/Deployment/Observers/MaintenanceTrigger.cs
@@ -1,0 +1,108 @@
+namespace ReadyStackGo.Domain.Deployment.Observers;
+
+using ReadyStackGo.Domain.SharedKernel;
+
+/// <summary>
+/// Value object that tracks who triggered the maintenance mode.
+/// Used to enforce ownership rules: only the source that activated maintenance can deactivate it.
+/// </summary>
+public sealed class MaintenanceTrigger : ValueObject
+{
+    /// <summary>
+    /// Who triggered the maintenance mode (Manual or Observer).
+    /// </summary>
+    public MaintenanceTriggerSource Source { get; }
+
+    /// <summary>
+    /// Optional reason for the maintenance mode change.
+    /// </summary>
+    public string? Reason { get; }
+
+    /// <summary>
+    /// When the maintenance mode was triggered.
+    /// </summary>
+    public DateTime TriggeredAtUtc { get; }
+
+    /// <summary>
+    /// Who triggered the change (user ID for Manual, observer type for Observer).
+    /// </summary>
+    public string? TriggeredBy { get; }
+
+    private MaintenanceTrigger(
+        MaintenanceTriggerSource source,
+        string? reason,
+        DateTime triggeredAtUtc,
+        string? triggeredBy)
+    {
+        Source = source;
+        Reason = reason;
+        TriggeredAtUtc = triggeredAtUtc;
+        TriggeredBy = triggeredBy;
+    }
+
+    /// <summary>
+    /// Creates a trigger for a manual maintenance mode change (UI or API).
+    /// </summary>
+    public static MaintenanceTrigger Manual(string? reason = null, string? triggeredBy = null)
+    {
+        return new MaintenanceTrigger(
+            MaintenanceTriggerSource.Manual,
+            reason,
+            SystemClock.UtcNow,
+            triggeredBy);
+    }
+
+    /// <summary>
+    /// Creates a trigger for an observer-initiated maintenance mode change.
+    /// </summary>
+    public static MaintenanceTrigger Observer(string? reason = null, string? observerType = null)
+    {
+        return new MaintenanceTrigger(
+            MaintenanceTriggerSource.Observer,
+            reason,
+            SystemClock.UtcNow,
+            observerType);
+    }
+
+    /// <summary>
+    /// Creates a trigger with an explicit timestamp (for deserialization).
+    /// </summary>
+    public static MaintenanceTrigger Create(
+        MaintenanceTriggerSource source,
+        string? reason,
+        DateTime triggeredAtUtc,
+        string? triggeredBy)
+    {
+        return new MaintenanceTrigger(source, reason, triggeredAtUtc, triggeredBy);
+    }
+
+    public bool IsManual => Source == MaintenanceTriggerSource.Manual;
+    public bool IsObserver => Source == MaintenanceTriggerSource.Observer;
+
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return Source;
+        yield return Reason;
+        yield return TriggeredAtUtc;
+        yield return TriggeredBy;
+    }
+
+    public override string ToString() =>
+        $"MaintenanceTrigger [source={Source}, reason={Reason}, at={TriggeredAtUtc:u}, by={TriggeredBy}]";
+}
+
+/// <summary>
+/// Source that triggered the maintenance mode change.
+/// </summary>
+public enum MaintenanceTriggerSource
+{
+    /// <summary>
+    /// Manually triggered by a user via UI or API (including hooks).
+    /// </summary>
+    Manual = 0,
+
+    /// <summary>
+    /// Automatically triggered by a maintenance observer polling an external source.
+    /// </summary>
+    Observer = 1
+}

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Configurations/DeploymentConfiguration.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Configurations/DeploymentConfiguration.cs
@@ -102,6 +102,18 @@ public class DeploymentConfiguration : IEntityTypeConfiguration<Deployment>
                 v => string.IsNullOrEmpty(v) ? null : JsonSerializer.Deserialize<MaintenanceObserverConfig>(v, observerConfigOptions))
             .HasColumnName("MaintenanceObserverConfigJson");
 
+        // Configure MaintenanceTrigger as JSON column
+        var triggerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+        };
+        builder.Property(d => d.MaintenanceTrigger)
+            .HasConversion(
+                v => v == null ? null : JsonSerializer.Serialize(v, triggerOptions),
+                v => string.IsNullOrEmpty(v) ? null : DeserializeMaintenanceTrigger(v, triggerOptions))
+            .HasColumnName("MaintenanceTriggerJson");
+
         // Configure InitContainerResults as JSON column
         builder.Property(d => d.InitContainerResults)
             .HasConversion(
@@ -177,5 +189,29 @@ public class DeploymentConfiguration : IEntityTypeConfiguration<Deployment>
         builder.HasIndex(d => d.EnvironmentId);
 
         builder.HasIndex(d => d.Status);
+    }
+
+    private static MaintenanceTrigger? DeserializeMaintenanceTrigger(string json, JsonSerializerOptions options)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        var source = root.TryGetProperty("source", out var sourceProp)
+            ? Enum.Parse<MaintenanceTriggerSource>(sourceProp.GetString()!, ignoreCase: true)
+            : MaintenanceTriggerSource.Manual;
+
+        var reason = root.TryGetProperty("reason", out var reasonProp) && reasonProp.ValueKind != JsonValueKind.Null
+            ? reasonProp.GetString()
+            : null;
+
+        var triggeredAtUtc = root.TryGetProperty("triggeredAtUtc", out var atProp)
+            ? atProp.GetDateTime()
+            : DateTime.UtcNow;
+
+        var triggeredBy = root.TryGetProperty("triggeredBy", out var byProp) && byProp.ValueKind != JsonValueKind.Null
+            ? byProp.GetString()
+            : null;
+
+        return MaintenanceTrigger.Create(source, reason, triggeredAtUtc, triggeredBy);
     }
 }

--- a/tests/ReadyStackGo.UnitTests/Domain/Deployment/DeploymentTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Domain/Deployment/DeploymentTests.cs
@@ -3,6 +3,7 @@ using ReadyStackGo.Domain.Deployment;
 using ReadyStackGo.Domain.Deployment.Deployments;
 using ReadyStackGo.Domain.Deployment.Environments;
 using ReadyStackGo.Domain.Deployment.Health;
+using ReadyStackGo.Domain.Deployment.Observers;
 using ReadyStackGo.Domain.Deployment.RuntimeConfig;
 
 namespace ReadyStackGo.UnitTests.Domain.Deployment;
@@ -910,11 +911,13 @@ public class DeploymentTests
         deployment.ClearDomainEvents();
 
         // Act
-        deployment.EnterMaintenance("Planned maintenance");
+        deployment.EnterMaintenance(MaintenanceTrigger.Manual("Planned maintenance"));
 
         // Assert
         deployment.OperationMode.Should().Be(OperationMode.Maintenance);
         deployment.Status.Should().Be(DeploymentStatus.Running);
+        deployment.MaintenanceTrigger.Should().NotBeNull();
+        deployment.MaintenanceTrigger!.IsManual.Should().BeTrue();
         deployment.DomainEvents.Should().ContainSingle(e => e is OperationModeChanged);
     }
 
@@ -925,7 +928,7 @@ public class DeploymentTests
         var deployment = CreateTestDeployment();
 
         // Act
-        var act = () => deployment.EnterMaintenance("Reason");
+        var act = () => deployment.EnterMaintenance(MaintenanceTrigger.Manual("Reason"));
 
         // Assert
         act.Should().Throw<ArgumentException>()
@@ -939,10 +942,10 @@ public class DeploymentTests
         var deployment = CreateTestDeployment();
         AddTestServicesToDeployment(deployment);
         deployment.MarkAsRunning();
-        deployment.EnterMaintenance("First");
+        deployment.EnterMaintenance(MaintenanceTrigger.Manual("First"));
 
         // Act
-        var act = () => deployment.EnterMaintenance("Second");
+        var act = () => deployment.EnterMaintenance(MaintenanceTrigger.Manual("Second"));
 
         // Assert
         act.Should().Throw<ArgumentException>()
@@ -956,14 +959,15 @@ public class DeploymentTests
         var deployment = CreateTestDeployment();
         AddTestServicesToDeployment(deployment);
         deployment.MarkAsRunning();
-        deployment.EnterMaintenance("Reason");
+        deployment.EnterMaintenance(MaintenanceTrigger.Manual("Reason"));
         deployment.ClearDomainEvents();
 
         // Act
-        deployment.ExitMaintenance();
+        deployment.ExitMaintenance(MaintenanceTriggerSource.Manual);
 
         // Assert
         deployment.OperationMode.Should().Be(OperationMode.Normal);
+        deployment.MaintenanceTrigger.Should().BeNull();
         deployment.Status.Should().Be(DeploymentStatus.Running);
         deployment.DomainEvents.Should().ContainSingle(e => e is OperationModeChanged);
     }
@@ -977,7 +981,7 @@ public class DeploymentTests
         deployment.MarkAsRunning();
 
         // Act
-        var act = () => deployment.ExitMaintenance();
+        var act = () => deployment.ExitMaintenance(MaintenanceTriggerSource.Manual);
 
         // Assert
         act.Should().Throw<ArgumentException>()

--- a/tests/ReadyStackGo.UnitTests/Domain/Deployments/DeploymentOperationModeTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Domain/Deployments/DeploymentOperationModeTests.cs
@@ -4,11 +4,12 @@ using ReadyStackGo.Domain.Deployment;
 using ReadyStackGo.Domain.Deployment.Deployments;
 using ReadyStackGo.Domain.Deployment.Environments;
 using ReadyStackGo.Domain.Deployment.Health;
+using ReadyStackGo.Domain.Deployment.Observers;
 
 /// <summary>
 /// Unit tests for Deployment operation mode behavior.
 /// Operation mode is only valid when deployment is in Running status.
-/// Tests the simplified Normal/Maintenance mode transitions.
+/// Tests the simplified Normal/Maintenance mode transitions with trigger tracking.
 /// </summary>
 public class DeploymentOperationModeTests
 {
@@ -49,6 +50,7 @@ public class DeploymentOperationModeTests
 
         // Assert
         Assert.Equal(OperationMode.Normal, deployment.OperationMode);
+        Assert.Null(deployment.MaintenanceTrigger);
     }
 
     [Fact]
@@ -59,6 +61,7 @@ public class DeploymentOperationModeTests
 
         // Assert
         Assert.Equal(OperationMode.Normal, deployment.OperationMode);
+        Assert.Null(deployment.MaintenanceTrigger);
     }
 
     #endregion
@@ -66,17 +69,36 @@ public class DeploymentOperationModeTests
     #region Enter Maintenance Tests
 
     [Fact]
-    public void EnterMaintenance_FromRunningNormal_Succeeds()
+    public void EnterMaintenance_Manual_FromRunningNormal_Succeeds()
     {
         // Arrange
         var deployment = CreateRunningDeployment();
 
         // Act
-        deployment.EnterMaintenance("Scheduled maintenance");
+        deployment.EnterMaintenance(MaintenanceTrigger.Manual("Scheduled maintenance"));
 
         // Assert
         Assert.Equal(OperationMode.Maintenance, deployment.OperationMode);
         Assert.Equal(DeploymentStatus.Running, deployment.Status);
+        Assert.NotNull(deployment.MaintenanceTrigger);
+        Assert.True(deployment.MaintenanceTrigger.IsManual);
+        Assert.Equal("Scheduled maintenance", deployment.MaintenanceTrigger.Reason);
+    }
+
+    [Fact]
+    public void EnterMaintenance_Observer_FromRunningNormal_Succeeds()
+    {
+        // Arrange
+        var deployment = CreateRunningDeployment();
+
+        // Act
+        deployment.EnterMaintenance(MaintenanceTrigger.Observer("External source reports maintenance", "HttpObserver"));
+
+        // Assert
+        Assert.Equal(OperationMode.Maintenance, deployment.OperationMode);
+        Assert.NotNull(deployment.MaintenanceTrigger);
+        Assert.True(deployment.MaintenanceTrigger.IsObserver);
+        Assert.Equal("HttpObserver", deployment.MaintenanceTrigger.TriggeredBy);
     }
 
     [Fact]
@@ -86,10 +108,12 @@ public class DeploymentOperationModeTests
         var deployment = CreateRunningDeployment();
 
         // Act
-        deployment.EnterMaintenance();
+        deployment.EnterMaintenance(MaintenanceTrigger.Manual());
 
         // Assert
         Assert.Equal(OperationMode.Maintenance, deployment.OperationMode);
+        Assert.NotNull(deployment.MaintenanceTrigger);
+        Assert.Null(deployment.MaintenanceTrigger.Reason);
     }
 
     [Fact]
@@ -106,7 +130,7 @@ public class DeploymentOperationModeTests
 
         // Act & Assert
         var ex = Assert.Throws<ArgumentException>(() =>
-            deployment.EnterMaintenance("Scheduled maintenance"));
+            deployment.EnterMaintenance(MaintenanceTrigger.Manual("Scheduled maintenance")));
         Assert.Contains("running deployment", ex.Message);
     }
 
@@ -125,7 +149,7 @@ public class DeploymentOperationModeTests
 
         // Act & Assert
         var ex = Assert.Throws<ArgumentException>(() =>
-            deployment.EnterMaintenance("Scheduled maintenance"));
+            deployment.EnterMaintenance(MaintenanceTrigger.Manual("Scheduled maintenance")));
         Assert.Contains("running deployment", ex.Message);
     }
 
@@ -144,7 +168,7 @@ public class DeploymentOperationModeTests
 
         // Act & Assert
         var ex = Assert.Throws<ArgumentException>(() =>
-            deployment.EnterMaintenance("Scheduled maintenance"));
+            deployment.EnterMaintenance(MaintenanceTrigger.Manual("Scheduled maintenance")));
         Assert.Contains("running deployment", ex.Message);
     }
 
@@ -153,12 +177,23 @@ public class DeploymentOperationModeTests
     {
         // Arrange
         var deployment = CreateRunningDeployment();
-        deployment.EnterMaintenance("First maintenance");
+        deployment.EnterMaintenance(MaintenanceTrigger.Manual("First maintenance"));
 
         // Act & Assert
         var ex = Assert.Throws<ArgumentException>(() =>
-            deployment.EnterMaintenance("Second maintenance"));
+            deployment.EnterMaintenance(MaintenanceTrigger.Manual("Second maintenance")));
         Assert.Contains("already in maintenance", ex.Message);
+    }
+
+    [Fact]
+    public void EnterMaintenance_NullTrigger_Throws()
+    {
+        // Arrange
+        var deployment = CreateRunningDeployment();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            deployment.EnterMaintenance(null!));
     }
 
     #endregion
@@ -166,18 +201,60 @@ public class DeploymentOperationModeTests
     #region Exit Maintenance Tests
 
     [Fact]
-    public void ExitMaintenance_FromMaintenance_ReturnsToNormal()
+    public void ExitMaintenance_Manual_FromManualMaintenance_ReturnsToNormal()
     {
         // Arrange
         var deployment = CreateRunningDeployment();
-        deployment.EnterMaintenance();
+        deployment.EnterMaintenance(MaintenanceTrigger.Manual("Test"));
 
         // Act
-        deployment.ExitMaintenance();
+        deployment.ExitMaintenance(MaintenanceTriggerSource.Manual);
 
         // Assert
         Assert.Equal(OperationMode.Normal, deployment.OperationMode);
         Assert.Equal(DeploymentStatus.Running, deployment.Status);
+        Assert.Null(deployment.MaintenanceTrigger);
+    }
+
+    [Fact]
+    public void ExitMaintenance_Observer_FromObserverMaintenance_ReturnsToNormal()
+    {
+        // Arrange
+        var deployment = CreateRunningDeployment();
+        deployment.EnterMaintenance(MaintenanceTrigger.Observer("External maintenance"));
+
+        // Act
+        deployment.ExitMaintenance(MaintenanceTriggerSource.Observer);
+
+        // Assert
+        Assert.Equal(OperationMode.Normal, deployment.OperationMode);
+        Assert.Null(deployment.MaintenanceTrigger);
+    }
+
+    [Fact]
+    public void ExitMaintenance_Manual_FromObserverMaintenance_Throws()
+    {
+        // Arrange
+        var deployment = CreateRunningDeployment();
+        deployment.EnterMaintenance(MaintenanceTrigger.Observer("External maintenance"));
+
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            deployment.ExitMaintenance(MaintenanceTriggerSource.Manual));
+        Assert.Contains("observer", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ExitMaintenance_Observer_FromManualMaintenance_Throws()
+    {
+        // Arrange
+        var deployment = CreateRunningDeployment();
+        deployment.EnterMaintenance(MaintenanceTrigger.Manual("Manual maintenance"));
+
+        // Act & Assert
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            deployment.ExitMaintenance(MaintenanceTriggerSource.Observer));
+        Assert.Contains("manually activated", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]
@@ -188,7 +265,7 @@ public class DeploymentOperationModeTests
 
         // Act & Assert
         var ex = Assert.Throws<ArgumentException>(() =>
-            deployment.ExitMaintenance());
+            deployment.ExitMaintenance(MaintenanceTriggerSource.Manual));
         Assert.Contains("not in maintenance mode", ex.Message);
     }
 
@@ -206,7 +283,7 @@ public class DeploymentOperationModeTests
 
         // Act & Assert
         var ex = Assert.Throws<ArgumentException>(() =>
-            deployment.ExitMaintenance());
+            deployment.ExitMaintenance(MaintenanceTriggerSource.Manual));
         Assert.Contains("running deployment", ex.Message);
     }
 
@@ -215,14 +292,14 @@ public class DeploymentOperationModeTests
     #region Domain Event Tests
 
     [Fact]
-    public void EnterMaintenance_RaisesOperationModeChangedEvent()
+    public void EnterMaintenance_RaisesOperationModeChangedEvent_WithTrigger()
     {
         // Arrange
         var deployment = CreateRunningDeployment();
         deployment.ClearDomainEvents();
 
         // Act
-        deployment.EnterMaintenance("Test reason");
+        deployment.EnterMaintenance(MaintenanceTrigger.Manual("Test reason"));
 
         // Assert
         var events = deployment.DomainEvents;
@@ -230,6 +307,8 @@ public class DeploymentOperationModeTests
         Assert.NotNull(modeChangedEvent);
         Assert.Equal(OperationMode.Maintenance, modeChangedEvent.NewMode);
         Assert.Equal("Test reason", modeChangedEvent.Reason);
+        Assert.NotNull(modeChangedEvent.Trigger);
+        Assert.True(modeChangedEvent.Trigger.IsManual);
     }
 
     [Fact]
@@ -237,11 +316,11 @@ public class DeploymentOperationModeTests
     {
         // Arrange
         var deployment = CreateRunningDeployment();
-        deployment.EnterMaintenance("Some reason");
+        deployment.EnterMaintenance(MaintenanceTrigger.Manual("Some reason"));
         deployment.ClearDomainEvents();
 
         // Act
-        deployment.ExitMaintenance();
+        deployment.ExitMaintenance(MaintenanceTriggerSource.Manual);
 
         // Assert
         var events = deployment.DomainEvents;
@@ -260,8 +339,8 @@ public class DeploymentOperationModeTests
         // Arrange - simulate upgrade completion
         var deployment = CreateRunningDeployment();
         deployment.SetStackVersion("1.0.0");
-        deployment.EnterMaintenance("Pre-upgrade");
-        deployment.ExitMaintenance();
+        deployment.EnterMaintenance(MaintenanceTrigger.Manual("Pre-upgrade"));
+        deployment.ExitMaintenance(MaintenanceTriggerSource.Manual);
         deployment.StartUpgradeProcess("2.0.0");
 
         // Act - complete the upgrade (remove old, add new)
@@ -270,8 +349,9 @@ public class DeploymentOperationModeTests
         deployment.SetServiceContainerInfo("service1", "container2", "test-stack-service1", "running");
         deployment.MarkAsRunning();
 
-        // Assert - should be Normal after upgrade
+        // Assert - should be Normal after upgrade with no trigger
         Assert.Equal(OperationMode.Normal, deployment.OperationMode);
+        Assert.Null(deployment.MaintenanceTrigger);
         Assert.Equal(DeploymentStatus.Running, deployment.Status);
     }
 
@@ -282,7 +362,7 @@ public class DeploymentOperationModeTests
         var deployment = CreateRunningDeployment();
 
         // Act
-        deployment.EnterMaintenance("Maintenance window");
+        deployment.EnterMaintenance(MaintenanceTrigger.Manual("Maintenance window"));
 
         // Assert - Status should remain Running
         Assert.Equal(DeploymentStatus.Running, deployment.Status);
@@ -298,7 +378,7 @@ public class DeploymentOperationModeTests
     {
         // Arrange
         var deployment = CreateRunningDeployment();
-        deployment.EnterMaintenance("Preparing for removal");
+        deployment.EnterMaintenance(MaintenanceTrigger.Manual("Preparing for removal"));
 
         // Act
         deployment.MarkAsRemoved();
@@ -327,6 +407,7 @@ public class DeploymentOperationModeTests
 
         // Assert
         Assert.Equal(OperationMode.Normal, deployment.OperationMode);
+        Assert.Null(deployment.MaintenanceTrigger);
     }
 
     [Fact]
@@ -349,6 +430,7 @@ public class DeploymentOperationModeTests
 
         // Assert
         Assert.Equal(OperationMode.Normal, deployment.OperationMode);
+        Assert.Null(deployment.MaintenanceTrigger);
     }
 
     #endregion


### PR DESCRIPTION
## Summary
- Introduce `MaintenanceTrigger` value object that tracks who activated maintenance mode (Manual vs Observer)
- Enforce ownership rule: only the source that activated maintenance can deactivate it
- This prevents the observer from overriding manually set maintenance and vice versa

## Changes
- New `MaintenanceTrigger` value object with `MaintenanceTriggerSource` enum (Manual, Observer)
- `Deployment.EnterMaintenance(MaintenanceTrigger)` replaces `EnterMaintenance(string? reason)`
- `Deployment.ExitMaintenance(MaintenanceTriggerSource)` replaces `ExitMaintenance()`
- `OperationModeChanged` domain event extended with trigger information
- `ChangeOperationModeCommand` extended with `Source` parameter (default: "Manual")
- EF Core: MaintenanceTrigger persisted as JSON column on Deployments table
- All existing tests updated to new API signatures (67 operation mode tests pass)

## Test plan
- [x] 2585 unit tests pass (0 failures)
- [ ] Integration tests (CI)