### PR TITLE
Exclude onboarding E2E test from regular test run

### DIFF
--- a/src/ReadyStackGo.WebUi/playwright.config.ts
+++ b/src/ReadyStackGo.WebUi/playwright.config.ts
@@ -11,6 +11,7 @@ const isCI = !!process.env.CI;
  */
 export default defineConfig({
   testDir: './e2e',
+  testIgnore: ['**/onboarding.spec.ts'],
   globalSetup: './e2e/global-setup.ts',
   globalTeardown: './e2e/global-teardown.ts',
   fullyParallel: true,


### PR DESCRIPTION
The onboarding test requires a fresh container (no admin created). It conflicts with the global-setup which creates the admin via wizard API. Excluded from the default test run — can be run standalone with a fresh container.