### PR TITLE
Show products per source with version selection

### DIFF
--- a/src/ReadyStackGo.Application/Services/IProductCache.cs
+++ b/src/ReadyStackGo.Application/Services/IProductCache.cs
@@ -31,6 +31,12 @@ public interface IProductCache
     IEnumerable<ProductDefinition> GetProductVersions(string groupId);
 
     /// <summary>
+    /// Get all versions of a product from a specific source.
+    /// Returns versions sorted by version number (newest first).
+    /// </summary>
+    IEnumerable<ProductDefinition> GetProductVersionsBySource(string sourceId, string groupId);
+
+    /// <summary>
     /// Get a specific version of a product.
     /// </summary>
     ProductDefinition? GetProductVersion(string groupId, string version);

--- a/src/ReadyStackGo.Application/UseCases/Stacks/GetProduct/GetProductHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Stacks/GetProduct/GetProductHandler.cs
@@ -33,9 +33,10 @@ public class GetProductHandler : IRequestHandler<GetProductQuery, GetProductResu
         var sources = await _productSourceService.GetSourcesAsync(cancellationToken);
         var sourceNames = sources.ToDictionary(s => s.Id.Value, s => s.Name);
 
-        // Get all versions for this product
+        // Get all versions for this product from the same source
         var allVersions = await _productSourceService.GetProductVersionsAsync(product.GroupId, cancellationToken);
         var availableVersions = allVersions
+            .Where(v => v.SourceId == product.SourceId)
             .Select(v => new ProductVersionInfo(
                 Version: v.ProductVersion ?? "unknown",
                 ProductId: v.Id,

--- a/src/ReadyStackGo.Application/UseCases/Stacks/ListProducts/ListProductsHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Stacks/ListProducts/ListProductsHandler.cs
@@ -7,10 +7,12 @@ namespace ReadyStackGo.Application.UseCases.Stacks.ListProducts;
 public class ListProductsHandler : IRequestHandler<ListProductsQuery, ListProductsResult>
 {
     private readonly IProductSourceService _productSourceService;
+    private readonly IProductCache _productCache;
 
-    public ListProductsHandler(IProductSourceService productSourceService)
+    public ListProductsHandler(IProductSourceService productSourceService, IProductCache productCache)
     {
         _productSourceService = productSourceService;
+        _productCache = productCache;
     }
 
     public async Task<ListProductsResult> Handle(ListProductsQuery request, CancellationToken cancellationToken)
@@ -51,7 +53,11 @@ public class ListProductsHandler : IRequestHandler<ListProductsQuery, ListProduc
                     v.Options?.Select(o => new SelectOptionItem(o.Value, o.Label, o.Description)).ToList()
                 )).ToList()
             )).ToList(),
-            LastSyncedAt: p.LastSyncedAt
+            LastSyncedAt: p.LastSyncedAt,
+            GroupId: p.GroupId,
+            AvailableVersions: _productCache.GetProductVersionsBySource(p.SourceId, p.GroupId)
+                .Select(v => new ProductVersionItem(v.ProductVersion ?? "latest", v.Id))
+                .ToList()
         )).ToList();
 
         return new ListProductsResult(productItems);

--- a/src/ReadyStackGo.Application/UseCases/Stacks/ListProducts/ListProductsQuery.cs
+++ b/src/ReadyStackGo.Application/UseCases/Stacks/ListProducts/ListProductsQuery.cs
@@ -66,7 +66,25 @@ public record ProductItem(
     /// <summary>
     /// Last sync timestamp
     /// </summary>
-    DateTime LastSyncedAt
+    DateTime LastSyncedAt,
+
+    /// <summary>
+    /// Product group identifier for versioning
+    /// </summary>
+    string GroupId,
+
+    /// <summary>
+    /// All available versions of this product from the same source
+    /// </summary>
+    List<ProductVersionItem> AvailableVersions
+);
+
+/// <summary>
+/// A version of a product available in the same source.
+/// </summary>
+public record ProductVersionItem(
+    string Version,
+    string ProductId
 );
 
 /// <summary>

--- a/src/ReadyStackGo.Infrastructure/Caching/InMemoryProductCache.cs
+++ b/src/ReadyStackGo.Infrastructure/Caching/InMemoryProductCache.cs
@@ -20,14 +20,15 @@ public class InMemoryProductCache : IProductCache
     public int StackCount => GetAllProducts().Sum(p => p.Stacks.Count);
 
     /// <summary>
-    /// Get all cached products (returns latest version of each product group for backward compatibility)
+    /// Get all cached products (returns latest version per source and product group).
+    /// Products from different sources are always returned separately, even if they share a GroupId.
     /// </summary>
     public IEnumerable<ProductDefinition> GetAllProducts()
     {
         return _productGroups.Values
-            .Select(group => GetLatestVersion(group))
-            .Where(p => p != null)
-            .Cast<ProductDefinition>()
+            .SelectMany(group => group.Values)
+            .GroupBy(p => (p.SourceId, p.GroupId))
+            .Select(g => g.OrderByDescending(p => p.ProductVersion, new SemVerComparer()).First())
             .ToList();
     }
 
@@ -100,6 +101,22 @@ public class InMemoryProductCache : IProductCache
         if (_productGroups.TryGetValue(groupId, out var versions))
         {
             return versions.Values
+                .OrderByDescending(p => p.ProductVersion, new SemVerComparer())
+                .ToList();
+        }
+        return Enumerable.Empty<ProductDefinition>();
+    }
+
+    /// <summary>
+    /// Get all versions of a product from a specific source.
+    /// Returns versions sorted by version number (newest first).
+    /// </summary>
+    public IEnumerable<ProductDefinition> GetProductVersionsBySource(string sourceId, string groupId)
+    {
+        if (_productGroups.TryGetValue(groupId, out var versions))
+        {
+            return versions.Values
+                .Where(p => p.SourceId == sourceId)
                 .OrderByDescending(p => p.ProductVersion, new SemVerComparer())
                 .ToList();
         }

--- a/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Catalog/ProductDetail.tsx
+++ b/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Catalog/ProductDetail.tsx
@@ -92,16 +92,26 @@ export default function ProductDetail() {
               <h1 className="text-2xl font-bold text-gray-900 dark:text-white">
                 {product.name}
               </h1>
-              {product.version && (
+              {product.version && product.availableVersions && product.availableVersions.length > 1 ? (
+                <select
+                  value={product.id}
+                  onChange={(e) => navigate(`/catalog/${encodeURIComponent(e.target.value)}`)}
+                  className="rounded-full bg-gray-100 px-3 py-1 text-sm font-medium text-gray-700 border-none cursor-pointer hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+                >
+                  {product.availableVersions.map((v) => (
+                    <option key={v.productId} value={v.productId}>
+                      v{v.version}
+                    </option>
+                  ))}
+                </select>
+              ) : product.version ? (
                 <span className="inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-sm font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-300">
                   v{product.version}
-                  {product.availableVersions && product.availableVersions.length > 1 && (
-                    <span className="ml-1 text-xs text-gray-500 dark:text-gray-400">
-                      ({product.availableVersions.length} versions)
-                    </span>
-                  )}
                 </span>
-              )}
+              ) : null}
+              <span className="text-sm text-gray-500 dark:text-gray-400">
+                {product.sourceName}
+              </span>
             </div>
 
             {product.description && (

--- a/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Catalog/StackCatalog.tsx
+++ b/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Catalog/StackCatalog.tsx
@@ -146,7 +146,12 @@ function ProductCard({ product }: ProductCardProps) {
               )}
             </div>
             <p className="text-xs text-gray-500 dark:text-gray-400">
-              {product.sourceName}
+              <span className="inline-flex items-center gap-1">
+                <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 8h14M5 8a2 2 0 110-4h14a2 2 0 110 4M5 8v10a2 2 0 002 2h10a2 2 0 002-2V8m-9 4h4" />
+                </svg>
+                {product.sourceName}
+              </span>
             </p>
           </div>
 

--- a/tests/ReadyStackGo.UnitTests/Infrastructure/Caching/InMemoryProductCacheTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Infrastructure/Caching/InMemoryProductCacheTests.cs
@@ -442,4 +442,111 @@ public class InMemoryProductCacheTests
     }
 
     #endregion
+
+    #region Source-Scoped Product Retrieval
+
+    [Fact]
+    public void GetAllProducts_SameProductFromTwoSources_ReturnsBoth()
+    {
+        // Arrange - Same product name and explicit GroupId, but different sources
+        var sourceA = CreateProduct("source-a", "ams.project", "1.0.0", "com.ams.project");
+        var sourceB = CreateProduct("source-b", "ams.project", "2.0.0", "com.ams.project");
+
+        _cache.Set(sourceA);
+        _cache.Set(sourceB);
+
+        // Act
+        var products = _cache.GetAllProducts().ToList();
+
+        // Assert - Should return both, one per source
+        products.Should().HaveCount(2);
+        products.Select(p => p.SourceId).Should().BeEquivalentTo(["source-a", "source-b"]);
+    }
+
+    [Fact]
+    public void GetAllProducts_SameSourceMultipleVersions_ReturnsLatestOnly()
+    {
+        // Arrange - Same source, same product, multiple versions
+        _cache.Set(CreateProduct("source-a", "ams.project", "1.0.0", "com.ams.project"));
+        _cache.Set(CreateProduct("source-a", "ams.project", "2.0.0", "com.ams.project"));
+        _cache.Set(CreateProduct("source-a", "ams.project", "3.0.0", "com.ams.project"));
+
+        // Act
+        var products = _cache.GetAllProducts().ToList();
+
+        // Assert - Should return only latest
+        products.Should().HaveCount(1);
+        products[0].ProductVersion.Should().Be("3.0.0");
+    }
+
+    [Fact]
+    public void GetAllProducts_MixedScenario_ReturnsLatestPerSourceAndGroup()
+    {
+        // Arrange
+        // Source A has v1.0 and v2.0 of product X
+        _cache.Set(CreateProduct("source-a", "ProductX", "1.0.0", "com.example.x"));
+        _cache.Set(CreateProduct("source-a", "ProductX", "2.0.0", "com.example.x"));
+        // Source B has v3.0 of same product X
+        _cache.Set(CreateProduct("source-b", "ProductX", "3.0.0", "com.example.x"));
+        // Source A also has product Y
+        _cache.Set(CreateProduct("source-a", "ProductY", "1.0.0"));
+
+        // Act
+        var products = _cache.GetAllProducts().ToList();
+
+        // Assert - 3 entries: source-a:ProductX (v2.0), source-b:ProductX (v3.0), source-a:ProductY (v1.0)
+        products.Should().HaveCount(3);
+        products.Should().Contain(p => p.SourceId == "source-a" && p.Name == "ProductX" && p.ProductVersion == "2.0.0");
+        products.Should().Contain(p => p.SourceId == "source-b" && p.Name == "ProductX" && p.ProductVersion == "3.0.0");
+        products.Should().Contain(p => p.SourceId == "source-a" && p.Name == "ProductY" && p.ProductVersion == "1.0.0");
+    }
+
+    [Fact]
+    public void GetProductVersionsBySource_ReturnsOnlyVersionsFromSpecificSource()
+    {
+        // Arrange
+        _cache.Set(CreateProduct("source-a", "ProductX", "1.0.0", "com.example.x"));
+        _cache.Set(CreateProduct("source-a", "ProductX", "2.0.0", "com.example.x"));
+        _cache.Set(CreateProduct("source-b", "ProductX", "3.0.0", "com.example.x"));
+
+        // Act
+        var versionsA = _cache.GetProductVersionsBySource("source-a", "com.example.x").ToList();
+        var versionsB = _cache.GetProductVersionsBySource("source-b", "com.example.x").ToList();
+
+        // Assert
+        versionsA.Should().HaveCount(2);
+        versionsA[0].ProductVersion.Should().Be("2.0.0"); // newest first
+        versionsA[1].ProductVersion.Should().Be("1.0.0");
+
+        versionsB.Should().HaveCount(1);
+        versionsB[0].ProductVersion.Should().Be("3.0.0");
+    }
+
+    [Fact]
+    public void GetProductVersionsBySource_NonExistentSource_ReturnsEmpty()
+    {
+        // Arrange
+        _cache.Set(CreateProduct("source-a", "ProductX", "1.0.0", "com.example.x"));
+
+        // Act
+        var versions = _cache.GetProductVersionsBySource("nonexistent", "com.example.x").ToList();
+
+        // Assert
+        versions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void GetProductVersionsBySource_NonExistentGroup_ReturnsEmpty()
+    {
+        // Arrange
+        _cache.Set(CreateProduct("source-a", "ProductX", "1.0.0"));
+
+        // Act
+        var versions = _cache.GetProductVersionsBySource("source-a", "nonexistent").ToList();
+
+        // Assert
+        versions.Should().BeEmpty();
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

- **Cache**: `GetAllProducts()` returns latest per (SourceId, GroupId) — products from different sources appear separately
- **API**: `ListProducts` response includes `groupId` and `availableVersions` (source-scoped)
- **UI Catalog**: Source icon on product cards, products naturally separated per source
- **UI Detail**: Version picker dropdown when multiple versions exist within a source
- **Tests**: 6 new unit tests for source-scoped cache behavior (2693 total passing)

## Changed files

| Layer | File | Change |
|---|---|---|
| Application | `IProductCache.cs` | Add `GetProductVersionsBySource()` |
| Application | `ListProductsQuery.cs` | Add `GroupId`, `AvailableVersions`, `ProductVersionItem` |
| Application | `ListProductsHandler.cs` | Inject `IProductCache`, populate versions |
| Application | `GetProductHandler.cs` | Filter versions by source |
| Infrastructure | `InMemoryProductCache.cs` | Source-scoped `GetAllProducts()`, new method |
| Frontend | `StackCatalog.tsx` | Source icon on cards |
| Frontend | `ProductDetail.tsx` | Version picker dropdown + source name |
| Tests | `InMemoryProductCacheTests.cs` | 6 new tests |

## AMS UI

AMS UI is affected — `@rsgo/core` API types (`Product`) already have `groupId`/`availableVersions` fields. AMS Catalog page will need version picker (deferred).

Closes #313