### PR TITLE
Add maintenance mode to ProductDeployment with trigger ownership

### DIFF
--- a/src/ReadyStackGo.Domain/Deployment/ProductDeployments/ProductDeployment.cs
+++ b/src/ReadyStackGo.Domain/Deployment/ProductDeployments/ProductDeployment.cs
@@ -3,6 +3,8 @@ namespace ReadyStackGo.Domain.Deployment.ProductDeployments;
 using System.Text.RegularExpressions;
 using ReadyStackGo.Domain.Deployment.Deployments;
 using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.Deployment.Health;
+using ReadyStackGo.Domain.Deployment.Observers;
 using ReadyStackGo.Domain.SharedKernel;
 
 /// <summary>
@@ -63,6 +65,11 @@ public class ProductDeployment : AggregateRoot<ProductDeploymentId>
     public string? PreviousVersion { get; private set; }
     public DateTime? LastUpgradedAt { get; private set; }
     public int UpgradeCount { get; private set; }
+
+    // ── Maintenance / Operation Mode ───────────────────────────────
+    public OperationMode OperationMode { get; private set; } = OperationMode.Normal;
+    public MaintenanceTrigger? MaintenanceTrigger { get; private set; }
+    public MaintenanceObserverConfig? MaintenanceObserverConfig { get; private set; }
 
     // ── Phase History ────────────────────────────────────────────────
     private readonly List<ProductDeploymentPhaseRecord> _phaseHistory = new();
@@ -659,6 +666,88 @@ public class ProductDeployment : AggregateRoot<ProductDeploymentId>
 
         return false;
     }
+
+    // ═══════════════════════════════════════════════════════════════════
+    // Maintenance / Operation Mode
+    // ═══════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// Sets the maintenance observer configuration for this product deployment.
+    /// Called during deployment when observer config is available from the product definition.
+    /// </summary>
+    public void SetMaintenanceObserverConfig(MaintenanceObserverConfig? config)
+    {
+        MaintenanceObserverConfig = config;
+    }
+
+    /// <summary>
+    /// Puts the product deployment into maintenance mode.
+    /// Only valid when the product is operational (Running or PartiallyRunning).
+    /// Both Manual and Observer sources can always activate maintenance.
+    /// </summary>
+    public void EnterMaintenance(MaintenanceTrigger trigger)
+    {
+        SelfAssertArgumentNotNull(trigger, "Maintenance trigger is required.");
+        SelfAssertStateTrue(IsOperational,
+            $"Can only enter maintenance when product is operational. Current status: {Status}.");
+        SelfAssertStateTrue(OperationMode == OperationMode.Normal,
+            "Product deployment is already in maintenance mode.");
+
+        OperationMode = OperationMode.Maintenance;
+        MaintenanceTrigger = trigger;
+
+        RecordPhase($"Entered maintenance mode ({trigger.Source}: {trigger.Reason ?? "no reason"})");
+        AddDomainEvent(new ProductMaintenanceModeChanged(
+            Id, OperationMode.Maintenance, trigger));
+    }
+
+    /// <summary>
+    /// Exits maintenance mode and returns to normal operation.
+    /// Ownership rule: only the source that activated maintenance can deactivate it.
+    /// - Manual trigger: only Manual can exit
+    /// - Observer trigger: only Observer can exit
+    /// </summary>
+    public void ExitMaintenance(MaintenanceTriggerSource source)
+    {
+        SelfAssertStateTrue(IsOperational,
+            $"Can only exit maintenance when product is operational. Current status: {Status}.");
+        SelfAssertStateTrue(OperationMode == OperationMode.Maintenance,
+            "Product deployment is not in maintenance mode.");
+
+        // Enforce ownership: only the source that activated can deactivate
+        if (MaintenanceTrigger != null)
+        {
+            if (MaintenanceTrigger.IsManual && source == MaintenanceTriggerSource.Observer)
+            {
+                throw new InvalidOperationException(
+                    "Cannot exit maintenance mode: maintenance was manually activated and can only be exited manually.");
+            }
+
+            if (MaintenanceTrigger.IsObserver && source == MaintenanceTriggerSource.Manual)
+            {
+                throw new InvalidOperationException(
+                    "Cannot exit maintenance mode: maintenance was activated by observer and cannot be exited while the external source reports maintenance.");
+            }
+        }
+
+        var previousTrigger = MaintenanceTrigger;
+        OperationMode = OperationMode.Normal;
+        MaintenanceTrigger = null;
+
+        RecordPhase($"Exited maintenance mode (by {source})");
+        AddDomainEvent(new ProductMaintenanceModeChanged(
+            Id, OperationMode.Normal, previousTrigger));
+    }
+
+    /// <summary>
+    /// Whether maintenance mode can be entered (product is operational and in Normal mode).
+    /// </summary>
+    public bool CanEnterMaintenance => IsOperational && OperationMode == OperationMode.Normal;
+
+    /// <summary>
+    /// Whether maintenance mode can be exited (product is operational and in Maintenance mode).
+    /// </summary>
+    public bool CanExitMaintenance => IsOperational && OperationMode == OperationMode.Maintenance;
 
     // ═══════════════════════════════════════════════════════════════════
     // Query Methods

--- a/src/ReadyStackGo.Domain/Deployment/ProductDeployments/ProductDeploymentEvents.cs
+++ b/src/ReadyStackGo.Domain/Deployment/ProductDeployments/ProductDeploymentEvents.cs
@@ -2,6 +2,8 @@ namespace ReadyStackGo.Domain.Deployment.ProductDeployments;
 
 using ReadyStackGo.Domain.Deployment.Deployments;
 using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.Deployment.Health;
+using ReadyStackGo.Domain.Deployment.Observers;
 using ReadyStackGo.Domain.SharedKernel;
 
 // ═══════════════════════════════════════════════════════════════════
@@ -215,6 +217,26 @@ public sealed class ProductDeploymentRemoved : DomainEvent
     {
         ProductDeploymentId = productDeploymentId;
         ProductName = productName;
+    }
+}
+
+/// <summary>
+/// Raised when the operation mode of a product deployment changes (Normal ↔ Maintenance).
+/// </summary>
+public sealed class ProductMaintenanceModeChanged : DomainEvent
+{
+    public ProductDeploymentId ProductDeploymentId { get; }
+    public OperationMode NewMode { get; }
+    public MaintenanceTrigger? Trigger { get; }
+
+    public ProductMaintenanceModeChanged(
+        ProductDeploymentId productDeploymentId,
+        OperationMode newMode,
+        MaintenanceTrigger? trigger = null)
+    {
+        ProductDeploymentId = productDeploymentId;
+        NewMode = newMode;
+        Trigger = trigger;
     }
 }
 

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Configurations/ProductDeploymentConfiguration.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Configurations/ProductDeploymentConfiguration.cs
@@ -1,11 +1,14 @@
 namespace ReadyStackGo.Infrastructure.DataAccess.Configurations;
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using ReadyStackGo.Domain.Deployment;
 using ReadyStackGo.Domain.Deployment.Deployments;
 using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.Deployment.Health;
+using ReadyStackGo.Domain.Deployment.Observers;
 using ReadyStackGo.Domain.Deployment.ProductDeployments;
 
 /// <summary>
@@ -84,6 +87,37 @@ public class ProductDeploymentConfiguration : IEntityTypeConfiguration<ProductDe
 
         builder.Property(d => d.Version)
             .IsConcurrencyToken();
+
+        // Configure OperationMode
+        builder.Property(d => d.OperationMode)
+            .HasConversion(
+                mode => mode.Value,
+                value => OperationMode.FromValue(value))
+            .IsRequired();
+
+        // Configure MaintenanceTrigger as JSON column
+        var triggerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+        };
+        builder.Property(d => d.MaintenanceTrigger)
+            .HasConversion(
+                v => v == null ? null : JsonSerializer.Serialize(v, triggerOptions),
+                v => string.IsNullOrEmpty(v) ? null : DeserializeMaintenanceTrigger(v))
+            .HasColumnName("MaintenanceTriggerJson");
+
+        // Configure MaintenanceObserverConfig as JSON column
+        var observerConfigOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters = { new MaintenanceObserverConfigJsonConverter() }
+        };
+        builder.Property(d => d.MaintenanceObserverConfig)
+            .HasConversion(
+                v => v == null ? null : JsonSerializer.Serialize(v, observerConfigOptions),
+                v => string.IsNullOrEmpty(v) ? null : JsonSerializer.Deserialize<MaintenanceObserverConfig>(v, observerConfigOptions))
+            .HasColumnName("MaintenanceObserverConfigJson");
 
         // Configure SharedVariables as JSON column
         builder.Property(d => d.SharedVariables)
@@ -165,5 +199,29 @@ public class ProductDeploymentConfiguration : IEntityTypeConfiguration<ProductDe
         builder.HasIndex(d => d.EnvironmentId);
         builder.HasIndex(d => d.ProductGroupId);
         builder.HasIndex(d => d.Status);
+    }
+
+    private static MaintenanceTrigger? DeserializeMaintenanceTrigger(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        var source = root.TryGetProperty("source", out var sourceProp)
+            ? Enum.Parse<MaintenanceTriggerSource>(sourceProp.GetString()!, ignoreCase: true)
+            : MaintenanceTriggerSource.Manual;
+
+        var reason = root.TryGetProperty("reason", out var reasonProp) && reasonProp.ValueKind != JsonValueKind.Null
+            ? reasonProp.GetString()
+            : null;
+
+        var triggeredAtUtc = root.TryGetProperty("triggeredAtUtc", out var atProp)
+            ? atProp.GetDateTime()
+            : DateTime.UtcNow;
+
+        var triggeredBy = root.TryGetProperty("triggeredBy", out var byProp) && byProp.ValueKind != JsonValueKind.Null
+            ? byProp.GetString()
+            : null;
+
+        return MaintenanceTrigger.Create(source, reason, triggeredAtUtc, triggeredBy);
     }
 }

--- a/tests/ReadyStackGo.UnitTests/Domain/Deployment/ProductDeploymentMaintenanceTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Domain/Deployment/ProductDeploymentMaintenanceTests.cs
@@ -1,0 +1,346 @@
+using FluentAssertions;
+using ReadyStackGo.Domain.Deployment;
+using ReadyStackGo.Domain.Deployment.Deployments;
+using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.Deployment.Health;
+using ReadyStackGo.Domain.Deployment.Observers;
+using ReadyStackGo.Domain.Deployment.ProductDeployments;
+
+namespace ReadyStackGo.UnitTests.Domain.Deployment;
+
+/// <summary>
+/// Unit tests for ProductDeployment maintenance mode behavior.
+/// Tests trigger-based ownership rules at the product level.
+/// </summary>
+public class ProductDeploymentMaintenanceTests
+{
+    private readonly ProductDeploymentId _productDeploymentId = new(Guid.NewGuid());
+    private readonly EnvironmentId _environmentId = new(Guid.NewGuid());
+    private readonly UserId _userId = UserId.NewId();
+
+    private ProductDeployment CreateRunningProductDeployment()
+    {
+        var stackConfigs = new List<StackDeploymentConfig>
+        {
+            new("db", "Database", "source:product:db:1.0", 1, new Dictionary<string, string>()),
+            new("api", "API Server", "source:product:api:1.0", 2, new Dictionary<string, string>())
+        };
+
+        var pd = ProductDeployment.InitiateDeployment(
+            _productDeploymentId,
+            _environmentId,
+            "product-group",
+            "product-id",
+            "test-product",
+            "Test Product",
+            "1.0.0",
+            _userId,
+            "test-deploy",
+            stackConfigs,
+            new Dictionary<string, string>());
+
+        // Complete all stacks to reach Running status
+        pd.StartStack("db", new DeploymentId(Guid.NewGuid()));
+        pd.CompleteStack("db");
+        pd.StartStack("api", new DeploymentId(Guid.NewGuid()));
+        pd.CompleteStack("api");
+
+        return pd;
+    }
+
+    #region Initial State
+
+    [Fact]
+    public void NewProductDeployment_HasNormalOperationMode()
+    {
+        var pd = CreateRunningProductDeployment();
+
+        pd.OperationMode.Should().Be(OperationMode.Normal);
+        pd.MaintenanceTrigger.Should().BeNull();
+        pd.MaintenanceObserverConfig.Should().BeNull();
+    }
+
+    #endregion
+
+    #region Enter Maintenance
+
+    [Fact]
+    public void EnterMaintenance_Manual_FromRunning_Succeeds()
+    {
+        var pd = CreateRunningProductDeployment();
+
+        pd.EnterMaintenance(MaintenanceTrigger.Manual("Scheduled maintenance", "admin"));
+
+        pd.OperationMode.Should().Be(OperationMode.Maintenance);
+        pd.MaintenanceTrigger.Should().NotBeNull();
+        pd.MaintenanceTrigger!.IsManual.Should().BeTrue();
+        pd.MaintenanceTrigger.Reason.Should().Be("Scheduled maintenance");
+        pd.MaintenanceTrigger.TriggeredBy.Should().Be("admin");
+        pd.Status.Should().Be(ProductDeploymentStatus.Running);
+    }
+
+    [Fact]
+    public void EnterMaintenance_Observer_FromRunning_Succeeds()
+    {
+        var pd = CreateRunningProductDeployment();
+
+        pd.EnterMaintenance(MaintenanceTrigger.Observer("DB maintenance detected", "SqlObserver"));
+
+        pd.OperationMode.Should().Be(OperationMode.Maintenance);
+        pd.MaintenanceTrigger!.IsObserver.Should().BeTrue();
+        pd.MaintenanceTrigger.TriggeredBy.Should().Be("SqlObserver");
+    }
+
+    [Fact]
+    public void EnterMaintenance_FromDeploying_Throws()
+    {
+        var stackConfigs = new List<StackDeploymentConfig>
+        {
+            new("db", "Database", "source:product:db:1.0", 1, new Dictionary<string, string>())
+        };
+
+        var pd = ProductDeployment.InitiateDeployment(
+            _productDeploymentId, _environmentId, "group", "id", "name", "Name", "1.0.0",
+            _userId, "deploy", stackConfigs, new Dictionary<string, string>());
+
+        var act = () => pd.EnterMaintenance(MaintenanceTrigger.Manual("test"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*operational*");
+    }
+
+    [Fact]
+    public void EnterMaintenance_WhenAlreadyInMaintenance_Throws()
+    {
+        var pd = CreateRunningProductDeployment();
+        pd.EnterMaintenance(MaintenanceTrigger.Manual("First"));
+
+        var act = () => pd.EnterMaintenance(MaintenanceTrigger.Manual("Second"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*already*maintenance*");
+    }
+
+    [Fact]
+    public void EnterMaintenance_NullTrigger_Throws()
+    {
+        var pd = CreateRunningProductDeployment();
+
+        var act = () => pd.EnterMaintenance(null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void EnterMaintenance_FromStopped_Throws()
+    {
+        var pd = CreateRunningProductDeployment();
+        pd.MarkAsStopped("User stopped");
+
+        var act = () => pd.EnterMaintenance(MaintenanceTrigger.Manual("test"));
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*operational*");
+    }
+
+    [Fact]
+    public void EnterMaintenance_RaisesProductMaintenanceModeChangedEvent()
+    {
+        var pd = CreateRunningProductDeployment();
+        pd.ClearDomainEvents();
+
+        pd.EnterMaintenance(MaintenanceTrigger.Manual("Test reason"));
+
+        pd.DomainEvents.Should().ContainSingle(e => e is ProductMaintenanceModeChanged);
+        var evt = pd.DomainEvents.OfType<ProductMaintenanceModeChanged>().First();
+        evt.NewMode.Should().Be(OperationMode.Maintenance);
+        evt.Trigger.Should().NotBeNull();
+        evt.Trigger!.IsManual.Should().BeTrue();
+    }
+
+    #endregion
+
+    #region Exit Maintenance — Ownership Rules
+
+    [Fact]
+    public void ExitMaintenance_Manual_FromManualMaintenance_Succeeds()
+    {
+        var pd = CreateRunningProductDeployment();
+        pd.EnterMaintenance(MaintenanceTrigger.Manual("Test"));
+
+        pd.ExitMaintenance(MaintenanceTriggerSource.Manual);
+
+        pd.OperationMode.Should().Be(OperationMode.Normal);
+        pd.MaintenanceTrigger.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExitMaintenance_Observer_FromObserverMaintenance_Succeeds()
+    {
+        var pd = CreateRunningProductDeployment();
+        pd.EnterMaintenance(MaintenanceTrigger.Observer("External"));
+
+        pd.ExitMaintenance(MaintenanceTriggerSource.Observer);
+
+        pd.OperationMode.Should().Be(OperationMode.Normal);
+        pd.MaintenanceTrigger.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExitMaintenance_Manual_FromObserverMaintenance_Throws()
+    {
+        var pd = CreateRunningProductDeployment();
+        pd.EnterMaintenance(MaintenanceTrigger.Observer("External maintenance"));
+
+        var act = () => pd.ExitMaintenance(MaintenanceTriggerSource.Manual);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*observer*");
+    }
+
+    [Fact]
+    public void ExitMaintenance_Observer_FromManualMaintenance_Throws()
+    {
+        var pd = CreateRunningProductDeployment();
+        pd.EnterMaintenance(MaintenanceTrigger.Manual("User maintenance"));
+
+        var act = () => pd.ExitMaintenance(MaintenanceTriggerSource.Observer);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*manually activated*");
+    }
+
+    [Fact]
+    public void ExitMaintenance_WhenNotInMaintenance_Throws()
+    {
+        var pd = CreateRunningProductDeployment();
+
+        var act = () => pd.ExitMaintenance(MaintenanceTriggerSource.Manual);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*not in maintenance*");
+    }
+
+    [Fact]
+    public void ExitMaintenance_RaisesProductMaintenanceModeChangedEvent()
+    {
+        var pd = CreateRunningProductDeployment();
+        pd.EnterMaintenance(MaintenanceTrigger.Manual("Test"));
+        pd.ClearDomainEvents();
+
+        pd.ExitMaintenance(MaintenanceTriggerSource.Manual);
+
+        pd.DomainEvents.Should().ContainSingle(e => e is ProductMaintenanceModeChanged);
+        var evt = pd.DomainEvents.OfType<ProductMaintenanceModeChanged>().First();
+        evt.NewMode.Should().Be(OperationMode.Normal);
+    }
+
+    #endregion
+
+    #region Query Properties
+
+    [Fact]
+    public void CanEnterMaintenance_WhenRunningAndNormal_ReturnsTrue()
+    {
+        var pd = CreateRunningProductDeployment();
+
+        pd.CanEnterMaintenance.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanEnterMaintenance_WhenInMaintenance_ReturnsFalse()
+    {
+        var pd = CreateRunningProductDeployment();
+        pd.EnterMaintenance(MaintenanceTrigger.Manual());
+
+        pd.CanEnterMaintenance.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanExitMaintenance_WhenInMaintenance_ReturnsTrue()
+    {
+        var pd = CreateRunningProductDeployment();
+        pd.EnterMaintenance(MaintenanceTrigger.Manual());
+
+        pd.CanExitMaintenance.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanExitMaintenance_WhenNormal_ReturnsFalse()
+    {
+        var pd = CreateRunningProductDeployment();
+
+        pd.CanExitMaintenance.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region Observer Config
+
+    [Fact]
+    public void SetMaintenanceObserverConfig_StoresConfig()
+    {
+        var pd = CreateRunningProductDeployment();
+        var config = MaintenanceObserverConfig.Create(
+            ObserverType.Http,
+            TimeSpan.FromSeconds(30),
+            "maintenance",
+            "normal",
+            HttpObserverSettings.Create("https://example.com/status"));
+
+        pd.SetMaintenanceObserverConfig(config);
+
+        pd.MaintenanceObserverConfig.Should().Be(config);
+    }
+
+    [Fact]
+    public void SetMaintenanceObserverConfig_Null_ClearsConfig()
+    {
+        var pd = CreateRunningProductDeployment();
+        pd.SetMaintenanceObserverConfig(MaintenanceObserverConfig.Create(
+            ObserverType.Http, TimeSpan.FromSeconds(30), "m", null,
+            HttpObserverSettings.Create("https://example.com")));
+
+        pd.SetMaintenanceObserverConfig(null);
+
+        pd.MaintenanceObserverConfig.Should().BeNull();
+    }
+
+    #endregion
+
+    #region Interaction with Lifecycle
+
+    [Fact]
+    public void MaintenanceMode_DoesNotAffectProductStatus()
+    {
+        var pd = CreateRunningProductDeployment();
+
+        pd.EnterMaintenance(MaintenanceTrigger.Manual("Window"));
+
+        pd.Status.Should().Be(ProductDeploymentStatus.Running);
+        pd.IsOperational.Should().BeTrue();
+    }
+
+    [Fact]
+    public void EnterMaintenance_FromPartiallyRunning_Succeeds()
+    {
+        var stackConfigs = new List<StackDeploymentConfig>
+        {
+            new("db", "Database", "source:product:db:1.0", 1, new Dictionary<string, string>()),
+            new("api", "API", "source:product:api:1.0", 2, new Dictionary<string, string>())
+        };
+
+        var pd = ProductDeployment.InitiateDeployment(
+            _productDeploymentId, _environmentId, "group", "id", "name", "Name", "1.0.0",
+            _userId, "deploy", stackConfigs, new Dictionary<string, string>());
+
+        pd.StartStack("db", new DeploymentId(Guid.NewGuid()));
+        pd.CompleteStack("db");
+        pd.StartStack("api", new DeploymentId(Guid.NewGuid()));
+        pd.FailStack("api", "Connection failed");
+        pd.MarkAsPartiallyRunning("1 of 2 stacks failed");
+
+        pd.EnterMaintenance(MaintenanceTrigger.Manual("Fix API"));
+
+        pd.OperationMode.Should().Be(OperationMode.Maintenance);
+        pd.Status.Should().Be(ProductDeploymentStatus.PartiallyRunning);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- ProductDeployment gets OperationMode, MaintenanceTrigger, and MaintenanceObserverConfig
- Same ownership rules as Deployment: Manual/Observer can only exit what they activated
- ProductMaintenanceModeChanged domain event for mode transitions
- EF Core persistence (OperationMode as int, Trigger + ObserverConfig as JSON)

## Test plan
- [x] 22 new ProductDeployment maintenance tests pass
- [x] 2618 total unit tests pass
- [ ] Integration tests (CI)