### PR TITLE
Fix milestone-release: push tag to trigger Docker build

### DIFF
--- a/.github/workflows/milestone-release.yml
+++ b/.github/workflows/milestone-release.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Get milestone version
         id: version
@@ -54,6 +56,21 @@ jobs:
               --draft=false \
               --latest
           fi
+
+      - name: Push tag to trigger Docker build
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # Check if tag already exists as a pushed tag
+          if git rev-parse "refs/tags/$VERSION" >/dev/null 2>&1; then
+            echo "Tag $VERSION already exists locally"
+          else
+            # Fetch the tag created by the release
+            git fetch --tags
+          fi
+
+          # Force push the tag to ensure the push event triggers Docker workflow
+          git push origin "refs/tags/$VERSION" --force
 
       - name: Summary
         run: |


### PR DESCRIPTION
The milestone-release workflow creates a release via gh CLI, but the tag created by GitHub API doesn't trigger the push tags event needed by the Docker build workflow. Added explicit git push of the tag after release creation.