### PR TITLE
Fix false Running status for failed stacks during product deployment

### DIFF
--- a/src/ReadyStackGo.WebUi/packages/core/src/hooks/useDeployProductStore.ts
+++ b/src/ReadyStackGo.WebUi/packages/core/src/hooks/useDeployProductStore.ts
@@ -145,12 +145,18 @@ export function useDeployProductStore(
       if (update.phase === 'ProductDeploy' && update.currentService) {
         const stackName = update.currentService;
 
-        // Mark previous deploying stack as running
+        // Determine previous stack's result from completedStacks count
+        // Backend sends completedStacks (as completedServices) BEFORE deploying the current stack.
+        // If completedStacks increased vs the stack index, previous stack succeeded; otherwise it failed.
         const prevStack = currentDeployingStackRef.current;
         if (prevStack && prevStack !== stackName) {
+          const prevStackIndex = product?.stacks.findIndex(s => s.name === prevStack) ?? -1;
+          // completedServices = completedStacks at this point.
+          // If prevStack (index N) succeeded, completedStacks should be > N.
+          const prevSucceeded = prevStackIndex >= 0 && update.completedServices > prevStackIndex;
           setStackStatuses(prev => ({
             ...prev,
-            [prevStack]: 'running'
+            [prevStack]: prevSucceeded ? 'running' : 'failed'
           }));
         }
 


### PR DESCRIPTION
## Summary

- **Bug**: During product deployment, the previous stack was always marked as "Running" (green checkmark) when a new stack started deploying, even if the previous stack's init container had failed
- **Fix**: Use the `completedStacks` count from the backend progress update to determine if the previous stack succeeded or failed. If `completedStacks > stackIndex`, the stack succeeded; otherwise it failed
- **Scope**: Only `useDeployProductStore` was affected. `useRedeployProductStore` correctly parses status from message text

Closes #322