### PR TITLE
Add product-level operation mode endpoint and refactor observer service

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/Deployments/ChangeProductOperationModeEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Deployments/ChangeProductOperationModeEndpoint.cs
@@ -1,0 +1,90 @@
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using ReadyStackGo.Api.Authorization;
+using ReadyStackGo.Application.UseCases.Deployments.ChangeProductOperationMode;
+
+namespace ReadyStackGo.API.Endpoints.Deployments;
+
+/// <summary>
+/// API request for changing the operation mode of a product deployment.
+/// </summary>
+public class ChangeProductOperationModeApiRequest
+{
+    /// <summary>
+    /// Environment ID for RBAC scope check (from route).
+    /// </summary>
+    public string? EnvironmentId { get; set; }
+
+    /// <summary>
+    /// Target operation mode: Normal or Maintenance.
+    /// </summary>
+    public string Mode { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional reason for the mode change.
+    /// </summary>
+    public string? Reason { get; set; }
+
+    /// <summary>
+    /// Source of the mode change: "Manual" (default) or "Observer".
+    /// </summary>
+    public string? Source { get; set; }
+}
+
+/// <summary>
+/// PUT /api/environments/{environmentId}/product-deployments/{productDeploymentId}/operation-mode
+/// Changes the operation mode of a product deployment (Normal ↔ Maintenance).
+/// Entering maintenance stops containers of all child stacks.
+/// Exiting maintenance starts containers of all child stacks.
+/// </summary>
+[RequirePermission("Deployments", "Write")]
+public class ChangeProductOperationModeEndpoint
+    : Endpoint<ChangeProductOperationModeApiRequest, ChangeProductOperationModeResponse>
+{
+    private readonly IMediator _mediator;
+
+    public ChangeProductOperationModeEndpoint(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public override void Configure()
+    {
+        Put("/api/environments/{environmentId}/product-deployments/{productDeploymentId}/operation-mode");
+        PreProcessor<RbacPreProcessor<ChangeProductOperationModeApiRequest>>();
+    }
+
+    public override async Task HandleAsync(ChangeProductOperationModeApiRequest req, CancellationToken ct)
+    {
+        var environmentId = Route<string>("environmentId")!;
+        var productDeploymentId = Route<string>("productDeploymentId")!;
+
+        var command = new ChangeProductOperationModeCommand(
+            environmentId,
+            productDeploymentId,
+            req.Mode,
+            req.Reason,
+            req.Source ?? "Manual");
+
+        var response = await _mediator.Send(command, ct);
+
+        if (!response.Success)
+        {
+            if (response.Message?.Contains("not found") == true)
+            {
+                ThrowError(response.Message, StatusCodes.Status404NotFound);
+            }
+
+            if (response.Message?.Contains("Cannot exit maintenance") == true ||
+                response.Message?.Contains("Cannot change operation mode") == true)
+            {
+                ThrowError(response.Message, StatusCodes.Status409Conflict);
+            }
+
+            ThrowError(response.Message ?? "Failed to change operation mode", StatusCodes.Status400BadRequest);
+        }
+
+        Response = response;
+    }
+}

--- a/src/ReadyStackGo.Application/Services/IMaintenanceObserverService.cs
+++ b/src/ReadyStackGo.Application/Services/IMaintenanceObserverService.cs
@@ -1,29 +1,39 @@
 using ReadyStackGo.Domain.Deployment.Deployments;
 using ReadyStackGo.Domain.Deployment.Observers;
+using ReadyStackGo.Domain.Deployment.ProductDeployments;
 
 namespace ReadyStackGo.Application.Services;
 
 /// <summary>
-/// Service responsible for running maintenance observers and updating deployment operation modes.
+/// Service responsible for running maintenance observers and updating operation modes.
+/// Observers are configured at the ProductDeployment level, producing one check per product
+/// instead of N duplicate checks per stack.
 /// </summary>
 public interface IMaintenanceObserverService
 {
     /// <summary>
-    /// Check all configured maintenance observers across all deployments.
+    /// Check all configured maintenance observers across all product deployments.
     /// Updates operation mode to Maintenance if observer indicates maintenance is required.
     /// </summary>
     Task CheckAllObserversAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Check the maintenance observer for a specific deployment.
+    /// Check the maintenance observer for a specific product deployment.
     /// </summary>
-    /// <param name="deploymentId">The deployment to check.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The observer result, or null if no observer is configured.</returns>
+    Task<ObserverResult?> CheckProductObserverAsync(ProductDeploymentId productDeploymentId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the last observer result for a product deployment.
+    /// </summary>
+    Task<ObserverResult?> GetLastResultAsync(ProductDeploymentId productDeploymentId);
+
+    /// <summary>
+    /// Check the maintenance observer for a specific deployment (legacy, looks up parent product).
+    /// </summary>
     Task<ObserverResult?> CheckDeploymentObserverAsync(DeploymentId deploymentId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Gets the last observer result for a deployment.
+    /// Gets the last observer result for a deployment (legacy, looks up parent product).
     /// </summary>
     Task<ObserverResult?> GetLastResultAsync(DeploymentId deploymentId);
 }

--- a/src/ReadyStackGo.Application/Services/Impl/MaintenanceObserverService.cs
+++ b/src/ReadyStackGo.Application/Services/Impl/MaintenanceObserverService.cs
@@ -2,49 +2,50 @@ using System.Collections.Concurrent;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using ReadyStackGo.Application.Services;
-using ReadyStackGo.Application.UseCases.Deployments.ChangeOperationMode;
+using ReadyStackGo.Application.UseCases.Deployments.ChangeProductOperationMode;
 using ReadyStackGo.Domain.Deployment.Deployments;
 using ReadyStackGo.Domain.Deployment.Health;
 using ReadyStackGo.Domain.Deployment.Observers;
+using ReadyStackGo.Domain.Deployment.ProductDeployments;
 
 namespace ReadyStackGo.Application.Services.Impl;
 
 /// <summary>
-/// Service that coordinates maintenance observer checks across all deployments.
-/// Caches observer instances and last results per deployment.
-/// Uses observer configuration stored directly on Deployment entities.
+/// Service that coordinates maintenance observer checks across all product deployments.
+/// Caches observer instances and last results per product deployment.
+/// Uses observer configuration stored on ProductDeployment entities (one check per product).
 /// </summary>
 public class MaintenanceObserverService : IMaintenanceObserverService
 {
     private readonly IMaintenanceObserverFactory _observerFactory;
-    private readonly IDeploymentRepository _deploymentRepository;
+    private readonly IProductDeploymentRepository _productDeploymentRepository;
     private readonly IHealthSnapshotRepository _healthSnapshotRepository;
     private readonly IHealthNotificationService _notificationService;
     private readonly ISender _mediator;
     private readonly ILogger<MaintenanceObserverService> _logger;
 
-    // Cache for observer instances per deployment
+    // Cache for observer instances per product deployment
     private readonly ConcurrentDictionary<Guid, IMaintenanceObserver> _observers = new();
 
-    // Cache for last results per deployment
+    // Cache for last results per product deployment
     private readonly ConcurrentDictionary<Guid, ObserverResult> _lastResults = new();
 
-    // Track last check time per deployment to respect individual polling intervals
+    // Track last check time per product deployment to respect individual polling intervals
     private readonly ConcurrentDictionary<Guid, DateTimeOffset> _lastCheckTimes = new();
 
-    // Cache for observer configs per deployment
+    // Cache for observer configs per product deployment
     private readonly ConcurrentDictionary<Guid, MaintenanceObserverConfig> _configs = new();
 
     public MaintenanceObserverService(
         IMaintenanceObserverFactory observerFactory,
-        IDeploymentRepository deploymentRepository,
+        IProductDeploymentRepository productDeploymentRepository,
         IHealthSnapshotRepository healthSnapshotRepository,
         IHealthNotificationService notificationService,
         ISender mediator,
         ILogger<MaintenanceObserverService> logger)
     {
         _observerFactory = observerFactory;
-        _deploymentRepository = deploymentRepository;
+        _productDeploymentRepository = productDeploymentRepository;
         _healthSnapshotRepository = healthSnapshotRepository;
         _notificationService = notificationService;
         _mediator = mediator;
@@ -55,115 +56,144 @@ public class MaintenanceObserverService : IMaintenanceObserverService
     {
         _logger.LogDebug("Starting maintenance observer check cycle");
 
-        var activeDeployments = _deploymentRepository.GetAllActive().ToList();
+        var activeProductDeployments = _productDeploymentRepository.GetAllActive().ToList();
 
-        foreach (var deployment in activeDeployments)
+        foreach (var productDeployment in activeProductDeployments)
         {
             if (cancellationToken.IsCancellationRequested)
                 break;
 
             try
             {
-                await CheckDeploymentObserverAsync(deployment.Id, cancellationToken);
+                await CheckProductObserverAsync(productDeployment.Id, cancellationToken);
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error checking maintenance observer for deployment {DeploymentId}", deployment.Id);
+                _logger.LogError(ex,
+                    "Error checking maintenance observer for product deployment {ProductDeploymentId} ({ProductName})",
+                    productDeployment.Id, productDeployment.ProductName);
             }
         }
 
         _logger.LogDebug("Maintenance observer check cycle completed");
     }
 
-    public async Task<ObserverResult?> CheckDeploymentObserverAsync(
-        DeploymentId deploymentId,
+    public async Task<ObserverResult?> CheckProductObserverAsync(
+        ProductDeploymentId productDeploymentId,
         CancellationToken cancellationToken = default)
     {
-        var deployment = _deploymentRepository.Get(deploymentId);
-        if (deployment == null)
+        var productDeployment = _productDeploymentRepository.Get(productDeploymentId);
+        if (productDeployment == null)
         {
-            _logger.LogDebug("Deployment {DeploymentId} not found", deploymentId);
+            _logger.LogDebug("Product deployment {ProductDeploymentId} not found", productDeploymentId);
             return null;
         }
 
-        // Only check running deployments
-        if (deployment.Status != DeploymentStatus.Running)
+        // Only check operational product deployments
+        if (!productDeployment.IsOperational)
         {
             return null;
         }
 
-        // Get or create observer for this deployment
-        var observer = await GetOrCreateObserverAsync(deployment);
+        // Get or create observer for this product deployment
+        var observer = GetOrCreateObserver(productDeployment);
         if (observer == null)
         {
-            // No observer configured for this deployment
             return null;
         }
 
         // Check if enough time has passed since last check (respecting polling interval)
-        if (!ShouldCheck(deploymentId.Value))
+        if (!ShouldCheck(productDeploymentId.Value))
         {
-            return _lastResults.GetValueOrDefault(deploymentId.Value);
+            return _lastResults.GetValueOrDefault(productDeploymentId.Value);
         }
 
         // Perform the check
         var result = await observer.CheckAsync(cancellationToken);
 
         // Update caches
-        _lastResults[deploymentId.Value] = result;
-        _lastCheckTimes[deploymentId.Value] = DateTimeOffset.UtcNow;
+        _lastResults[productDeploymentId.Value] = result;
+        _lastCheckTimes[productDeploymentId.Value] = DateTimeOffset.UtcNow;
 
-        // Handle result - log and track for now
-        // Full integration with OperationMode change will be added later
-        await HandleObserverResultAsync(deployment, result, cancellationToken);
+        // Handle result
+        await HandleObserverResultAsync(productDeployment, result, cancellationToken);
 
         return result;
     }
 
-    public Task<ObserverResult?> GetLastResultAsync(DeploymentId deploymentId)
+    public Task<ObserverResult?> GetLastResultAsync(ProductDeploymentId productDeploymentId)
     {
-        var result = _lastResults.GetValueOrDefault(deploymentId.Value);
+        var result = _lastResults.GetValueOrDefault(productDeploymentId.Value);
         return Task.FromResult(result);
     }
 
-    private Task<IMaintenanceObserver?> GetOrCreateObserverAsync(Deployment deployment)
+    public async Task<ObserverResult?> CheckDeploymentObserverAsync(
+        DeploymentId deploymentId,
+        CancellationToken cancellationToken = default)
     {
-        // Try to get cached observer
-        if (_observers.TryGetValue(deployment.Id.Value, out var cachedObserver))
+        // Look up parent product deployment for this stack
+        var productDeployment = _productDeploymentRepository.GetByStackDeploymentId(deploymentId);
+        if (productDeployment == null)
         {
-            return Task.FromResult<IMaintenanceObserver?>(cachedObserver);
+            _logger.LogDebug("No parent product deployment found for deployment {DeploymentId}", deploymentId);
+            return null;
         }
 
-        // Get observer configuration from the deployment entity (set at deploy time)
-        var observerConfig = deployment.MaintenanceObserverConfig;
+        return await CheckProductObserverAsync(productDeployment.Id, cancellationToken);
+    }
+
+    public Task<ObserverResult?> GetLastResultAsync(DeploymentId deploymentId)
+    {
+        // Look up parent product deployment for this stack
+        var productDeployment = _productDeploymentRepository.GetByStackDeploymentId(deploymentId);
+        if (productDeployment == null)
+        {
+            return Task.FromResult<ObserverResult?>(null);
+        }
+
+        return GetLastResultAsync(productDeployment.Id);
+    }
+
+    private IMaintenanceObserver? GetOrCreateObserver(ProductDeployment productDeployment)
+    {
+        var id = productDeployment.Id.Value;
+
+        // Try to get cached observer
+        if (_observers.TryGetValue(id, out var cachedObserver))
+        {
+            return cachedObserver;
+        }
+
+        // Get observer configuration from the product deployment
+        var observerConfig = productDeployment.MaintenanceObserverConfig;
         if (observerConfig == null)
         {
-            _logger.LogDebug("No maintenance observer configured for deployment {StackName}", deployment.StackName);
-            return Task.FromResult<IMaintenanceObserver?>(null);
+            _logger.LogDebug("No maintenance observer configured for product {ProductName}",
+                productDeployment.ProductName);
+            return null;
         }
 
         // Create observer and cache it
         var observer = _observerFactory.Create(observerConfig);
-        _observers[deployment.Id.Value] = observer;
-        _configs[deployment.Id.Value] = observerConfig;
+        _observers[id] = observer;
+        _configs[id] = observerConfig;
 
         _logger.LogInformation(
-            "Created maintenance observer for deployment {StackName}: type={ObserverType}",
-            deployment.StackName, observer.Type.DisplayName);
+            "Created maintenance observer for product {ProductName}: type={ObserverType}",
+            productDeployment.ProductName, observer.Type.DisplayName);
 
-        return Task.FromResult<IMaintenanceObserver?>(observer);
+        return observer;
     }
 
-    private bool ShouldCheck(Guid deploymentId)
+    private bool ShouldCheck(Guid productDeploymentId)
     {
-        if (!_lastCheckTimes.TryGetValue(deploymentId, out var lastCheck))
+        if (!_lastCheckTimes.TryGetValue(productDeploymentId, out var lastCheck))
         {
             return true;
         }
 
-        // Get polling interval from config if available
         var interval = TimeSpan.FromSeconds(30);
-        if (_configs.TryGetValue(deploymentId, out var config))
+        if (_configs.TryGetValue(productDeploymentId, out var config))
         {
             interval = config.PollingInterval;
         }
@@ -172,44 +202,54 @@ public class MaintenanceObserverService : IMaintenanceObserverService
     }
 
     private async Task HandleObserverResultAsync(
-        Deployment deployment,
+        ProductDeployment productDeployment,
         ObserverResult result,
         CancellationToken cancellationToken)
     {
+        var id = productDeployment.Id.Value;
+
         // Get observer type for notification
-        var observerType = _configs.TryGetValue(deployment.Id.Value, out var config)
+        var observerType = _configs.TryGetValue(id, out var config)
             ? config.Type.Value
             : null;
 
-        // Always notify clients about observer results (success or failure)
+        // Notify clients about observer results for each running stack
         var resultDto = ObserverResultDto.FromDomain(result, observerType);
-        await _notificationService.NotifyObserverResultAsync(
-            deployment.Id,
-            deployment.StackName,
-            resultDto,
-            cancellationToken);
+        foreach (var stack in productDeployment.Stacks.Where(s => s.Status == StackDeploymentStatus.Running))
+        {
+            if (stack.DeploymentId != null)
+            {
+                await _notificationService.NotifyObserverResultAsync(
+                    stack.DeploymentId,
+                    stack.StackName,
+                    resultDto,
+                    cancellationToken);
+            }
+        }
 
         if (!result.IsSuccess)
         {
             _logger.LogWarning(
-                "Maintenance observer check failed for {StackName}: {Error}",
-                deployment.StackName, result.ErrorMessage);
+                "Maintenance observer check failed for product {ProductName}: {Error}",
+                productDeployment.ProductName, result.ErrorMessage);
             return;
         }
 
-        // Get current operation mode from deployment (OperationMode is now on Deployment aggregate)
-        var currentMode = deployment.OperationMode;
+        var currentMode = productDeployment.OperationMode;
         var shouldBeMaintenance = result.IsMaintenanceRequired;
+        var environmentId = productDeployment.EnvironmentId.Value.ToString();
+        var productDeploymentId = productDeployment.Id.Value.ToString();
 
-        // Handle mode transitions via the business logic (ChangeOperationModeCommand)
+        // Handle mode transitions via ChangeProductOperationModeCommand
         if (shouldBeMaintenance && currentMode != OperationMode.Maintenance)
         {
             _logger.LogInformation(
-                "Maintenance observer triggered maintenance mode for {StackName} (observed: {Value})",
-                deployment.StackName, result.ObservedValue);
+                "Maintenance observer triggered maintenance mode for product {ProductName} (observed: {Value})",
+                productDeployment.ProductName, result.ObservedValue);
 
-            var command = new ChangeOperationModeCommand(
-                deployment.Id.Value.ToString(),
+            var command = new ChangeProductOperationModeCommand(
+                environmentId,
+                productDeploymentId,
                 OperationMode.Maintenance.Name,
                 Reason: $"Triggered by maintenance observer (observed: {result.ObservedValue})",
                 Source: "Observer");
@@ -218,28 +258,28 @@ public class MaintenanceObserverService : IMaintenanceObserverService
             if (!response.Success)
             {
                 _logger.LogWarning(
-                    "Failed to enter maintenance mode for {StackName}: {Message}",
-                    deployment.StackName, response.Message);
+                    "Failed to enter maintenance mode for product {ProductName}: {Message}",
+                    productDeployment.ProductName, response.Message);
             }
         }
         else if (!shouldBeMaintenance && currentMode == OperationMode.Maintenance)
         {
             // Observer can only exit maintenance it activated itself.
-            // If trigger is Manual, skip (manual has priority).
-            if (deployment.MaintenanceTrigger?.IsManual == true)
+            if (productDeployment.MaintenanceTrigger?.IsManual == true)
             {
                 _logger.LogDebug(
-                    "Observer skipping exit for {StackName}: maintenance was manually activated",
-                    deployment.StackName);
+                    "Observer skipping exit for product {ProductName}: maintenance was manually activated",
+                    productDeployment.ProductName);
                 return;
             }
 
             _logger.LogInformation(
-                "Maintenance observer cleared maintenance mode for {StackName} (observed: {Value})",
-                deployment.StackName, result.ObservedValue);
+                "Maintenance observer cleared maintenance mode for product {ProductName} (observed: {Value})",
+                productDeployment.ProductName, result.ObservedValue);
 
-            var command = new ChangeOperationModeCommand(
-                deployment.Id.Value.ToString(),
+            var command = new ChangeProductOperationModeCommand(
+                environmentId,
+                productDeploymentId,
                 OperationMode.Normal.Name,
                 Reason: $"Cleared by maintenance observer (observed: {result.ObservedValue})",
                 Source: "Observer");
@@ -248,8 +288,8 @@ public class MaintenanceObserverService : IMaintenanceObserverService
             if (!response.Success)
             {
                 _logger.LogWarning(
-                    "Failed to exit maintenance mode for {StackName}: {Message}",
-                    deployment.StackName, response.Message);
+                    "Failed to exit maintenance mode for product {ProductName}: {Message}",
+                    productDeployment.ProductName, response.Message);
             }
         }
     }

--- a/src/ReadyStackGo.Application/UseCases/Deployments/ChangeProductOperationMode/ChangeProductOperationModeCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/ChangeProductOperationMode/ChangeProductOperationModeCommand.cs
@@ -1,0 +1,42 @@
+namespace ReadyStackGo.Application.UseCases.Deployments.ChangeProductOperationMode;
+
+using MediatR;
+
+/// <summary>
+/// Command to change the operation mode of a product deployment.
+/// Maintenance mode stops containers of all child stacks.
+/// </summary>
+public record ChangeProductOperationModeCommand(
+    string EnvironmentId,
+    string ProductDeploymentId,
+    string NewMode,
+    string? Reason = null,
+    string Source = "Manual") : IRequest<ChangeProductOperationModeResponse>;
+
+/// <summary>
+/// Response from changing product operation mode.
+/// </summary>
+public record ChangeProductOperationModeResponse
+{
+    public bool Success { get; init; }
+    public string? Message { get; init; }
+    public string? ProductDeploymentId { get; init; }
+    public string? PreviousMode { get; init; }
+    public string? NewMode { get; init; }
+    public string? TriggerSource { get; init; }
+
+    public static ChangeProductOperationModeResponse Ok(
+        string productDeploymentId, string previousMode, string newMode, string? triggerSource = null) =>
+        new()
+        {
+            Success = true,
+            ProductDeploymentId = productDeploymentId,
+            PreviousMode = previousMode,
+            NewMode = newMode,
+            TriggerSource = triggerSource,
+            Message = $"Operation mode changed from {previousMode} to {newMode}"
+        };
+
+    public static ChangeProductOperationModeResponse Fail(string message) =>
+        new() { Success = false, Message = message };
+}

--- a/src/ReadyStackGo.Application/UseCases/Deployments/ChangeProductOperationMode/ChangeProductOperationModeHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/ChangeProductOperationMode/ChangeProductOperationModeHandler.cs
@@ -1,0 +1,159 @@
+namespace ReadyStackGo.Application.UseCases.Deployments.ChangeProductOperationMode;
+
+using MediatR;
+using Microsoft.Extensions.Logging;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Application.UseCases.Health;
+using ReadyStackGo.Domain.Deployment.Deployments;
+using ReadyStackGo.Domain.Deployment.Health;
+using ReadyStackGo.Domain.Deployment.Observers;
+using ReadyStackGo.Domain.Deployment.ProductDeployments;
+
+/// <summary>
+/// Handler for changing the operation mode of a product deployment.
+/// Entering maintenance stops containers of ALL child stacks.
+/// Exiting maintenance starts containers of ALL child stacks.
+/// </summary>
+public class ChangeProductOperationModeHandler
+    : IRequestHandler<ChangeProductOperationModeCommand, ChangeProductOperationModeResponse>
+{
+    private readonly IProductDeploymentRepository _productDeploymentRepository;
+    private readonly IDockerService _dockerService;
+    private readonly IHealthNotificationService _healthNotificationService;
+    private readonly ILogger<ChangeProductOperationModeHandler> _logger;
+
+    public ChangeProductOperationModeHandler(
+        IProductDeploymentRepository productDeploymentRepository,
+        IDockerService dockerService,
+        IHealthNotificationService healthNotificationService,
+        ILogger<ChangeProductOperationModeHandler> logger)
+    {
+        _productDeploymentRepository = productDeploymentRepository;
+        _dockerService = dockerService;
+        _healthNotificationService = healthNotificationService;
+        _logger = logger;
+    }
+
+    public async Task<ChangeProductOperationModeResponse> Handle(
+        ChangeProductOperationModeCommand request,
+        CancellationToken cancellationToken)
+    {
+        if (!Guid.TryParse(request.ProductDeploymentId, out var productDeploymentGuid))
+        {
+            return ChangeProductOperationModeResponse.Fail("Invalid product deployment ID format");
+        }
+
+        var productDeploymentId = new ProductDeploymentId(productDeploymentGuid);
+        var productDeployment = _productDeploymentRepository.Get(productDeploymentId);
+
+        if (productDeployment == null)
+        {
+            return ChangeProductOperationModeResponse.Fail("Product deployment not found");
+        }
+
+        if (!productDeployment.IsOperational)
+        {
+            return ChangeProductOperationModeResponse.Fail(
+                $"Cannot change operation mode. Product deployment is {productDeployment.Status}, must be Running or PartiallyRunning.");
+        }
+
+        if (!OperationMode.TryFromName(request.NewMode, out var targetMode) || targetMode == null)
+        {
+            var validModes = string.Join(", ", OperationMode.GetAll().Select(m => m.Name));
+            return ChangeProductOperationModeResponse.Fail(
+                $"Invalid operation mode '{request.NewMode}'. Valid modes: {validModes}");
+        }
+
+        var previousMode = productDeployment.OperationMode;
+
+        if (previousMode == targetMode)
+        {
+            return ChangeProductOperationModeResponse.Ok(
+                request.ProductDeploymentId, previousMode.Name, targetMode.Name);
+        }
+
+        var source = string.Equals(request.Source, "Observer", StringComparison.OrdinalIgnoreCase)
+            ? MaintenanceTriggerSource.Observer
+            : MaintenanceTriggerSource.Manual;
+
+        try
+        {
+            if (targetMode == OperationMode.Maintenance)
+            {
+                var trigger = source == MaintenanceTriggerSource.Observer
+                    ? MaintenanceTrigger.Observer(request.Reason)
+                    : MaintenanceTrigger.Manual(request.Reason);
+                productDeployment.EnterMaintenance(trigger);
+            }
+            else if (targetMode == OperationMode.Normal)
+            {
+                productDeployment.ExitMaintenance(source);
+            }
+            else
+            {
+                return ChangeProductOperationModeResponse.Fail($"Unknown target mode: {targetMode.Name}");
+            }
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            _logger.LogWarning(ex, "Failed to change operation mode for product deployment {ProductDeploymentId}",
+                request.ProductDeploymentId);
+            return ChangeProductOperationModeResponse.Fail(ex.Message);
+        }
+
+        _productDeploymentRepository.SaveChanges();
+
+        _logger.LogInformation(
+            "Changed operation mode for product deployment {ProductDeploymentId} ({ProductName}) from {PreviousMode} to {NewMode}",
+            request.ProductDeploymentId, productDeployment.ProductName, previousMode.Name, targetMode.Name);
+
+        // Handle container lifecycle for ALL child stacks
+        await HandleContainerLifecycleAsync(
+            productDeployment, previousMode, targetMode, cancellationToken);
+
+        return ChangeProductOperationModeResponse.Ok(
+            request.ProductDeploymentId, previousMode.Name, targetMode.Name, source.ToString());
+    }
+
+    private async Task HandleContainerLifecycleAsync(
+        ProductDeployment productDeployment,
+        OperationMode previousMode,
+        OperationMode targetMode,
+        CancellationToken cancellationToken)
+    {
+        var environmentId = productDeployment.EnvironmentId.Value.ToString();
+
+        foreach (var stack in productDeployment.Stacks)
+        {
+            if (stack.Status != StackDeploymentStatus.Running) continue;
+
+            try
+            {
+                if (targetMode == OperationMode.Maintenance)
+                {
+                    _logger.LogInformation(
+                        "Stopping containers for stack {StackName} (product maintenance)",
+                        stack.StackName);
+
+                    await _dockerService.StopStackContainersAsync(
+                        environmentId, stack.DeploymentStackName!, cancellationToken);
+                }
+                else if (previousMode == OperationMode.Maintenance && targetMode == OperationMode.Normal)
+                {
+                    _logger.LogInformation(
+                        "Starting containers for stack {StackName} (product maintenance exit)",
+                        stack.StackName);
+
+                    await _dockerService.StartStackContainersAsync(
+                        environmentId, stack.DeploymentStackName!, cancellationToken);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Failed to manage containers for stack {StackName} during product mode transition",
+                    stack.StackName);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ChangeProductOperationModeEndpoint` at `PUT /api/environments/{environmentId}/product-deployments/{productDeploymentId}/operation-mode` with 409 Conflict for ownership-blocked transitions
- Add `ChangeProductOperationModeHandler` that stops/starts containers of all child stacks during maintenance transitions
- Refactor `MaintenanceObserverService` to iterate `ProductDeployments` instead of individual `Deployments` — one observer check per product instead of N duplicate checks per stack
- Update `IMaintenanceObserverService` interface with product-level methods (`CheckProductObserverAsync`, `GetLastResultAsync(ProductDeploymentId)`) while keeping legacy deployment-level methods via parent product lookup

## Test plan
- [x] Build compiles with 0 errors
- [x] All 2618 unit tests pass
- [ ] Integration tests for product operation mode change
- [ ] E2E tests for product maintenance UI (Phase 3)