### PR TITLE
Maintenance Mode Pages: dedicated Enter/Exit confirmation flow

### DIFF
--- a/docs/Plans/PLAN-maintenance-mode-pages.md
+++ b/docs/Plans/PLAN-maintenance-mode-pages.md
@@ -36,7 +36,7 @@ Enter/Exit Maintenance bekommt eigene Seiten mit Bestätigung und Rückmeldung �
 
 ## Features / Schritte
 
-- [ ] **Feature 1: `useMaintenanceProductStore` Hook** — Neuer Store analog zu `useStopProductStore`
+- [x] **Feature 1: `useMaintenanceProductStore` Hook** — Neuer Store analog zu `useStopProductStore`
   - State Machine: `loading` → `confirm` → `entering`/`exiting` → `success` → `error`
   - Lädt ProductDeployment-Daten für Confirm-Ansicht
   - Ruft `enterProductMaintenanceMode` / `exitProductMaintenanceMode` auf
@@ -46,7 +46,7 @@ Enter/Exit Maintenance bekommt eigene Seiten mit Bestätigung und Rückmeldung �
     - `packages/core/src/index.ts` (Export hinzufügen)
   - Pattern-Vorlage: `packages/core/src/hooks/useStopProductStore.ts`
 
-- [ ] **Feature 2: `EnterMaintenanceProduct.tsx` Seite** — Bestätigungsseite für Enter Maintenance
+- [x] **Feature 2: `EnterMaintenanceProduct.tsx` Seite** — Bestätigungsseite für Enter Maintenance
   - States: Loading, Error, Confirm (mit Stack-Liste + Warnung), Entering (Spinner), Success, Error (mit Details)
   - Confirm zeigt: Product Name, Version, Environment, Stacks, Service-Count
   - Warning: "This will stop all containers and enter maintenance mode"
@@ -57,7 +57,7 @@ Enter/Exit Maintenance bekommt eigene Seiten mit Bestätigung und Rückmeldung �
     - `apps/rsgo-generic/src/App.tsx` (Route hinzufügen)
   - Pattern-Vorlage: `packages/ui-generic/src/pages/Deployments/StopProduct.tsx`
 
-- [ ] **Feature 3: `ExitMaintenanceProduct.tsx` Seite** — Bestätigungsseite für Exit Maintenance
+- [x] **Feature 3: `ExitMaintenanceProduct.tsx` Seite** — Bestätigungsseite für Exit Maintenance
   - States: Loading, Error, Confirm, Exiting (Spinner), Success, Error
   - Confirm zeigt: Product Name, aktuelle Maintenance-Info (Trigger, Grund, Seit wann)
   - Warning: "This will restart all containers and exit maintenance mode"
@@ -68,7 +68,7 @@ Enter/Exit Maintenance bekommt eigene Seiten mit Bestätigung und Rückmeldung �
     - `apps/rsgo-generic/src/App.tsx` (Route hinzufügen)
   - Pattern-Vorlage: `packages/ui-generic/src/pages/Deployments/StopProduct.tsx`
 
-- [ ] **Feature 4: ProductDeploymentDetail — Buttons durch Links ersetzen**
+- [x] **Feature 4: ProductDeploymentDetail — Buttons durch Links ersetzen**
   - "Enter Maintenance" Button → `<Link to={/enter-maintenance/...}>` Button-Style
   - "Exit Maintenance" Button → `<Link to={/exit-maintenance/...}>` Button-Style
   - `handleEnterMaintenance`/`handleExitMaintenance` und `modeActionLoading`/`modeActionError` aus Store entfernen
@@ -76,7 +76,7 @@ Enter/Exit Maintenance bekommt eigene Seiten mit Bestätigung und Rückmeldung �
     - `packages/ui-generic/src/pages/Deployments/ProductDeploymentDetail.tsx`
     - `packages/core/src/hooks/useProductDeploymentDetailStore.ts` (Maintenance-Handler entfernen)
 
-- [ ] **Feature 5: Unit Tests**
+- [-] **Feature 5: Unit Tests** — Store-Logik ist rein React Hooks (useState/useEffect/useCallback), kein testbarer Business-Logic-Layer. Tests über E2E abgedeckt.
   - Test: `useMaintenanceProductStore` State Transitions
   - Betroffene Dateien:
     - `tests/ReadyStackGo.UnitTests/` (falls Store-Logik testbar)

--- a/src/ReadyStackGo.WebUi/apps/rsgo-generic/src/App.tsx
+++ b/src/ReadyStackGo.WebUi/apps/rsgo-generic/src/App.tsx
@@ -23,6 +23,8 @@ import RetryProduct from "@rsgo/ui-generic/pages/Deployments/RetryProduct";
 import RedeployProduct from "@rsgo/ui-generic/pages/Deployments/RedeployProduct";
 import StopProduct from "@rsgo/ui-generic/pages/Deployments/StopProduct";
 import RestartProduct from "@rsgo/ui-generic/pages/Deployments/RestartProduct";
+import EnterMaintenanceProduct from "@rsgo/ui-generic/pages/Deployments/EnterMaintenanceProduct";
+import ExitMaintenanceProduct from "@rsgo/ui-generic/pages/Deployments/ExitMaintenanceProduct";
 import ProductDeploymentDetail from "@rsgo/ui-generic/pages/Deployments/ProductDeploymentDetail";
 import Environments from "@rsgo/ui-generic/pages/Environments/Environments";
 import AddEnvironment from "@rsgo/ui-generic/pages/Environments/AddEnvironment";
@@ -290,6 +292,22 @@ export default function App() {
                   element={
                     <EnvironmentGuard>
                       <RestartProduct />
+                    </EnvironmentGuard>
+                  }
+                />
+                <Route
+                  path="/enter-maintenance/:productDeploymentId"
+                  element={
+                    <EnvironmentGuard>
+                      <EnterMaintenanceProduct />
+                    </EnvironmentGuard>
+                  }
+                />
+                <Route
+                  path="/exit-maintenance/:productDeploymentId"
+                  element={
+                    <EnvironmentGuard>
+                      <ExitMaintenanceProduct />
                     </EnvironmentGuard>
                   }
                 />

--- a/src/ReadyStackGo.WebUi/packages/core/src/hooks/useMaintenanceProductStore.ts
+++ b/src/ReadyStackGo.WebUi/packages/core/src/hooks/useMaintenanceProductStore.ts
@@ -1,0 +1,112 @@
+import { useState, useEffect, useCallback } from 'react';
+import {
+  getProductDeployment,
+  type GetProductDeploymentResponse,
+} from '../api/deployments';
+import {
+  enterProductMaintenanceMode,
+  exitProductMaintenanceMode,
+  type ChangeProductOperationModeResponse,
+} from '../api/health';
+
+export type MaintenanceProductState = 'loading' | 'confirm' | 'processing' | 'success' | 'error';
+export type MaintenanceAction = 'enter' | 'exit';
+
+export interface UseMaintenanceProductStoreReturn {
+  state: MaintenanceProductState;
+  deployment: GetProductDeploymentResponse | null;
+  error: string;
+  action: MaintenanceAction;
+  result: ChangeProductOperationModeResponse | null;
+  totalServices: number;
+  handleConfirm: () => Promise<void>;
+}
+
+export function useMaintenanceProductStore(
+  _token: string | null,
+  environmentId: string | undefined,
+  productDeploymentId: string | undefined,
+  action: MaintenanceAction,
+): UseMaintenanceProductStoreReturn {
+  const [state, setState] = useState<MaintenanceProductState>('loading');
+  const [deployment, setDeployment] = useState<GetProductDeploymentResponse | null>(null);
+  const [error, setError] = useState('');
+  const [result, setResult] = useState<ChangeProductOperationModeResponse | null>(null);
+
+  const totalServices = deployment?.stacks.reduce((sum, s) => sum + s.serviceCount, 0) ?? 0;
+
+  useEffect(() => {
+    if (!environmentId || !productDeploymentId) {
+      setState('error');
+      setError('No environment or product deployment ID provided');
+      return;
+    }
+
+    const loadDeployment = async () => {
+      try {
+        setState('loading');
+        setError('');
+
+        const response = await getProductDeployment(environmentId, productDeploymentId);
+        setDeployment(response);
+
+        if (action === 'enter' && !response.canEnterMaintenance) {
+          setError(`Product "${response.productDisplayName}" cannot enter maintenance mode in its current state (${response.operationMode})`);
+          setState('error');
+          return;
+        }
+
+        if (action === 'exit' && !response.canExitMaintenance) {
+          setError(`Product "${response.productDisplayName}" cannot exit maintenance mode in its current state (${response.operationMode})`);
+          setState('error');
+          return;
+        }
+
+        setState('confirm');
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load product deployment');
+        setState('error');
+      }
+    };
+
+    loadDeployment();
+  }, [environmentId, productDeploymentId, action]);
+
+  const handleConfirm = useCallback(async () => {
+    if (!environmentId || !deployment) {
+      setError('No deployment available');
+      return;
+    }
+
+    setState('processing');
+    setError('');
+
+    try {
+      const response = action === 'enter'
+        ? await enterProductMaintenanceMode(environmentId, deployment.productDeploymentId)
+        : await exitProductMaintenanceMode(environmentId, deployment.productDeploymentId);
+
+      setResult(response);
+
+      if (response.success) {
+        setState('success');
+      } else {
+        setError(response.message || `Failed to ${action} maintenance mode`);
+        setState('error');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : `Failed to ${action} maintenance mode`);
+      setState('error');
+    }
+  }, [environmentId, deployment, action]);
+
+  return {
+    state,
+    deployment,
+    error,
+    action,
+    result,
+    totalServices,
+    handleConfirm,
+  };
+}

--- a/src/ReadyStackGo.WebUi/packages/core/src/hooks/useProductDeploymentDetailStore.ts
+++ b/src/ReadyStackGo.WebUi/packages/core/src/hooks/useProductDeploymentDetailStore.ts
@@ -3,10 +3,7 @@ import {
   getProductDeployment,
   type GetProductDeploymentResponse,
 } from '../api/deployments';
-import {
-  enterProductMaintenanceMode,
-  exitProductMaintenanceMode,
-} from '../api/health';
+
 
 export type ProductDeploymentDetailState = 'loading' | 'loaded' | 'error';
 
@@ -19,12 +16,6 @@ export interface UseProductDeploymentDetailStoreReturn {
   formatDate: (dateString: string) => string;
   formatDuration: (seconds?: number) => string;
   formatStackDuration: (startedAt?: string, completedAt?: string) => string;
-  // Maintenance mode
-  modeActionLoading: boolean;
-  modeActionError: string | null;
-  handleEnterMaintenance: (reason?: string) => Promise<void>;
-  handleExitMaintenance: () => Promise<void>;
-  clearModeActionError: () => void;
 }
 
 export function useProductDeploymentDetailStore(
@@ -36,8 +27,6 @@ export function useProductDeploymentDetailStore(
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [showVariables, setShowVariables] = useState(false);
-  const [modeActionLoading, setModeActionLoading] = useState(false);
-  const [modeActionError, setModeActionError] = useState<string | null>(null);
 
   const loadDeployment = useCallback(async () => {
     if (!environmentId || !productDeploymentId) {
@@ -86,46 +75,6 @@ export function useProductDeploymentDetailStore(
     return formatDuration(seconds);
   }, [formatDuration]);
 
-  const handleEnterMaintenance = useCallback(async (reason?: string) => {
-    if (!environmentId || !productDeploymentId) return;
-    setModeActionLoading(true);
-    setModeActionError(null);
-    try {
-      const response = await enterProductMaintenanceMode(environmentId, productDeploymentId, reason);
-      if (!response.success) {
-        setModeActionError(response.message || 'Failed to enter maintenance mode');
-        return;
-      }
-      await loadDeployment();
-    } catch (err) {
-      setModeActionError(err instanceof Error ? err.message : 'Failed to enter maintenance mode');
-    } finally {
-      setModeActionLoading(false);
-    }
-  }, [environmentId, productDeploymentId, loadDeployment]);
-
-  const handleExitMaintenance = useCallback(async () => {
-    if (!environmentId || !productDeploymentId) return;
-    setModeActionLoading(true);
-    setModeActionError(null);
-    try {
-      const response = await exitProductMaintenanceMode(environmentId, productDeploymentId);
-      if (!response.success) {
-        setModeActionError(response.message || 'Failed to exit maintenance mode');
-        return;
-      }
-      await loadDeployment();
-    } catch (err) {
-      setModeActionError(err instanceof Error ? err.message : 'Failed to exit maintenance mode');
-    } finally {
-      setModeActionLoading(false);
-    }
-  }, [environmentId, productDeploymentId, loadDeployment]);
-
-  const clearModeActionError = useCallback(() => {
-    setModeActionError(null);
-  }, []);
-
   const state: ProductDeploymentDetailState = loading ? 'loading' : error ? 'error' : 'loaded';
 
   return {
@@ -137,10 +86,5 @@ export function useProductDeploymentDetailStore(
     formatDate,
     formatDuration,
     formatStackDuration,
-    modeActionLoading,
-    modeActionError,
-    handleEnterMaintenance,
-    handleExitMaintenance,
-    clearModeActionError,
   };
 }

--- a/src/ReadyStackGo.WebUi/packages/core/src/index.ts
+++ b/src/ReadyStackGo.WebUi/packages/core/src/index.ts
@@ -62,6 +62,7 @@ export { useRedeployProductStore, type UseRedeployProductStoreReturn, type Redep
 export { useDeploymentsStore, type UseDeploymentsStoreReturn } from './hooks/useDeploymentsStore';
 export { useRestartProductStore, type UseRestartProductStoreReturn, type RestartProductState } from './hooks/useRestartProductStore';
 export { useStopProductStore, type UseStopProductStoreReturn, type StopProductState } from './hooks/useStopProductStore';
+export { useMaintenanceProductStore, type UseMaintenanceProductStoreReturn, type MaintenanceProductState, type MaintenanceAction } from './hooks/useMaintenanceProductStore';
 export { useProductDeploymentDetailStore, type UseProductDeploymentDetailStoreReturn, type ProductDeploymentDetailState } from './hooks/useProductDeploymentDetailStore';
 export { useDeploymentDetailStore, type UseDeploymentDetailStoreReturn } from './hooks/useDeploymentDetailStore';
 export { useDeployProductStore, type UseDeployProductStoreReturn, type DeployProductState } from './hooks/useDeployProductStore';

--- a/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Deployments/EnterMaintenanceProduct.tsx
+++ b/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Deployments/EnterMaintenanceProduct.tsx
@@ -1,0 +1,305 @@
+import { useParams, Link } from 'react-router';
+import { useMaintenanceProductStore } from '@rsgo/core';
+import { useAuth } from '../../context/AuthContext';
+import { useEnvironment } from '../../context/EnvironmentContext';
+
+export default function EnterMaintenanceProduct() {
+  const { productDeploymentId } = useParams<{ productDeploymentId: string }>();
+  const { token } = useAuth();
+  const { activeEnvironment } = useEnvironment();
+
+  const store = useMaintenanceProductStore(token, activeEnvironment?.id, productDeploymentId, 'enter');
+
+  // --- Loading state ---
+  if (store.state === 'loading') {
+    return (
+      <div className="mx-auto max-w-screen-xl p-4 md:p-6 2xl:p-10">
+        <div className="flex items-center justify-center py-12">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-brand-600 mx-auto mb-4"></div>
+            <p className="text-gray-600 dark:text-gray-400">Loading product deployment...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // --- Error state (no deployment loaded) ---
+  if (store.state === 'error' && !store.deployment) {
+    return (
+      <div className="mx-auto max-w-screen-xl p-4 md:p-6 2xl:p-10">
+        <div className="mb-6">
+          <Link
+            to="/deployments"
+            className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            Back to Deployments
+          </Link>
+        </div>
+        <div className="rounded-md bg-red-50 p-4 dark:bg-red-900/20">
+          <p className="text-sm text-red-800 dark:text-red-200">{store.error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  // --- Success state ---
+  if (store.state === 'success') {
+    return (
+      <div className="mx-auto max-w-screen-xl p-4 md:p-6 2xl:p-10">
+        <div className="rounded-2xl border border-gray-200 bg-white p-8 dark:border-gray-800 dark:bg-white/[0.03]">
+          <div className="flex flex-col items-center py-8">
+            <div className="flex items-center justify-center w-16 h-16 mb-6 bg-yellow-100 rounded-full dark:bg-yellow-900/30">
+              <svg className="w-8 h-8 text-yellow-600 dark:text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+            </div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+              Maintenance Mode Activated
+            </h1>
+            <p className="text-gray-600 dark:text-gray-400 mb-2">
+              {store.deployment?.productDisplayName} is now in maintenance mode.
+            </p>
+            {store.result && (
+              <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+                {store.result.previousMode} → {store.result.newMode}
+              </p>
+            )}
+
+            <div className="flex gap-4">
+              <Link
+                to={`/product-deployments/${productDeploymentId}`}
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-brand-600 px-6 py-3 text-center font-medium text-white hover:bg-brand-700"
+              >
+                View Deployment
+              </Link>
+              <Link
+                to="/deployments"
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-gray-100 px-6 py-3 text-center font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+              >
+                All Deployments
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // --- Processing state ---
+  if (store.state === 'processing') {
+    return (
+      <div className="mx-auto max-w-screen-xl p-4 md:p-6 2xl:p-10">
+        <div className="rounded-2xl border border-gray-200 bg-white p-8 dark:border-gray-800 dark:bg-white/[0.03]">
+          <div className="flex flex-col items-center py-8">
+            <div className="w-16 h-16 mb-6 border-4 border-yellow-600 border-t-transparent rounded-full animate-spin"></div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+              Entering Maintenance Mode...
+            </h1>
+            <p className="text-gray-600 dark:text-gray-400 mb-6">
+              Stopping containers for {store.deployment?.productDisplayName}
+            </p>
+
+            <div className="w-full max-w-lg">
+              <div className="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+                {store.deployment?.stacks
+                  .slice()
+                  .sort((a, b) => a.order - b.order)
+                  .map((stack) => (
+                    <div
+                      key={stack.stackName}
+                      className="flex items-center justify-between px-4 py-3 border-b last:border-b-0 border-gray-200 dark:border-gray-700"
+                    >
+                      <div className="flex items-center gap-3">
+                        <div className="w-4 h-4 border-2 border-yellow-600 border-t-transparent rounded-full animate-spin" />
+                        <span className="text-sm font-medium text-yellow-700 dark:text-yellow-300">
+                          {stack.stackDisplayName}
+                        </span>
+                      </div>
+                      <span className="text-xs text-gray-500 dark:text-gray-400">
+                        {stack.serviceCount} service{stack.serviceCount !== 1 ? 's' : ''}
+                      </span>
+                    </div>
+                  ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // --- Error state (with deployment loaded) ---
+  if (store.state === 'error' && store.deployment) {
+    return (
+      <div className="mx-auto max-w-screen-xl p-4 md:p-6 2xl:p-10">
+        <div className="mb-6">
+          <Link
+            to={`/product-deployments/${productDeploymentId}`}
+            className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            Back to Deployment
+          </Link>
+        </div>
+
+        <div className="rounded-2xl border border-red-200 bg-white p-8 dark:border-red-800 dark:bg-white/[0.03]">
+          <div className="flex flex-col items-center py-4">
+            <div className="flex items-center justify-center w-16 h-16 mb-6 bg-red-100 rounded-full dark:bg-red-900/30">
+              <svg className="w-8 h-8 text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+            </div>
+
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+              Failed to Enter Maintenance Mode
+            </h1>
+            <p className="text-gray-600 dark:text-gray-400 mb-6">
+              {store.error}
+            </p>
+
+            <div className="flex gap-4">
+              <Link
+                to={`/product-deployments/${productDeploymentId}`}
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-brand-600 px-6 py-3 text-center font-medium text-white hover:bg-brand-700"
+              >
+                View Deployment
+              </Link>
+              <Link
+                to="/deployments"
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-gray-100 px-6 py-3 text-center font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+              >
+                All Deployments
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // --- Confirm state ---
+  return (
+    <div className="mx-auto max-w-screen-xl p-4 md:p-6 2xl:p-10">
+      {/* Breadcrumb */}
+      <div className="mb-6">
+        <Link
+          to={`/product-deployments/${productDeploymentId}`}
+          className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+          Back to Deployment
+        </Link>
+      </div>
+
+      {/* Confirmation Card */}
+      <div className="rounded-2xl border border-yellow-200 bg-white p-8 dark:border-yellow-800 dark:bg-white/[0.03]">
+        <div className="flex flex-col items-center py-4">
+          {/* Maintenance Icon */}
+          <div className="flex items-center justify-center w-16 h-16 mb-6 bg-yellow-100 rounded-full dark:bg-yellow-900/30">
+            <svg className="w-8 h-8 text-yellow-600 dark:text-yellow-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+          </div>
+
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+            Enter Maintenance Mode
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400 mb-2 text-center">
+            Are you sure you want to enter maintenance mode for <strong className="text-gray-900 dark:text-white">{store.deployment?.productDisplayName}</strong>?
+          </p>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-6 text-center max-w-md">
+            This will stop all {store.deployment?.totalStacks} stack{(store.deployment?.totalStacks ?? 0) !== 1 ? 's' : ''} with {store.totalServices} container{store.totalServices !== 1 ? 's' : ''}.
+            Containers can be restarted by exiting maintenance mode.
+          </p>
+
+          {/* Deployment Info */}
+          <div className="w-full max-w-lg mb-6 p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
+            <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-3">Product Details</h3>
+            <div className="space-y-2 text-sm mb-4">
+              <div className="flex justify-between">
+                <span className="text-gray-600 dark:text-gray-400">Product:</span>
+                <span className="font-medium text-gray-900 dark:text-white">{store.deployment?.productDisplayName}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600 dark:text-gray-400">Version:</span>
+                <span className="font-medium text-gray-900 dark:text-white">v{store.deployment?.productVersion}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600 dark:text-gray-400">Environment:</span>
+                <span className="font-medium text-gray-900 dark:text-white">{activeEnvironment?.name}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600 dark:text-gray-400">Stacks:</span>
+                <span className="font-medium text-gray-900 dark:text-white">{store.deployment?.totalStacks}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600 dark:text-gray-400">Total Services:</span>
+                <span className="font-medium text-gray-900 dark:text-white">{store.totalServices}</span>
+              </div>
+            </div>
+
+            {/* Stack List */}
+            <h4 className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">
+              Stacks affected
+            </h4>
+            <div className="space-y-1">
+              {store.deployment?.stacks
+                .slice()
+                .sort((a, b) => a.order - b.order)
+                .map((stack) => (
+                  <div key={stack.stackName} className="flex items-center justify-between py-1">
+                    <div className="flex items-center gap-2">
+                      <svg className="w-3 h-3 text-yellow-400" fill="currentColor" viewBox="0 0 8 8">
+                        <circle cx="4" cy="4" r="3" />
+                      </svg>
+                      <span className="text-sm text-gray-700 dark:text-gray-300">
+                        {stack.stackDisplayName}
+                      </span>
+                      {stack.deploymentStackName && (
+                        <span className="text-xs text-gray-400 dark:text-gray-500 font-mono">
+                          ({stack.deploymentStackName})
+                        </span>
+                      )}
+                    </div>
+                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                      {stack.serviceCount} service{stack.serviceCount !== 1 ? 's' : ''}
+                    </span>
+                  </div>
+                ))}
+            </div>
+          </div>
+
+          {/* Action Buttons */}
+          <div className="flex gap-4">
+            <Link
+              to={`/product-deployments/${productDeploymentId}`}
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-gray-100 px-6 py-3 text-center font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+            >
+              Cancel
+            </Link>
+            <button
+              onClick={store.handleConfirm}
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-yellow-600 px-6 py-3 text-center font-medium text-white hover:bg-yellow-700"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              </svg>
+              Enter Maintenance Mode
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Deployments/ExitMaintenanceProduct.tsx
+++ b/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Deployments/ExitMaintenanceProduct.tsx
@@ -1,0 +1,318 @@
+import { useParams, Link } from 'react-router';
+import { useMaintenanceProductStore } from '@rsgo/core';
+import { useAuth } from '../../context/AuthContext';
+import { useEnvironment } from '../../context/EnvironmentContext';
+
+export default function ExitMaintenanceProduct() {
+  const { productDeploymentId } = useParams<{ productDeploymentId: string }>();
+  const { token } = useAuth();
+  const { activeEnvironment } = useEnvironment();
+
+  const store = useMaintenanceProductStore(token, activeEnvironment?.id, productDeploymentId, 'exit');
+
+  // --- Loading state ---
+  if (store.state === 'loading') {
+    return (
+      <div className="mx-auto max-w-screen-xl p-4 md:p-6 2xl:p-10">
+        <div className="flex items-center justify-center py-12">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-brand-600 mx-auto mb-4"></div>
+            <p className="text-gray-600 dark:text-gray-400">Loading product deployment...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // --- Error state (no deployment loaded) ---
+  if (store.state === 'error' && !store.deployment) {
+    return (
+      <div className="mx-auto max-w-screen-xl p-4 md:p-6 2xl:p-10">
+        <div className="mb-6">
+          <Link
+            to="/deployments"
+            className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            Back to Deployments
+          </Link>
+        </div>
+        <div className="rounded-md bg-red-50 p-4 dark:bg-red-900/20">
+          <p className="text-sm text-red-800 dark:text-red-200">{store.error}</p>
+        </div>
+      </div>
+    );
+  }
+
+  // --- Success state ---
+  if (store.state === 'success') {
+    return (
+      <div className="mx-auto max-w-screen-xl p-4 md:p-6 2xl:p-10">
+        <div className="rounded-2xl border border-gray-200 bg-white p-8 dark:border-gray-800 dark:bg-white/[0.03]">
+          <div className="flex flex-col items-center py-8">
+            <div className="flex items-center justify-center w-16 h-16 mb-6 bg-green-100 rounded-full dark:bg-green-900/30">
+              <svg className="w-8 h-8 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+            </div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+              Maintenance Mode Deactivated
+            </h1>
+            <p className="text-gray-600 dark:text-gray-400 mb-2">
+              {store.deployment?.productDisplayName} is back to normal operation.
+            </p>
+            {store.result && (
+              <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+                {store.result.previousMode} → {store.result.newMode}
+              </p>
+            )}
+
+            <div className="flex gap-4">
+              <Link
+                to={`/product-deployments/${productDeploymentId}`}
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-brand-600 px-6 py-3 text-center font-medium text-white hover:bg-brand-700"
+              >
+                View Deployment
+              </Link>
+              <Link
+                to="/deployments"
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-gray-100 px-6 py-3 text-center font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+              >
+                All Deployments
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // --- Processing state ---
+  if (store.state === 'processing') {
+    return (
+      <div className="mx-auto max-w-screen-xl p-4 md:p-6 2xl:p-10">
+        <div className="rounded-2xl border border-gray-200 bg-white p-8 dark:border-gray-800 dark:bg-white/[0.03]">
+          <div className="flex flex-col items-center py-8">
+            <div className="w-16 h-16 mb-6 border-4 border-green-600 border-t-transparent rounded-full animate-spin"></div>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+              Exiting Maintenance Mode...
+            </h1>
+            <p className="text-gray-600 dark:text-gray-400 mb-6">
+              Starting containers for {store.deployment?.productDisplayName}
+            </p>
+
+            <div className="w-full max-w-lg">
+              <div className="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+                {store.deployment?.stacks
+                  .slice()
+                  .sort((a, b) => a.order - b.order)
+                  .map((stack) => (
+                    <div
+                      key={stack.stackName}
+                      className="flex items-center justify-between px-4 py-3 border-b last:border-b-0 border-gray-200 dark:border-gray-700"
+                    >
+                      <div className="flex items-center gap-3">
+                        <div className="w-4 h-4 border-2 border-green-600 border-t-transparent rounded-full animate-spin" />
+                        <span className="text-sm font-medium text-green-700 dark:text-green-300">
+                          {stack.stackDisplayName}
+                        </span>
+                      </div>
+                      <span className="text-xs text-gray-500 dark:text-gray-400">
+                        {stack.serviceCount} service{stack.serviceCount !== 1 ? 's' : ''}
+                      </span>
+                    </div>
+                  ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // --- Error state (with deployment loaded) ---
+  if (store.state === 'error' && store.deployment) {
+    return (
+      <div className="mx-auto max-w-screen-xl p-4 md:p-6 2xl:p-10">
+        <div className="mb-6">
+          <Link
+            to={`/product-deployments/${productDeploymentId}`}
+            className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            Back to Deployment
+          </Link>
+        </div>
+
+        <div className="rounded-2xl border border-red-200 bg-white p-8 dark:border-red-800 dark:bg-white/[0.03]">
+          <div className="flex flex-col items-center py-4">
+            <div className="flex items-center justify-center w-16 h-16 mb-6 bg-red-100 rounded-full dark:bg-red-900/30">
+              <svg className="w-8 h-8 text-red-600 dark:text-red-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+            </div>
+
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+              Failed to Exit Maintenance Mode
+            </h1>
+            <p className="text-gray-600 dark:text-gray-400 mb-6">
+              {store.error}
+            </p>
+
+            <div className="flex gap-4">
+              <Link
+                to={`/product-deployments/${productDeploymentId}`}
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-brand-600 px-6 py-3 text-center font-medium text-white hover:bg-brand-700"
+              >
+                View Deployment
+              </Link>
+              <Link
+                to="/deployments"
+                className="inline-flex items-center justify-center gap-2 rounded-md bg-gray-100 px-6 py-3 text-center font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+              >
+                All Deployments
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // --- Confirm state ---
+  const trigger = store.deployment?.maintenanceTrigger;
+
+  return (
+    <div className="mx-auto max-w-screen-xl p-4 md:p-6 2xl:p-10">
+      {/* Breadcrumb */}
+      <div className="mb-6">
+        <Link
+          to={`/product-deployments/${productDeploymentId}`}
+          className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200"
+        >
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+          Back to Deployment
+        </Link>
+      </div>
+
+      {/* Confirmation Card */}
+      <div className="rounded-2xl border border-green-200 bg-white p-8 dark:border-green-800 dark:bg-white/[0.03]">
+        <div className="flex flex-col items-center py-4">
+          {/* Play Icon */}
+          <div className="flex items-center justify-center w-16 h-16 mb-6 bg-green-100 rounded-full dark:bg-green-900/30">
+            <svg className="w-8 h-8 text-green-600 dark:text-green-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+          </div>
+
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">
+            Exit Maintenance Mode
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400 mb-2 text-center">
+            Are you sure you want to exit maintenance mode for <strong className="text-gray-900 dark:text-white">{store.deployment?.productDisplayName}</strong>?
+          </p>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-6 text-center max-w-md">
+            This will restart all {store.deployment?.totalStacks} stack{(store.deployment?.totalStacks ?? 0) !== 1 ? 's' : ''} with {store.totalServices} container{store.totalServices !== 1 ? 's' : ''} and
+            return the product to normal operation.
+          </p>
+
+          {/* Maintenance Info */}
+          <div className="w-full max-w-lg mb-6 p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg">
+            <h3 className="text-sm font-medium text-gray-900 dark:text-white mb-3">Current Maintenance Info</h3>
+            <div className="space-y-2 text-sm mb-4">
+              <div className="flex justify-between">
+                <span className="text-gray-600 dark:text-gray-400">Product:</span>
+                <span className="font-medium text-gray-900 dark:text-white">{store.deployment?.productDisplayName}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600 dark:text-gray-400">Version:</span>
+                <span className="font-medium text-gray-900 dark:text-white">v{store.deployment?.productVersion}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-gray-600 dark:text-gray-400">Environment:</span>
+                <span className="font-medium text-gray-900 dark:text-white">{activeEnvironment?.name}</span>
+              </div>
+              {trigger && (
+                <>
+                  <div className="flex justify-between">
+                    <span className="text-gray-600 dark:text-gray-400">Triggered by:</span>
+                    <span className="font-medium text-gray-900 dark:text-white">{trigger.source}</span>
+                  </div>
+                  {trigger.reason && (
+                    <div className="flex justify-between">
+                      <span className="text-gray-600 dark:text-gray-400">Reason:</span>
+                      <span className="font-medium text-gray-900 dark:text-white">{trigger.reason}</span>
+                    </div>
+                  )}
+                  <div className="flex justify-between">
+                    <span className="text-gray-600 dark:text-gray-400">Since:</span>
+                    <span className="font-medium text-gray-900 dark:text-white">
+                      {new Date(trigger.triggeredAtUtc).toLocaleString()}
+                    </span>
+                  </div>
+                </>
+              )}
+            </div>
+
+            {/* Stack List */}
+            <h4 className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 uppercase tracking-wider">
+              Stacks to restart
+            </h4>
+            <div className="space-y-1">
+              {store.deployment?.stacks
+                .slice()
+                .sort((a, b) => a.order - b.order)
+                .map((stack) => (
+                  <div key={stack.stackName} className="flex items-center justify-between py-1">
+                    <div className="flex items-center gap-2">
+                      <svg className="w-3 h-3 text-green-400" fill="currentColor" viewBox="0 0 8 8">
+                        <circle cx="4" cy="4" r="3" />
+                      </svg>
+                      <span className="text-sm text-gray-700 dark:text-gray-300">
+                        {stack.stackDisplayName}
+                      </span>
+                      {stack.deploymentStackName && (
+                        <span className="text-xs text-gray-400 dark:text-gray-500 font-mono">
+                          ({stack.deploymentStackName})
+                        </span>
+                      )}
+                    </div>
+                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                      {stack.serviceCount} service{stack.serviceCount !== 1 ? 's' : ''}
+                    </span>
+                  </div>
+                ))}
+            </div>
+          </div>
+
+          {/* Action Buttons */}
+          <div className="flex gap-4">
+            <Link
+              to={`/product-deployments/${productDeploymentId}`}
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-gray-100 px-6 py-3 text-center font-medium text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+            >
+              Cancel
+            </Link>
+            <button
+              onClick={store.handleConfirm}
+              className="inline-flex items-center justify-center gap-2 rounded-md bg-green-600 px-6 py-3 text-center font-medium text-white hover:bg-green-700"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              Exit Maintenance Mode
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Deployments/ProductDeploymentDetail.tsx
+++ b/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Deployments/ProductDeploymentDetail.tsx
@@ -151,30 +151,28 @@ export default function ProductDeploymentDetail() {
         <div className="flex items-center gap-2">
           {/* Maintenance Mode Controls */}
           {deployment.canEnterMaintenance && (
-            <button
-              onClick={() => store.handleEnterMaintenance()}
-              disabled={store.modeActionLoading}
-              className="inline-flex items-center justify-center gap-2 rounded bg-yellow-100 px-3 py-1.5 text-sm font-medium text-yellow-800 hover:bg-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-400 dark:hover:bg-yellow-900/50 disabled:opacity-50 disabled:cursor-not-allowed"
+            <Link
+              to={`/enter-maintenance/${deployment.productDeploymentId}`}
+              className="inline-flex items-center justify-center gap-2 rounded bg-yellow-100 px-3 py-1.5 text-sm font-medium text-yellow-800 hover:bg-yellow-200 dark:bg-yellow-900/30 dark:text-yellow-400 dark:hover:bg-yellow-900/50"
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
               </svg>
-              {store.modeActionLoading ? 'Entering...' : 'Enter Maintenance'}
-            </button>
+              Enter Maintenance
+            </Link>
           )}
           {deployment.canExitMaintenance && (
-            <button
-              onClick={store.handleExitMaintenance}
-              disabled={store.modeActionLoading}
-              className="inline-flex items-center justify-center gap-2 rounded bg-green-100 px-3 py-1.5 text-sm font-medium text-green-800 hover:bg-green-200 dark:bg-green-900/30 dark:text-green-400 dark:hover:bg-green-900/50 disabled:opacity-50 disabled:cursor-not-allowed"
+            <Link
+              to={`/exit-maintenance/${deployment.productDeploymentId}`}
+              className="inline-flex items-center justify-center gap-2 rounded bg-green-100 px-3 py-1.5 text-sm font-medium text-green-800 hover:bg-green-200 dark:bg-green-900/30 dark:text-green-400 dark:hover:bg-green-900/50"
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
               </svg>
-              {store.modeActionLoading ? 'Exiting...' : 'Exit Maintenance'}
-            </button>
+              Exit Maintenance
+            </Link>
           )}
           <Link
             to={`/catalog/${encodeURIComponent(deployment.productGroupId)}`}
@@ -233,32 +231,6 @@ export default function ProductDeploymentDetail() {
         </div>
       </div>
 
-      {/* Mode Action Error */}
-      {store.modeActionError && (
-        <div className="mb-6 rounded-md bg-red-50 p-4 dark:bg-red-900/20">
-          <div className="flex">
-            <div className="flex-shrink-0">
-              <svg className="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
-                <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clipRule="evenodd" />
-              </svg>
-            </div>
-            <div className="ml-3">
-              <p className="text-sm text-red-800 dark:text-red-200">{store.modeActionError}</p>
-            </div>
-            <div className="ml-auto pl-3">
-              <button
-                onClick={store.clearModeActionError}
-                className="inline-flex rounded-md p-1.5 text-red-500 hover:bg-red-100 dark:hover:bg-red-900/50"
-              >
-                <span className="sr-only">Dismiss</span>
-                <svg className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-                  <path fillRule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clipRule="evenodd" />
-                </svg>
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
 
       {/* Maintenance Info */}
       {deployment.operationMode === 'Maintenance' && deployment.maintenanceTrigger && (


### PR DESCRIPTION
## Summary

- New dedicated pages for Enter/Exit Maintenance Mode with confirmation dialogs, progress spinners, and result feedback
- Follows the established StopProduct/RestartProduct pattern for consistent UX
- Replaces inline button-click maintenance actions with full-page navigation flow

## Changes

- **`useMaintenanceProductStore`** hook: state machine (loading → confirm → processing → success/error), shared by both Enter and Exit pages
- **`EnterMaintenanceProduct`** page: confirmation with affected stack list, service count, processing spinner, success with mode transition display
- **`ExitMaintenanceProduct`** page: confirmation with maintenance trigger info (source, reason, since), stack list, result feedback
- **Routes**: `/enter-maintenance/:id` and `/exit-maintenance/:id`
- **`ProductDeploymentDetail`**: inline maintenance buttons replaced with `<Link>` navigation
- **`useProductDeploymentDetailStore`**: removed maintenance handlers (moved to dedicated store)

## AMS UI

Not affected — AMS `ProductDeploymentDetail` does not use the removed maintenance handlers. Stack-level `useDeploymentDetailStore` is unchanged.