### PR TITLE
Add structured deployment error display

### DIFF
--- a/src/ReadyStackGo.WebUi/packages/core/src/index.ts
+++ b/src/ReadyStackGo.WebUi/packages/core/src/index.ts
@@ -99,3 +99,4 @@ export * from './services/EnvironmentService';
 
 // Utils
 export * from './utils/timeAgo';
+export * from './utils/errorParser';

--- a/src/ReadyStackGo.WebUi/packages/core/src/utils/errorParser.ts
+++ b/src/ReadyStackGo.WebUi/packages/core/src/utils/errorParser.ts
@@ -1,0 +1,106 @@
+/**
+ * Parse a raw deployment error message into a structured format with
+ * a short summary line and collapsible details.
+ */
+export interface ParsedError {
+  /** Short one-line summary of the error (first meaningful line) */
+  summary: string;
+  /** Full error details (stack trace, logs) — may be empty if error is short */
+  details: string;
+  /** Detected container/service name if available */
+  containerName?: string;
+  /** Detected exit code if available */
+  exitCode?: number;
+}
+
+/**
+ * Parse a raw error message into summary + details.
+ *
+ * Patterns detected:
+ * - Init container failures: "Init container 'X' failed with exit code N"
+ * - Image pull failures: "Failed to pull image 'X'"
+ * - Generic: first line = summary, rest = details
+ */
+export function parseErrorMessage(raw: string | null | undefined): ParsedError | null {
+  if (!raw || raw.trim().length === 0) return null;
+
+  const trimmed = raw.trim();
+
+  // Pattern: Init container failure
+  const initMatch = trimmed.match(/Init container '([^']+)' failed with exit code (\d+)/i);
+  if (initMatch) {
+    return {
+      summary: `Init container '${initMatch[1]}' failed with exit code ${initMatch[2]}`,
+      details: trimmed,
+      containerName: initMatch[1],
+      exitCode: parseInt(initMatch[2]),
+    };
+  }
+
+  // Pattern: "Deployment failed: Init container 'X' failed: ..."
+  const deployInitMatch = trimmed.match(/Deployment failed: Init container '([^']+)' failed/i);
+  if (deployInitMatch) {
+    const firstSentenceEnd = trimmed.indexOf('. Last ');
+    const summary = firstSentenceEnd > 0
+      ? trimmed.substring(0, firstSentenceEnd + 1)
+      : trimmed.substring(0, Math.min(trimmed.length, 200));
+    return {
+      summary,
+      details: trimmed,
+      containerName: deployInitMatch[1],
+    };
+  }
+
+  // Pattern: Image pull failure
+  const pullMatch = trimmed.match(/Failed to pull image '([^']+)'/i);
+  if (pullMatch) {
+    return {
+      summary: `Failed to pull image '${pullMatch[1]}'`,
+      details: trimmed,
+    };
+  }
+
+  // Pattern: Service failed
+  const serviceMatch = trimmed.match(/Service '([^']+)' failed/i);
+  if (serviceMatch) {
+    return {
+      summary: `Service '${serviceMatch[1]}' failed to start`,
+      details: trimmed,
+      containerName: serviceMatch[1],
+    };
+  }
+
+  // Generic: split at first stack trace marker or take first line
+  const stackTraceIdx = trimmed.indexOf(' --- End of stack trace');
+  const atIdx = trimmed.indexOf(' at ');
+  const splitIdx = stackTraceIdx > 0 ? stackTraceIdx : (atIdx > 0 ? atIdx : -1);
+
+  if (splitIdx > 0 && splitIdx < 300) {
+    return {
+      summary: trimmed.substring(0, splitIdx).trim(),
+      details: trimmed,
+    };
+  }
+
+  // Fallback: first line or first 200 chars
+  const firstNewline = trimmed.indexOf('\n');
+  if (firstNewline > 0 && firstNewline < 300) {
+    return {
+      summary: trimmed.substring(0, firstNewline).trim(),
+      details: trimmed.length > firstNewline + 10 ? trimmed : '',
+    };
+  }
+
+  // Short error — no details needed
+  if (trimmed.length <= 200) {
+    return {
+      summary: trimmed,
+      details: '',
+    };
+  }
+
+  return {
+    summary: trimmed.substring(0, 200) + '...',
+    details: trimmed,
+  };
+}

--- a/src/ReadyStackGo.WebUi/packages/ui-generic/src/components/ui/DeploymentError.tsx
+++ b/src/ReadyStackGo.WebUi/packages/ui-generic/src/components/ui/DeploymentError.tsx
@@ -1,0 +1,74 @@
+import { parseErrorMessage, type ParsedError } from '@rsgo/core';
+
+interface DeploymentErrorProps {
+  /** Raw error message string */
+  error: string | null | undefined;
+  /** Optional title override (default: "Deployment Error") */
+  title?: string;
+  /** Compact mode — no title, smaller text */
+  compact?: boolean;
+}
+
+/**
+ * Structured deployment error display.
+ * Shows a short summary with optional collapsible details for stack traces.
+ */
+export function DeploymentError({ error, title = 'Deployment Error', compact = false }: DeploymentErrorProps) {
+  const parsed = parseErrorMessage(error);
+  if (!parsed) return null;
+
+  if (compact) {
+    return <CompactError parsed={parsed} />;
+  }
+
+  return (
+    <div className="rounded-lg border border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-900/20 overflow-hidden">
+      <div className="px-4 py-3">
+        <div className="flex items-start gap-3">
+          <svg className="w-5 h-5 text-red-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+          </svg>
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-semibold text-red-800 dark:text-red-200">{title}</p>
+            {parsed.containerName && (
+              <p className="mt-0.5 text-xs text-red-600 dark:text-red-400">
+                Container: <code className="font-mono bg-red-100 dark:bg-red-900/40 px-1 rounded">{parsed.containerName}</code>
+                {parsed.exitCode !== undefined && (
+                  <span className="ml-2">Exit code: <code className="font-mono bg-red-100 dark:bg-red-900/40 px-1 rounded">{parsed.exitCode}</code></span>
+                )}
+              </p>
+            )}
+            <p className="mt-1 text-sm text-red-700 dark:text-red-300 break-words">{parsed.summary}</p>
+          </div>
+        </div>
+      </div>
+
+      {parsed.details && parsed.details !== parsed.summary && (
+        <details className="border-t border-red-200 dark:border-red-800">
+          <summary className="px-4 py-2 text-xs font-medium text-red-600 dark:text-red-400 cursor-pointer hover:bg-red-100 dark:hover:bg-red-900/30 select-none">
+            Show full error details
+          </summary>
+          <pre className="px-4 py-3 text-xs text-red-700 dark:text-red-300 bg-red-100/50 dark:bg-red-950/30 overflow-x-auto max-h-64 whitespace-pre-wrap break-words font-mono">
+            {parsed.details}
+          </pre>
+        </details>
+      )}
+    </div>
+  );
+}
+
+function CompactError({ parsed }: { parsed: ParsedError }) {
+  return (
+    <div className="text-xs text-red-600 dark:text-red-400">
+      <span className="font-medium">{parsed.summary}</span>
+      {parsed.details && parsed.details !== parsed.summary && (
+        <details className="mt-1">
+          <summary className="cursor-pointer hover:underline select-none">Details</summary>
+          <pre className="mt-1 p-2 text-xs bg-red-50 dark:bg-red-950/30 rounded overflow-x-auto max-h-48 whitespace-pre-wrap break-words font-mono">
+            {parsed.details}
+          </pre>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Deployments/Deployments.tsx
+++ b/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Deployments/Deployments.tsx
@@ -9,6 +9,7 @@ import {
 } from '@rsgo/core';
 import { useEnvironment } from "../../context/EnvironmentContext";
 import { useAuth } from "../../context/AuthContext";
+import { DeploymentError } from "../../components/ui/DeploymentError";
 
 export default function Deployments() {
   const { activeEnvironment } = useEnvironment();
@@ -235,9 +236,9 @@ function ProductDeploymentRow({ deployment, formatDate }: ProductDeploymentRowPr
             <span>Deployed {formatDate(deployment.createdAt)}</span>
           </div>
           {deployment.errorMessage && (
-            <p className="mt-1 text-xs text-red-600 dark:text-red-400">
-              {deployment.errorMessage}
-            </p>
+            <div className="mt-1">
+              <DeploymentError error={deployment.errorMessage} compact />
+            </div>
           )}
         </div>
 

--- a/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Deployments/ProductDeploymentDetail.tsx
+++ b/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Deployments/ProductDeploymentDetail.tsx
@@ -6,6 +6,7 @@ import {
 } from '@rsgo/core';
 import { useAuth } from "../../context/AuthContext";
 import { useEnvironment } from "../../context/EnvironmentContext";
+import { DeploymentError } from "../../components/ui/DeploymentError";
 
 function getProductStatusPresentation(status: string) {
   switch (status) {
@@ -255,9 +256,8 @@ export default function ProductDeploymentDetail() {
 
       {/* Error Alert */}
       {deployment.errorMessage && (
-        <div className="mb-6 rounded-md bg-red-50 p-4 dark:bg-red-900/20">
-          <p className="text-sm font-medium text-red-800 dark:text-red-200">Deployment Error</p>
-          <p className="mt-1 text-sm text-red-700 dark:text-red-300">{deployment.errorMessage}</p>
+        <div className="mb-6">
+          <DeploymentError error={deployment.errorMessage} />
         </div>
       )}
 
@@ -422,7 +422,9 @@ function StackRow({ stack, parentOperationMode, formatDate, formatStackDuration 
           )}
         </div>
         {stack.errorMessage && (
-          <p className="mt-1 ml-9 text-xs text-red-600 dark:text-red-400">{stack.errorMessage}</p>
+          <div className="mt-1 ml-9">
+            <DeploymentError error={stack.errorMessage} compact />
+          </div>
         )}
       </div>
       {canDrillDown && (


### PR DESCRIPTION
## Summary

- `errorParser.ts` in @rsgo/core: parses raw error messages into summary + details, detects container names and exit codes
- `DeploymentError` component: structured error display with icon, summary, container info, and HTML `<details>` for full stack trace
- Product detail: replaces raw error text block with structured component
- Stack errors: compact mode with expandable details inline
- Deployments list: compact error display

Closes #306

## AMS UI

Deferred — RSGO Generic UI is the reference. AMS will adopt the pattern in next release.