### PR TITLE
Fix SSH tunnel destroyed after every request

### DIFF
--- a/src/ReadyStackGo.Infrastructure.Docker/DockerService.cs
+++ b/src/ReadyStackGo.Infrastructure.Docker/DockerService.cs
@@ -1147,10 +1147,12 @@ public class DockerService : IDockerService, IDisposable
     {
         if (_disposed) return;
 
-        foreach (var (envId, client) in _clientCache)
+        foreach (var (_, client) in _clientCache)
         {
             client.Dispose();
-            _sshTunnelManager.CloseTunnel(envId);
+            // Do NOT close SSH tunnels here — DockerService is scoped (per-request),
+            // but SshTunnelManager is a singleton. Tunnels are shared across requests
+            // and managed by SshTunnelManager's own lifecycle.
         }
         _clientCache.Clear();
 


### PR DESCRIPTION
## Summary

- **Root cause**: `DockerService` is scoped (per HTTP request) but called `SshTunnelManager.CloseTunnel()` in its `Dispose()`. Since `SshTunnelManager` is a singleton, this destroyed the shared SSH tunnel after every single request.
- **Symptom**: SSH tunnel constantly recycled (close → create → close), causing intermittent "Internal Server Error" on container/health pages
- **Fix**: Remove `CloseTunnel` from `DockerService.Dispose()` — tunnel lifecycle is owned by the singleton `SshTunnelManager`

## Evidence from logs

```
SSH tunnel closed for environment 482afa5a...
SSH tunnel created: localhost:36581 → socat STDIO → /var/run/docker.sock
SSH tunnel established for environment 482afa5a...
SSH tunnel closed for environment 482afa5a...  ← immediately after each request
SSH tunnel created: localhost:33413 → ...       ← new port every time
```