### PR TITLE
Fix milestone-release Docker build via workflow_dispatch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,11 @@ name: Docker Build and Push
 on:
   push:
     tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Version tag to build (e.g., v0.53.1)'
+        required: true
 
 env:
   DOCKERHUB_IMAGE: wiesenwischer/readystackgo
@@ -16,6 +21,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -75,12 +82,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Extract version from tag
         id: version
         run: |
           # Extract version from tag (e.g., v0.11.0 -> 0.11.0)
-          VERSION=${GITHUB_REF#refs/tags/v}
+          # Support both push-tag and workflow_dispatch triggers
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            VERSION="${{ github.event.inputs.tag }}"
+            VERSION="${VERSION#v}"
+          else
+            VERSION=${GITHUB_REF#refs/tags/v}
+          fi
           MAJOR=$(echo $VERSION | cut -d. -f1)
           MINOR=$(echo $VERSION | cut -d. -f2)
           echo "semVer=$VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/milestone-release.yml
+++ b/.github/workflows/milestone-release.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   release:
@@ -26,7 +27,9 @@ jobs:
           echo "version=$MILESTONE_TITLE" >> $GITHUB_OUTPUT
           echo "Milestone closed: ${{ github.event.milestone.title }} → Release: $MILESTONE_TITLE"
 
-      - name: Push tag to trigger Docker build
+      - name: Create tag and release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
@@ -37,18 +40,6 @@ jobs:
             gh release delete "$VERSION" --yes --cleanup-tag
           fi
 
-          # Create and push the tag FIRST — this triggers the Docker Build workflow
-          git tag -f "$VERSION"
-          git push origin "refs/tags/$VERSION" --force
-
-          echo "Tag $VERSION pushed — Docker Build workflow triggered"
-
-      - name: Create release from milestone
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-
           # Generate release notes from milestone issues
           BODY=$(gh api repos/${{ github.repository }}/issues \
             --method GET \
@@ -57,13 +48,25 @@ jobs:
             -f per_page=100 \
             --jq '.[] | "- " + .title + " (#" + (.number | tostring) + ")"')
 
-          # Create release on the existing tag (does NOT re-push the tag)
+          # Create release (this also creates the tag)
           gh release create "$VERSION" \
             --title "$VERSION – ${{ github.event.milestone.description }}" \
             --notes "## What's Changed in $VERSION"$'\n\n'"$BODY" \
             --latest
 
           echo "Release $VERSION created and published"
+
+      - name: Trigger Docker Build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+
+          # GITHUB_TOKEN from within a workflow cannot trigger other workflows
+          # via push events. Use workflow_dispatch instead.
+          gh workflow run docker.yml -f tag="$VERSION"
+
+          echo "Docker Build workflow dispatched for $VERSION"
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary

- **Root cause**: `GITHUB_TOKEN` cannot trigger other workflows via push events (GitHub Actions security restriction). Tag pushes from milestone-release were silently ignored.
- **Fix**: Replace tag-push trigger with direct `gh workflow run docker.yml -f tag=VERSION` call
- **Also**: Add `workflow_dispatch` input to `docker.yml` for manual triggering

This affected v0.52.0, v0.53.0, and v0.53.1 releases.