### PR TITLE
Plan maintenance mode pages with confirmation and feedback

### DIFF
--- a/docs/Plans/PLAN-maintenance-mode-pages.md
+++ b/docs/Plans/PLAN-maintenance-mode-pages.md
@@ -1,0 +1,99 @@
+# Phase: Maintenance Mode Pages
+
+## Ziel
+
+Enter/Exit Maintenance bekommt eigene Seiten mit Bestätigung und Rückmeldung — analog zu StopProduct/RestartProduct. Aktuell sind es nur Buttons auf der ProductDeploymentDetail-Seite ohne Bestätigung, ohne Übersicht betroffener Stacks, ohne Ergebnis-Anzeige.
+
+## Analyse
+
+### Bestehende Architektur
+
+**Pattern-Vorlage: StopProduct** (identischer Flow)
+- `useStopProductStore` (`packages/core/src/hooks/useStopProductStore.ts`) — State Machine: loading → confirm → stopping → success/error
+- `StopProduct.tsx` (`packages/ui-generic/src/pages/Deployments/StopProduct.tsx`) — 5 States: Loading, Error (no deployment), Confirm, Stopping, Success, Error (partial)
+- Route: `/stop-product/:productDeploymentId` in `App.tsx`
+- ProductDeploymentDetail verlinkt per `<Link to={/stop-product/...}>`
+
+**Bestehende Maintenance-API** (bereits vorhanden, kein Backend-Änderung nötig):
+- `enterProductMaintenanceMode(environmentId, productDeploymentId, request)` in `packages/core/src/api/health.ts`
+- `exitProductMaintenanceMode(environmentId, productDeploymentId)` in `packages/core/src/api/health.ts`
+- Response: `ChangeProductOperationModeResponse` mit `success`, `message`, `previousMode`, `newMode`
+
+**Aktuell**: `handleEnterMaintenance`/`handleExitMaintenance` in `useProductDeploymentDetailStore` — direkte API-Aufrufe ohne eigene Seite.
+
+### Betroffene Bounded Contexts
+- **Domain**: Keine Änderung (Maintenance-Logik existiert bereits)
+- **Application**: Keine Änderung (Handler existiert bereits)
+- **Infrastructure**: Keine Änderung
+- **API**: Keine Änderung (Endpoint existiert bereits)
+- **WebUI (rsgo-generic)**: Neue Seiten + Store + Route
+
+## AMS UI Counterpart
+
+- [x] **Ja (deferred)** — AMS-Counterpart wird später geplant
+  - Begründung: AMS UI hat noch keinen vollständigen Maintenance-Support (siehe PLAN-maintenance-mode-status-fix.md)
+  - Erinnerung: Nach Umsetzung der AMS-Maintenance-Fixes als Follow-up planen
+
+## Features / Schritte
+
+- [ ] **Feature 1: `useMaintenanceProductStore` Hook** — Neuer Store analog zu `useStopProductStore`
+  - State Machine: `loading` → `confirm` → `entering`/`exiting` → `success` → `error`
+  - Lädt ProductDeployment-Daten für Confirm-Ansicht
+  - Ruft `enterProductMaintenanceMode` / `exitProductMaintenanceMode` auf
+  - Gibt Ergebnis mit `ChangeProductOperationModeResponse` zurück
+  - Betroffene Dateien:
+    - `packages/core/src/hooks/useMaintenanceProductStore.ts` (neu)
+    - `packages/core/src/index.ts` (Export hinzufügen)
+  - Pattern-Vorlage: `packages/core/src/hooks/useStopProductStore.ts`
+
+- [ ] **Feature 2: `EnterMaintenanceProduct.tsx` Seite** — Bestätigungsseite für Enter Maintenance
+  - States: Loading, Error, Confirm (mit Stack-Liste + Warnung), Entering (Spinner), Success, Error (mit Details)
+  - Confirm zeigt: Product Name, Version, Environment, Stacks, Service-Count
+  - Warning: "This will stop all containers and enter maintenance mode"
+  - Success: "Maintenance Mode Activated" mit Mode-Übergang (Normal → Maintenance)
+  - Route: `/enter-maintenance/:productDeploymentId`
+  - Betroffene Dateien:
+    - `packages/ui-generic/src/pages/Deployments/EnterMaintenanceProduct.tsx` (neu)
+    - `apps/rsgo-generic/src/App.tsx` (Route hinzufügen)
+  - Pattern-Vorlage: `packages/ui-generic/src/pages/Deployments/StopProduct.tsx`
+
+- [ ] **Feature 3: `ExitMaintenanceProduct.tsx` Seite** — Bestätigungsseite für Exit Maintenance
+  - States: Loading, Error, Confirm, Exiting (Spinner), Success, Error
+  - Confirm zeigt: Product Name, aktuelle Maintenance-Info (Trigger, Grund, Seit wann)
+  - Warning: "This will restart all containers and exit maintenance mode"
+  - Success: "Maintenance Mode Deactivated" mit Mode-Übergang (Maintenance → Normal)
+  - Route: `/exit-maintenance/:productDeploymentId`
+  - Betroffene Dateien:
+    - `packages/ui-generic/src/pages/Deployments/ExitMaintenanceProduct.tsx` (neu)
+    - `apps/rsgo-generic/src/App.tsx` (Route hinzufügen)
+  - Pattern-Vorlage: `packages/ui-generic/src/pages/Deployments/StopProduct.tsx`
+
+- [ ] **Feature 4: ProductDeploymentDetail — Buttons durch Links ersetzen**
+  - "Enter Maintenance" Button → `<Link to={/enter-maintenance/...}>` Button-Style
+  - "Exit Maintenance" Button → `<Link to={/exit-maintenance/...}>` Button-Style
+  - `handleEnterMaintenance`/`handleExitMaintenance` und `modeActionLoading`/`modeActionError` aus Store entfernen
+  - Betroffene Dateien:
+    - `packages/ui-generic/src/pages/Deployments/ProductDeploymentDetail.tsx`
+    - `packages/core/src/hooks/useProductDeploymentDetailStore.ts` (Maintenance-Handler entfernen)
+
+- [ ] **Feature 5: Unit Tests**
+  - Test: `useMaintenanceProductStore` State Transitions
+  - Betroffene Dateien:
+    - `tests/ReadyStackGo.UnitTests/` (falls Store-Logik testbar)
+
+- [ ] **Dokumentation & Website**
+- [ ] **Phase abschließen** — Alle Tests grün, PR gegen main
+
+## Test-Strategie
+- **Unit Tests**: Store State Machine (loading → confirm → entering → success/error)
+- **E2E Tests**: Enter Maintenance Flow, Exit Maintenance Flow, Cancel-Button, Error-State
+
+## Offene Punkte
+- (keine)
+
+## Entscheidungen
+| Entscheidung | Optionen | Gewählt | Begründung |
+|---|---|---|---|
+| Scope | Product + Stack, Nur Product | **Nur Product** | User-Entscheidung — Stack-Level bleibt Button-Klick |
+| Confirm-Felder | Grund + Bestätigung, Nur Bestätigung, Grund + Checkboxen | **Nur Bestätigung** | User-Entscheidung — analog StopProduct Pattern |
+| Pattern | Eigenes Pattern, StopProduct-Analogie | **StopProduct-Analogie** | Bewährtes Pattern, konsistente UX |

--- a/docs/Reference/Roadmap.md
+++ b/docs/Reference/Roadmap.md
@@ -332,12 +332,19 @@ Release version numbers are assigned when an Epic ships, not during planning.
   - Product operation mode API endpoint with 409 Conflict for ownership-blocked transitions
   - Product detail page: enter/exit maintenance buttons, operation mode badge, trigger info panel
   - 23 new handler unit tests, 22 domain unit tests, 11 value object unit tests
+  - Fix: Maintenance mode propagation to child stacks (OperationMode + status badge override)
 
 ---
 
 ## Planned
 
 Epics are listed in priority order. Top = next.
+
+### Epic: Maintenance Mode Pages
+- Dedicated Enter/Exit Maintenance pages with confirmation and feedback (analog to StopProduct)
+- `useMaintenanceProductStore` hook with state machine (loading → confirm → entering/exiting → success/error)
+- Stack list preview and result summary on confirmation/success pages
+- Replace inline buttons on ProductDeploymentDetail with page navigation links
 
 ### Epic: OCI Stack Bundles
 


### PR DESCRIPTION
## Summary

- Add `PLAN-maintenance-mode-pages.md` — dedicated Enter/Exit Maintenance pages with confirmation dialogs and result feedback, following the StopProduct pattern
- Update roadmap: add maintenance fix note to v0.48, add new planned epic "Maintenance Mode Pages"

## Details

Currently Enter/Exit Maintenance is a direct button click on ProductDeploymentDetail without confirmation, stack preview, or result feedback. This plan introduces:

- `useMaintenanceProductStore` hook (state machine: loading → confirm → entering/exiting → success/error)
- `EnterMaintenanceProduct.tsx` — confirmation page showing affected stacks, then success/error result
- `ExitMaintenanceProduct.tsx` — same pattern for exiting maintenance
- Replace inline buttons with `<Link>` navigation to dedicated pages