### PR TITLE
Fix encryption key lost after self-update

### DIFF
--- a/src/ReadyStackGo.Infrastructure/Services/CredentialEncryptionService.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/CredentialEncryptionService.cs
@@ -29,7 +29,7 @@ public class CredentialEncryptionService : ICredentialEncryptionService
         else
         {
             // Auto-generate a key and persist it in a file next to the database
-            var dataDir = configuration["DataDirectory"] ?? "/data";
+            var dataDir = configuration["DataPath"] ?? "/app/data";
             var keyFilePath = Path.Combine(dataDir, ".encryption-key");
 
             if (File.Exists(keyFilePath))


### PR DESCRIPTION
## Summary

- **Root cause**: `CredentialEncryptionService` used config key `DataDirectory` (default `/data`) instead of `DataPath` (default `/app/data`). The encryption key file was stored in the container overlay filesystem at `/data/.encryption-key` instead of the persistent volume at `/app/data/.encryption-key`.
- **Symptom**: After every self-update (new container), a new encryption key was generated, making all existing SSH credentials unreadable (`CryptographicException: Padding is invalid`).
- **Fix**: Use correct config key `DataPath` with default `/app/data`

## Impact

After deploying this fix, the SSH environment on test-ux-dokker will need to be re-created (re-enter SSH credentials) since the old encrypted credentials are unrecoverable with the lost key.