### PR TITLE
Add environment resolution by name to all hook endpoints

### DIFF
--- a/src/ReadyStackGo.Application/Services/EnvironmentResolver.cs
+++ b/src/ReadyStackGo.Application/Services/EnvironmentResolver.cs
@@ -1,0 +1,41 @@
+using ReadyStackGo.Domain.Deployment.Environments;
+
+namespace ReadyStackGo.Application.Services;
+
+/// <summary>
+/// Resolves an environment identifier that can be either a GUID or a name.
+/// Used by hook endpoints to allow CI/CD pipelines to reference environments by name.
+/// </summary>
+public static class EnvironmentResolver
+{
+    /// <summary>
+    /// Resolves an environment ID or name to an EnvironmentId.
+    /// If the value is a valid GUID, it is used directly.
+    /// Otherwise, a case-insensitive name lookup is performed.
+    /// </summary>
+    /// <returns>The resolved EnvironmentId, or an error message.</returns>
+    public static (EnvironmentId? Id, string? Error) Resolve(
+        string? idOrName,
+        IEnvironmentRepository environmentRepository)
+    {
+        if (string.IsNullOrWhiteSpace(idOrName))
+        {
+            return (null, "EnvironmentId is required. Provide a GUID or environment name.");
+        }
+
+        // Try as GUID first
+        if (Guid.TryParse(idOrName, out var envGuid))
+        {
+            return (new EnvironmentId(envGuid), null);
+        }
+
+        // Fall back to case-insensitive name lookup
+        var match = environmentRepository.FindByName(idOrName);
+        if (match == null)
+        {
+            return (null, $"Environment '{idOrName}' not found. Provide a valid GUID or environment name.");
+        }
+
+        return (match.Id, null);
+    }
+}

--- a/src/ReadyStackGo.Application/UseCases/Hooks/DeployStack/DeployViaHookCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Hooks/DeployStack/DeployViaHookCommand.cs
@@ -48,6 +48,7 @@ public class DeployViaHookHandler : IRequestHandler<DeployViaHookCommand, Deploy
     private readonly IDeploymentRepository _deploymentRepository;
     private readonly IProductDeploymentRepository _productDeploymentRepository;
     private readonly IProductSourceService _productSourceService;
+    private readonly IEnvironmentRepository _environmentRepository;
     private readonly IMediator _mediator;
     private readonly ILogger<DeployViaHookHandler> _logger;
 
@@ -55,12 +56,14 @@ public class DeployViaHookHandler : IRequestHandler<DeployViaHookCommand, Deploy
         IDeploymentRepository deploymentRepository,
         IProductDeploymentRepository productDeploymentRepository,
         IProductSourceService productSourceService,
+        IEnvironmentRepository environmentRepository,
         IMediator mediator,
         ILogger<DeployViaHookHandler> logger)
     {
         _deploymentRepository = deploymentRepository;
         _productDeploymentRepository = productDeploymentRepository;
         _productSourceService = productSourceService;
+        _environmentRepository = environmentRepository;
         _mediator = mediator;
         _logger = logger;
     }
@@ -78,9 +81,10 @@ public class DeployViaHookHandler : IRequestHandler<DeployViaHookCommand, Deploy
             return DeployViaHookResponse.Failed("StackName is required.");
         }
 
-        if (!Guid.TryParse(request.EnvironmentId, out var envGuid))
+        var (resolvedEnvId, envError) = EnvironmentResolver.Resolve(request.EnvironmentId, _environmentRepository);
+        if (resolvedEnvId == null)
         {
-            return DeployViaHookResponse.Failed("Invalid environment ID format.");
+            return DeployViaHookResponse.Failed(envError!);
         }
 
         // 1b. Resolve StackId from ProductId if not directly provided
@@ -102,7 +106,7 @@ public class DeployViaHookHandler : IRequestHandler<DeployViaHookCommand, Deploy
             resolvedStackDefinitionName = resolveResult.StackDefinitionName;
         }
 
-        var environmentId = new EnvironmentId(envGuid);
+        var environmentId = resolvedEnvId;
 
         // 1c. If deploying via ProductId, check if stack belongs to an active ProductDeployment
         // and resolve the actual deployment stack name (e.g., "Analytics" → "ams-project-analytics")
@@ -175,8 +179,9 @@ public class DeployViaHookHandler : IRequestHandler<DeployViaHookCommand, Deploy
         }
 
         // 3. Delegate to DeployStackCommand
+        var envIdString = resolvedEnvId.Value.ToString();
         var deployResult = await _mediator.Send(new DeployStackCommand(
-            request.EnvironmentId,
+            envIdString,
             stackId,
             deployStackName,
             variables,

--- a/src/ReadyStackGo.Application/UseCases/Hooks/RedeployStack/RedeployStackCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Hooks/RedeployStack/RedeployStackCommand.cs
@@ -1,5 +1,6 @@
 using MediatR;
 using Microsoft.Extensions.Logging;
+using ReadyStackGo.Application.Services;
 using ReadyStackGo.Application.UseCases.Deployments.DeployStack;
 using ReadyStackGo.Application.UseCases.Deployments.RedeployProduct;
 using ReadyStackGo.Domain.Deployment.Deployments;
@@ -42,30 +43,34 @@ public class RedeployStackHandler : IRequestHandler<RedeployStackCommand, Redepl
 {
     private readonly IDeploymentRepository _deploymentRepository;
     private readonly IProductDeploymentRepository _productDeploymentRepository;
+    private readonly IEnvironmentRepository _environmentRepository;
     private readonly IMediator _mediator;
     private readonly ILogger<RedeployStackHandler> _logger;
 
     public RedeployStackHandler(
         IDeploymentRepository deploymentRepository,
         IProductDeploymentRepository productDeploymentRepository,
+        IEnvironmentRepository environmentRepository,
         IMediator mediator,
         ILogger<RedeployStackHandler> logger)
     {
         _deploymentRepository = deploymentRepository;
         _productDeploymentRepository = productDeploymentRepository;
+        _environmentRepository = environmentRepository;
         _mediator = mediator;
         _logger = logger;
     }
 
     public async Task<RedeployStackResponse> Handle(RedeployStackCommand request, CancellationToken cancellationToken)
     {
-        // 1. Parse environment ID
-        if (!Guid.TryParse(request.EnvironmentId, out var envGuid))
+        // 1. Resolve environment (GUID or name)
+        var (resolvedEnvId, envError) = EnvironmentResolver.Resolve(request.EnvironmentId, _environmentRepository);
+        if (resolvedEnvId == null)
         {
-            return RedeployStackResponse.Failed("Invalid environment ID format.");
+            return RedeployStackResponse.Failed(envError!);
         }
 
-        var environmentId = new EnvironmentId(envGuid);
+        var environmentId = resolvedEnvId;
 
         // 2. Route: Product redeploy or standalone stack redeploy?
         if (!string.IsNullOrWhiteSpace(request.ProductId))

--- a/src/ReadyStackGo.Application/UseCases/Hooks/RestartContainers/RestartContainersViaHookCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Hooks/RestartContainers/RestartContainersViaHookCommand.cs
@@ -1,6 +1,8 @@
 using MediatR;
 using Microsoft.Extensions.Logging;
+using ReadyStackGo.Application.Services;
 using ReadyStackGo.Application.UseCases.Deployments.RestartProductContainers;
+using ReadyStackGo.Domain.Deployment.Environments;
 using ReadyStackGo.Domain.Deployment.ProductDeployments;
 
 namespace ReadyStackGo.Application.UseCases.Hooks.RestartContainers;
@@ -33,15 +35,18 @@ public record RestartContainersViaHookCommand(
 public class RestartContainersViaHookHandler : IRequestHandler<RestartContainersViaHookCommand, RestartContainersViaHookResponse>
 {
     private readonly IProductDeploymentRepository _productDeploymentRepository;
+    private readonly IEnvironmentRepository _environmentRepository;
     private readonly IMediator _mediator;
     private readonly ILogger<RestartContainersViaHookHandler> _logger;
 
     public RestartContainersViaHookHandler(
         IProductDeploymentRepository productDeploymentRepository,
+        IEnvironmentRepository environmentRepository,
         IMediator mediator,
         ILogger<RestartContainersViaHookHandler> logger)
     {
         _productDeploymentRepository = productDeploymentRepository;
+        _environmentRepository = environmentRepository;
         _mediator = mediator;
         _logger = logger;
     }
@@ -54,14 +59,15 @@ public class RestartContainersViaHookHandler : IRequestHandler<RestartContainers
             return RestartContainersViaHookResponse.Failed("ProductId is required.");
         }
 
-        if (!Guid.TryParse(request.EnvironmentId, out var envGuid))
+        var (resolvedEnvId, envError) = EnvironmentResolver.Resolve(request.EnvironmentId, _environmentRepository);
+        if (resolvedEnvId == null)
         {
-            return RestartContainersViaHookResponse.Failed("Invalid EnvironmentId format.");
+            return RestartContainersViaHookResponse.Failed(envError!);
         }
 
         // Resolve active product deployment
         var productDeployment = _productDeploymentRepository.GetActiveByProductGroupId(
-            new Domain.Deployment.Environments.EnvironmentId(envGuid), request.ProductId);
+            resolvedEnvId, request.ProductId);
 
         if (productDeployment == null)
         {

--- a/src/ReadyStackGo.Application/UseCases/Hooks/StopContainers/StopContainersViaHookCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Hooks/StopContainers/StopContainersViaHookCommand.cs
@@ -1,6 +1,8 @@
 using MediatR;
 using Microsoft.Extensions.Logging;
+using ReadyStackGo.Application.Services;
 using ReadyStackGo.Application.UseCases.Deployments.StopProductContainers;
+using ReadyStackGo.Domain.Deployment.Environments;
 using ReadyStackGo.Domain.Deployment.ProductDeployments;
 
 namespace ReadyStackGo.Application.UseCases.Hooks.StopContainers;
@@ -33,15 +35,18 @@ public record StopContainersViaHookCommand(
 public class StopContainersViaHookHandler : IRequestHandler<StopContainersViaHookCommand, StopContainersViaHookResponse>
 {
     private readonly IProductDeploymentRepository _productDeploymentRepository;
+    private readonly IEnvironmentRepository _environmentRepository;
     private readonly IMediator _mediator;
     private readonly ILogger<StopContainersViaHookHandler> _logger;
 
     public StopContainersViaHookHandler(
         IProductDeploymentRepository productDeploymentRepository,
+        IEnvironmentRepository environmentRepository,
         IMediator mediator,
         ILogger<StopContainersViaHookHandler> logger)
     {
         _productDeploymentRepository = productDeploymentRepository;
+        _environmentRepository = environmentRepository;
         _mediator = mediator;
         _logger = logger;
     }
@@ -54,14 +59,15 @@ public class StopContainersViaHookHandler : IRequestHandler<StopContainersViaHoo
             return StopContainersViaHookResponse.Failed("ProductId is required.");
         }
 
-        if (!Guid.TryParse(request.EnvironmentId, out var envGuid))
+        var (resolvedEnvId, envError) = EnvironmentResolver.Resolve(request.EnvironmentId, _environmentRepository);
+        if (resolvedEnvId == null)
         {
-            return StopContainersViaHookResponse.Failed("Invalid EnvironmentId format.");
+            return StopContainersViaHookResponse.Failed(envError!);
         }
 
         // Resolve active product deployment
         var productDeployment = _productDeploymentRepository.GetActiveByProductGroupId(
-            new Domain.Deployment.Environments.EnvironmentId(envGuid), request.ProductId);
+            resolvedEnvId, request.ProductId);
 
         if (productDeployment == null)
         {

--- a/src/ReadyStackGo.Application/UseCases/Hooks/UpgradeViaHook/UpgradeViaHookCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Hooks/UpgradeViaHook/UpgradeViaHookCommand.cs
@@ -39,30 +39,34 @@ public class UpgradeViaHookHandler : IRequestHandler<UpgradeViaHookCommand, Upgr
 {
     private readonly IDeploymentRepository _deploymentRepository;
     private readonly IProductSourceService _productSourceService;
+    private readonly IEnvironmentRepository _environmentRepository;
     private readonly IMediator _mediator;
     private readonly ILogger<UpgradeViaHookHandler> _logger;
 
     public UpgradeViaHookHandler(
         IDeploymentRepository deploymentRepository,
         IProductSourceService productSourceService,
+        IEnvironmentRepository environmentRepository,
         IMediator mediator,
         ILogger<UpgradeViaHookHandler> logger)
     {
         _deploymentRepository = deploymentRepository;
         _productSourceService = productSourceService;
+        _environmentRepository = environmentRepository;
         _mediator = mediator;
         _logger = logger;
     }
 
     public async Task<UpgradeViaHookResponse> Handle(UpgradeViaHookCommand request, CancellationToken cancellationToken)
     {
-        // 1. Parse environment ID
-        if (!Guid.TryParse(request.EnvironmentId, out var envGuid))
+        // 1. Resolve environment (GUID or name)
+        var (resolvedEnvId, envError) = EnvironmentResolver.Resolve(request.EnvironmentId, _environmentRepository);
+        if (resolvedEnvId == null)
         {
-            return UpgradeViaHookResponse.Failed("Invalid environment ID format.");
+            return UpgradeViaHookResponse.Failed(envError!);
         }
 
-        var environmentId = new EnvironmentId(envGuid);
+        var environmentId = resolvedEnvId;
 
         // 2. Find deployment by stack name + environment
         var deployment = _deploymentRepository.GetByStackName(environmentId, request.StackName);

--- a/src/ReadyStackGo.Domain/Deployment/Environments/IEnvironmentRepository.cs
+++ b/src/ReadyStackGo.Domain/Deployment/Environments/IEnvironmentRepository.cs
@@ -41,6 +41,12 @@ public interface IEnvironmentRepository
     Environment? GetDefault(OrganizationId organizationId);
 
     /// <summary>
+    /// Finds an environment by name across all organizations.
+    /// Returns null if no environment with the given name exists.
+    /// </summary>
+    Environment? FindByName(string name);
+
+    /// <summary>
     /// Removes an environment.
     /// </summary>
     void Remove(Environment environment);

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Repositories/EnvironmentRepository.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Repositories/EnvironmentRepository.cs
@@ -51,6 +51,12 @@ public class EnvironmentRepository : IEnvironmentRepository
             .ToList();
     }
 
+    public Environment? FindByName(string name)
+    {
+        return _context.Environments
+            .FirstOrDefault(e => EF.Functions.Collate(e.Name, "NOCASE") == name);
+    }
+
     public Environment? GetDefault(OrganizationId organizationId)
     {
         return _context.Environments

--- a/tests/ReadyStackGo.UnitTests/Application/Hooks/DeployViaHookHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Hooks/DeployViaHookHandlerTests.cs
@@ -37,6 +37,7 @@ public class DeployViaHookHandlerTests
             _deploymentRepoMock.Object,
             _productDeploymentRepoMock.Object,
             _productSourceMock.Object,
+            Mock.Of<IEnvironmentRepository>(),
             _mediatorMock.Object,
             _loggerMock.Object);
     }
@@ -427,7 +428,7 @@ public class DeployViaHookHandlerTests
             CancellationToken.None);
 
         result.Success.Should().BeFalse();
-        result.Message.Should().Contain("Invalid environment ID");
+        result.Message.Should().Contain("not found");
     }
 
     [Fact]
@@ -438,7 +439,7 @@ public class DeployViaHookHandlerTests
             CancellationToken.None);
 
         result.Success.Should().BeFalse();
-        result.Message.Should().Contain("Invalid environment ID");
+        result.Message.Should().Contain("required");
     }
 
     [Fact]

--- a/tests/ReadyStackGo.UnitTests/Application/Hooks/RedeployStackHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Hooks/RedeployStackHandlerTests.cs
@@ -34,6 +34,7 @@ public class RedeployStackHandlerTests
         _handler = new RedeployStackHandler(
             _deploymentRepoMock.Object,
             _productDeploymentRepoMock.Object,
+            Mock.Of<IEnvironmentRepository>(),
             _mediatorMock.Object,
             _loggerMock.Object);
     }
@@ -249,7 +250,7 @@ public class RedeployStackHandlerTests
             CancellationToken.None);
 
         result.Success.Should().BeFalse();
-        result.Message.Should().Contain("Invalid environment ID");
+        result.Message.Should().Contain("not found");
     }
 
     [Fact]
@@ -260,7 +261,7 @@ public class RedeployStackHandlerTests
             CancellationToken.None);
 
         result.Success.Should().BeFalse();
-        result.Message.Should().Contain("Invalid environment ID");
+        result.Message.Should().Contain("required");
     }
 
     [Fact]
@@ -618,7 +619,7 @@ public class RedeployStackHandlerTests
             CancellationToken.None);
 
         result.Success.Should().BeFalse();
-        result.Message.Should().Contain("Invalid environment ID");
+        result.Message.Should().Contain("not found");
     }
 
     [Fact]

--- a/tests/ReadyStackGo.UnitTests/Application/Hooks/RestartContainersViaHookHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Hooks/RestartContainersViaHookHandlerTests.cs
@@ -27,6 +27,7 @@ public class RestartContainersViaHookHandlerTests
         _loggerMock = new Mock<ILogger<RestartContainersViaHookHandler>>();
         _handler = new RestartContainersViaHookHandler(
             _productDeploymentRepoMock.Object,
+            Mock.Of<IEnvironmentRepository>(),
             _mediatorMock.Object,
             _loggerMock.Object);
     }
@@ -137,7 +138,7 @@ public class RestartContainersViaHookHandlerTests
             CancellationToken.None);
 
         result.Success.Should().BeFalse();
-        result.Message.Should().Contain("Invalid EnvironmentId");
+        result.Message.Should().Contain("not found");
     }
 
     [Fact]

--- a/tests/ReadyStackGo.UnitTests/Application/Hooks/StopContainersViaHookHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Hooks/StopContainersViaHookHandlerTests.cs
@@ -27,6 +27,7 @@ public class StopContainersViaHookHandlerTests
         _loggerMock = new Mock<ILogger<StopContainersViaHookHandler>>();
         _handler = new StopContainersViaHookHandler(
             _productDeploymentRepoMock.Object,
+            Mock.Of<IEnvironmentRepository>(),
             _mediatorMock.Object,
             _loggerMock.Object);
     }
@@ -137,7 +138,7 @@ public class StopContainersViaHookHandlerTests
             CancellationToken.None);
 
         result.Success.Should().BeFalse();
-        result.Message.Should().Contain("Invalid EnvironmentId");
+        result.Message.Should().Contain("not found");
     }
 
     [Fact]

--- a/tests/ReadyStackGo.UnitTests/Application/Hooks/UpgradeViaHookHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Hooks/UpgradeViaHookHandlerTests.cs
@@ -34,6 +34,7 @@ public class UpgradeViaHookHandlerTests
         _handler = new UpgradeViaHookHandler(
             _deploymentRepoMock.Object,
             _productSourceMock.Object,
+            Mock.Of<IEnvironmentRepository>(),
             _mediatorMock.Object,
             _loggerMock.Object);
     }
@@ -267,7 +268,7 @@ public class UpgradeViaHookHandlerTests
             CancellationToken.None);
 
         result.Success.Should().BeFalse();
-        result.Message.Should().Contain("Invalid environment ID");
+        result.Message.Should().Contain("not found");
     }
 
     #endregion


### PR DESCRIPTION
## Summary

- New `EnvironmentResolver` static helper: GUID or case-insensitive name lookup
- New `FindByName(string)` on `IEnvironmentRepository` for cross-org name search
- All 5 hook handlers updated to use resolver instead of `Guid.TryParse`
- Existing tests updated for new error messages

## AMS UI: not affected (backend-only change)

Closes #324