### PR TITLE
fix(ssh): add diagnostic logging for SSH tunnel port forwarding

### DIFF
--- a/src/ReadyStackGo.Infrastructure.Docker/SshTunnelManager.cs
+++ b/src/ReadyStackGo.Infrastructure.Docker/SshTunnelManager.cs
@@ -140,10 +140,12 @@ public class SshTunnelManager : ISshTunnelManager
         // Run in background, will be killed when SSH connection closes
         var socatCmd = $"socat TCP-LISTEN:{remoteBridgePort},fork,reuseaddr,bind=127.0.0.1 UNIX-CONNECT:{remoteSocketPath} &";
         var socatResult = client.RunCommand(socatCmd);
+        _logger.LogInformation("socat command exit: {ExitStatus}, output: '{Result}', error: '{Error}'",
+            socatResult.ExitStatus, socatResult.Result?.Trim(), socatResult.Error?.Trim());
         if (socatResult.ExitStatus != 0)
         {
-            // socat might not be installed — try docker proxy or direct approach
-            _logger.LogWarning("socat not available on remote ({ExitStatus}), trying direct Docker TCP check", socatResult.ExitStatus);
+            _logger.LogWarning("socat not available or failed on remote ({ExitStatus}): {Error}",
+                socatResult.ExitStatus, socatResult.Error?.Trim());
         }
 
         // Small delay to let socat start
@@ -158,11 +160,18 @@ public class SshTunnelManager : ISshTunnelManager
             (uint)remoteBridgePort);
 
         client.AddForwardedPort(forwardedPort);
+        forwardedPort.Exception += (_, e) =>
+            _logger.LogError(e.Exception, "SSH forwarded port exception on localhost:{LocalPort}", localPort);
         forwardedPort.Start();
 
-        _logger.LogDebug(
-            "SSH tunnel created: localhost:{LocalPort} → remote:127.0.0.1:{RemotePort} → {RemoteSocket} via {Host}:{SshPort}",
-            localPort, remoteBridgePort, remoteSocketPath, host, port);
+        if (!forwardedPort.IsStarted)
+        {
+            _logger.LogError("SSH forwarded port failed to start on localhost:{LocalPort}", localPort);
+        }
+
+        _logger.LogInformation(
+            "SSH tunnel created: localhost:{LocalPort} → remote:127.0.0.1:{RemotePort} → {RemoteSocket} via {Host}:{SshPort} (IsStarted={IsStarted})",
+            localPort, remoteBridgePort, remoteSocketPath, host, port, forwardedPort.IsStarted);
 
         return new SshTunnelEntry(client, forwardedPort, localPort, remoteBridgePort);
     }


### PR DESCRIPTION
## Summary
- Add `Exception` event handler on `ForwardedPortLocal` to log port forwarding errors
- Log `IsStarted` state after `forwardedPort.Start()`
- Log socat command exit status, stdout and stderr for debugging
- Elevate tunnel creation log from Debug to Information

## Context
SSH tunnel test connection fails with "Unexpected end of stream" on remote Docker environments. 
The error actually comes from Docker.DotNet, not SSH.NET — the SSH connection succeeds but the 
local port forwarding may silently fail. This adds visibility into what's happening.