### PR TITLE
Add observer trigger protection and Source parameter to API

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/Deployments/ChangeOperationModeEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Deployments/ChangeOperationModeEndpoint.cs
@@ -37,7 +37,8 @@ public class ChangeOperationModeEndpoint : Endpoint<ChangeOperationModeRequest, 
             deploymentId,
             req.Mode,
             req.Reason,
-            req.TargetVersion);
+            req.TargetVersion,
+            req.Source ?? "Manual");
 
         var response = await _mediator.Send(command, ct);
 
@@ -80,4 +81,11 @@ public class ChangeOperationModeRequest
     /// Target version (required when entering Migrating mode).
     /// </summary>
     public string? TargetVersion { get; set; }
+
+    /// <summary>
+    /// Source of the mode change: "Manual" (default) or "Observer".
+    /// Manual is used for UI and API/Hook-triggered changes.
+    /// Observer is used by the automatic maintenance observer service.
+    /// </summary>
+    public string? Source { get; set; }
 }

--- a/src/ReadyStackGo.Application/Services/Impl/MaintenanceObserverService.cs
+++ b/src/ReadyStackGo.Application/Services/Impl/MaintenanceObserverService.cs
@@ -208,12 +208,11 @@ public class MaintenanceObserverService : IMaintenanceObserverService
                 "Maintenance observer triggered maintenance mode for {StackName} (observed: {Value})",
                 deployment.StackName, result.ObservedValue);
 
-            // Use ChangeOperationModeCommand to properly enter maintenance mode
-            // This triggers the same business logic as the UI button
             var command = new ChangeOperationModeCommand(
                 deployment.Id.Value.ToString(),
                 OperationMode.Maintenance.Name,
-                Reason: $"Triggered by maintenance observer (observed: {result.ObservedValue})");
+                Reason: $"Triggered by maintenance observer (observed: {result.ObservedValue})",
+                Source: "Observer");
 
             var response = await _mediator.Send(command, cancellationToken);
             if (!response.Success)
@@ -225,15 +224,25 @@ public class MaintenanceObserverService : IMaintenanceObserverService
         }
         else if (!shouldBeMaintenance && currentMode == OperationMode.Maintenance)
         {
+            // Observer can only exit maintenance it activated itself.
+            // If trigger is Manual, skip (manual has priority).
+            if (deployment.MaintenanceTrigger?.IsManual == true)
+            {
+                _logger.LogDebug(
+                    "Observer skipping exit for {StackName}: maintenance was manually activated",
+                    deployment.StackName);
+                return;
+            }
+
             _logger.LogInformation(
                 "Maintenance observer cleared maintenance mode for {StackName} (observed: {Value})",
                 deployment.StackName, result.ObservedValue);
 
-            // Use ChangeOperationModeCommand to properly exit maintenance mode
             var command = new ChangeOperationModeCommand(
                 deployment.Id.Value.ToString(),
                 OperationMode.Normal.Name,
-                Reason: $"Cleared by maintenance observer (observed: {result.ObservedValue})");
+                Reason: $"Cleared by maintenance observer (observed: {result.ObservedValue})",
+                Source: "Observer");
 
             var response = await _mediator.Send(command, cancellationToken);
             if (!response.Success)

--- a/src/ReadyStackGo.Application/UseCases/Deployments/ChangeOperationMode/ChangeOperationModeHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/ChangeOperationMode/ChangeOperationModeHandler.cs
@@ -83,7 +83,7 @@ public class ChangeOperationModeHandler : IRequestHandler<ChangeOperationModeCom
                 : MaintenanceTriggerSource.Manual;
             ExecuteModeTransition(deployment, targetMode, request.Reason, source);
         }
-        catch (ArgumentException ex)
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
         {
             _logger.LogWarning(ex, "Failed to change operation mode for deployment {DeploymentId}", request.DeploymentId);
             return ChangeOperationModeResponse.Fail(ex.Message);


### PR DESCRIPTION
## Summary
- Observer service now respects MaintenanceTrigger ownership rules
- Observer skips exit when maintenance was manually activated (Manual has priority)
- API endpoint extended with optional `Source` field for trigger tracking

## Changes
- `MaintenanceObserverService`: sends `Source=Observer` in all commands, checks `MaintenanceTrigger.IsManual` before exit
- `ChangeOperationModeEndpoint`: new optional `Source` field on request (default: "Manual")
- `ChangeOperationModeHandler`: catches `InvalidOperationException` from domain ownership validation

## Test plan
- [x] 2585 unit tests pass
- [ ] Integration tests (CI)