### PR TITLE
Separate environmentId and environmentName into distinct hook fields

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/Hooks/DeployEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Hooks/DeployEndpoint.cs
@@ -39,7 +39,7 @@ public class DeployEndpoint : Endpoint<DeployViaHookRequest, DeployViaHookRespon
 
         var response = await _mediator.Send(
             new DeployViaHookCommand(req.StackId, req.StackName, environmentId!, req.Variables,
-                req.ProductId, req.Version, req.StackDefinitionName), ct);
+                req.EnvironmentName, req.ProductId, req.Version, req.StackDefinitionName), ct);
 
         if (!response.Success)
         {

--- a/src/ReadyStackGo.Api/Endpoints/Hooks/RedeployEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Hooks/RedeployEndpoint.cs
@@ -44,7 +44,7 @@ public class RedeployEndpoint : Endpoint<RedeployStackRequest, RedeployStackResp
         }
 
         var response = await _mediator.Send(
-            new RedeployStackCommand(req.StackName, environmentId!, req.Variables, req.ProductId, req.StackDefinitionName), ct);
+            new RedeployStackCommand(req.StackName, environmentId!, req.EnvironmentName, req.Variables, req.ProductId, req.StackDefinitionName), ct);
 
         if (!response.Success)
         {

--- a/src/ReadyStackGo.Api/Endpoints/Hooks/RestartContainersEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Hooks/RestartContainersEndpoint.cs
@@ -38,7 +38,7 @@ public class RestartContainersEndpoint : Endpoint<RestartContainersViaHookReques
         }
 
         var response = await _mediator.Send(
-            new RestartContainersViaHookCommand(req.ProductId, req.StackDefinitionName, environmentId!), ct);
+            new RestartContainersViaHookCommand(req.ProductId, req.StackDefinitionName, environmentId!, req.EnvironmentName), ct);
 
         if (!response.Success)
         {

--- a/src/ReadyStackGo.Api/Endpoints/Hooks/StopContainersEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Hooks/StopContainersEndpoint.cs
@@ -38,7 +38,7 @@ public class StopContainersEndpoint : Endpoint<StopContainersViaHookRequest, Sto
         }
 
         var response = await _mediator.Send(
-            new StopContainersViaHookCommand(req.ProductId, req.StackDefinitionName, environmentId!), ct);
+            new StopContainersViaHookCommand(req.ProductId, req.StackDefinitionName, environmentId!, req.EnvironmentName), ct);
 
         if (!response.Success)
         {

--- a/src/ReadyStackGo.Api/Endpoints/Hooks/UpgradeEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Hooks/UpgradeEndpoint.cs
@@ -38,7 +38,7 @@ public class UpgradeEndpoint : Endpoint<UpgradeViaHookRequest, UpgradeViaHookRes
         }
 
         var response = await _mediator.Send(
-            new UpgradeViaHookCommand(req.StackName, req.TargetVersion, environmentId!, req.Variables), ct);
+            new UpgradeViaHookCommand(req.StackName, req.TargetVersion, environmentId!, req.EnvironmentName, req.Variables), ct);
 
         if (!response.Success)
         {

--- a/src/ReadyStackGo.Application/Services/EnvironmentResolver.cs
+++ b/src/ReadyStackGo.Application/Services/EnvironmentResolver.cs
@@ -3,39 +3,49 @@ using ReadyStackGo.Domain.Deployment.Environments;
 namespace ReadyStackGo.Application.Services;
 
 /// <summary>
-/// Resolves an environment identifier that can be either a GUID or a name.
+/// Resolves an environment from separate ID and name fields.
+/// Priority: environmentId (GUID) > environmentName (name lookup) > fallback claim.
 /// Used by hook endpoints to allow CI/CD pipelines to reference environments by name.
 /// </summary>
 public static class EnvironmentResolver
 {
     /// <summary>
-    /// Resolves an environment ID or name to an EnvironmentId.
-    /// If the value is a valid GUID, it is used directly.
-    /// Otherwise, a case-insensitive name lookup is performed.
+    /// Resolves an environment from separate ID and name fields.
+    /// Priority: environmentId > environmentName.
     /// </summary>
+    /// <param name="environmentId">Optional GUID identifier.</param>
+    /// <param name="environmentName">Optional environment name for case-insensitive lookup.</param>
+    /// <param name="environmentRepository">Repository for name-based lookups.</param>
     /// <returns>The resolved EnvironmentId, or an error message.</returns>
     public static (EnvironmentId? Id, string? Error) Resolve(
-        string? idOrName,
+        string? environmentId,
+        string? environmentName,
         IEnvironmentRepository environmentRepository)
     {
-        if (string.IsNullOrWhiteSpace(idOrName))
+        // 1. Try environmentId as GUID
+        if (!string.IsNullOrWhiteSpace(environmentId))
         {
-            return (null, "EnvironmentId is required. Provide a GUID or environment name.");
+            if (Guid.TryParse(environmentId, out var envGuid))
+            {
+                return (new EnvironmentId(envGuid), null);
+            }
+
+            return (null, $"Invalid EnvironmentId format: '{environmentId}'. Must be a valid GUID.");
         }
 
-        // Try as GUID first
-        if (Guid.TryParse(idOrName, out var envGuid))
+        // 2. Try environmentName lookup
+        if (!string.IsNullOrWhiteSpace(environmentName))
         {
-            return (new EnvironmentId(envGuid), null);
+            var match = environmentRepository.FindByName(environmentName);
+            if (match == null)
+            {
+                return (null, $"Environment with name '{environmentName}' not found.");
+            }
+
+            return (match.Id, null);
         }
 
-        // Fall back to case-insensitive name lookup
-        var match = environmentRepository.FindByName(idOrName);
-        if (match == null)
-        {
-            return (null, $"Environment '{idOrName}' not found. Provide a valid GUID or environment name.");
-        }
-
-        return (match.Id, null);
+        // 3. Neither provided
+        return (null, "Either EnvironmentId (GUID) or EnvironmentName is required.");
     }
 }

--- a/src/ReadyStackGo.Application/UseCases/Hooks/DeployStack/DeployViaHookCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Hooks/DeployStack/DeployViaHookCommand.cs
@@ -14,6 +14,7 @@ public record DeployViaHookRequest
     public string? StackId { get; init; }
     public required string StackName { get; init; }
     public string? EnvironmentId { get; init; }
+    public string? EnvironmentName { get; init; }
     public string? ProductId { get; init; }
     public string? Version { get; init; }
     public string? StackDefinitionName { get; init; }
@@ -38,6 +39,7 @@ public record DeployViaHookCommand(
     string StackName,
     string EnvironmentId,
     Dictionary<string, string> Variables,
+    string? EnvironmentName = null,
     string? ProductId = null,
     string? Version = null,
     string? StackDefinitionName = null
@@ -81,7 +83,7 @@ public class DeployViaHookHandler : IRequestHandler<DeployViaHookCommand, Deploy
             return DeployViaHookResponse.Failed("StackName is required.");
         }
 
-        var (resolvedEnvId, envError) = EnvironmentResolver.Resolve(request.EnvironmentId, _environmentRepository);
+        var (resolvedEnvId, envError) = EnvironmentResolver.Resolve(request.EnvironmentId, request.EnvironmentName, _environmentRepository);
         if (resolvedEnvId == null)
         {
             return DeployViaHookResponse.Failed(envError!);

--- a/src/ReadyStackGo.Application/UseCases/Hooks/RedeployStack/RedeployStackCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Hooks/RedeployStack/RedeployStackCommand.cs
@@ -13,6 +13,7 @@ public record RedeployStackRequest
 {
     public string? StackName { get; init; }
     public string? EnvironmentId { get; init; }
+    public string? EnvironmentName { get; init; }
     public string? ProductId { get; init; }
     public string? StackDefinitionName { get; init; }
     public Dictionary<string, string>? Variables { get; init; }
@@ -34,6 +35,7 @@ public record RedeployStackResponse
 public record RedeployStackCommand(
     string? StackName,
     string EnvironmentId,
+    string? EnvironmentName = null,
     Dictionary<string, string>? Variables = null,
     string? ProductId = null,
     string? StackDefinitionName = null
@@ -64,7 +66,7 @@ public class RedeployStackHandler : IRequestHandler<RedeployStackCommand, Redepl
     public async Task<RedeployStackResponse> Handle(RedeployStackCommand request, CancellationToken cancellationToken)
     {
         // 1. Resolve environment (GUID or name)
-        var (resolvedEnvId, envError) = EnvironmentResolver.Resolve(request.EnvironmentId, _environmentRepository);
+        var (resolvedEnvId, envError) = EnvironmentResolver.Resolve(request.EnvironmentId, request.EnvironmentName, _environmentRepository);
         if (resolvedEnvId == null)
         {
             return RedeployStackResponse.Failed(envError!);

--- a/src/ReadyStackGo.Application/UseCases/Hooks/RestartContainers/RestartContainersViaHookCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Hooks/RestartContainers/RestartContainersViaHookCommand.cs
@@ -12,6 +12,7 @@ public record RestartContainersViaHookRequest
     public required string ProductId { get; init; }
     public string? StackDefinitionName { get; init; }
     public string? EnvironmentId { get; init; }
+    public string? EnvironmentName { get; init; }
 }
 
 public record RestartContainersViaHookResponse
@@ -29,7 +30,8 @@ public record RestartContainersViaHookResponse
 public record RestartContainersViaHookCommand(
     string ProductId,
     string? StackDefinitionName,
-    string EnvironmentId
+    string EnvironmentId,
+    string? EnvironmentName = null
 ) : IRequest<RestartContainersViaHookResponse>;
 
 public class RestartContainersViaHookHandler : IRequestHandler<RestartContainersViaHookCommand, RestartContainersViaHookResponse>
@@ -59,7 +61,7 @@ public class RestartContainersViaHookHandler : IRequestHandler<RestartContainers
             return RestartContainersViaHookResponse.Failed("ProductId is required.");
         }
 
-        var (resolvedEnvId, envError) = EnvironmentResolver.Resolve(request.EnvironmentId, _environmentRepository);
+        var (resolvedEnvId, envError) = EnvironmentResolver.Resolve(request.EnvironmentId, request.EnvironmentName, _environmentRepository);
         if (resolvedEnvId == null)
         {
             return RestartContainersViaHookResponse.Failed(envError!);

--- a/src/ReadyStackGo.Application/UseCases/Hooks/StopContainers/StopContainersViaHookCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Hooks/StopContainers/StopContainersViaHookCommand.cs
@@ -12,6 +12,7 @@ public record StopContainersViaHookRequest
     public required string ProductId { get; init; }
     public string? StackDefinitionName { get; init; }
     public string? EnvironmentId { get; init; }
+    public string? EnvironmentName { get; init; }
 }
 
 public record StopContainersViaHookResponse
@@ -29,7 +30,8 @@ public record StopContainersViaHookResponse
 public record StopContainersViaHookCommand(
     string ProductId,
     string? StackDefinitionName,
-    string EnvironmentId
+    string EnvironmentId,
+    string? EnvironmentName = null
 ) : IRequest<StopContainersViaHookResponse>;
 
 public class StopContainersViaHookHandler : IRequestHandler<StopContainersViaHookCommand, StopContainersViaHookResponse>
@@ -59,7 +61,7 @@ public class StopContainersViaHookHandler : IRequestHandler<StopContainersViaHoo
             return StopContainersViaHookResponse.Failed("ProductId is required.");
         }
 
-        var (resolvedEnvId, envError) = EnvironmentResolver.Resolve(request.EnvironmentId, _environmentRepository);
+        var (resolvedEnvId, envError) = EnvironmentResolver.Resolve(request.EnvironmentId, request.EnvironmentName, _environmentRepository);
         if (resolvedEnvId == null)
         {
             return StopContainersViaHookResponse.Failed(envError!);

--- a/src/ReadyStackGo.Application/UseCases/Hooks/UpgradeViaHook/UpgradeViaHookCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Hooks/UpgradeViaHook/UpgradeViaHookCommand.cs
@@ -13,6 +13,7 @@ public record UpgradeViaHookRequest
     public required string StackName { get; init; }
     public required string TargetVersion { get; init; }
     public string? EnvironmentId { get; init; }
+    public string? EnvironmentName { get; init; }
     public Dictionary<string, string>? Variables { get; init; }
 }
 
@@ -32,6 +33,7 @@ public record UpgradeViaHookCommand(
     string StackName,
     string TargetVersion,
     string EnvironmentId,
+    string? EnvironmentName = null,
     Dictionary<string, string>? Variables = null
 ) : IRequest<UpgradeViaHookResponse>;
 
@@ -60,7 +62,7 @@ public class UpgradeViaHookHandler : IRequestHandler<UpgradeViaHookCommand, Upgr
     public async Task<UpgradeViaHookResponse> Handle(UpgradeViaHookCommand request, CancellationToken cancellationToken)
     {
         // 1. Resolve environment (GUID or name)
-        var (resolvedEnvId, envError) = EnvironmentResolver.Resolve(request.EnvironmentId, _environmentRepository);
+        var (resolvedEnvId, envError) = EnvironmentResolver.Resolve(request.EnvironmentId, request.EnvironmentName, _environmentRepository);
         if (resolvedEnvId == null)
         {
             return UpgradeViaHookResponse.Failed(envError!);

--- a/tests/ReadyStackGo.IntegrationTests/DeployEndpointIntegrationTests.cs
+++ b/tests/ReadyStackGo.IntegrationTests/DeployEndpointIntegrationTests.cs
@@ -65,7 +65,7 @@ public class DeployEndpointIntegrationTests : AuthenticatedTestBase
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var body = await response.Content.ReadAsStringAsync();
-        body.Should().Contain("not found");
+        body.Should().Contain("Invalid EnvironmentId format");
     }
 
     [Fact]

--- a/tests/ReadyStackGo.IntegrationTests/RedeployEndpointIntegrationTests.cs
+++ b/tests/ReadyStackGo.IntegrationTests/RedeployEndpointIntegrationTests.cs
@@ -69,7 +69,7 @@ public class RedeployEndpointIntegrationTests : AuthenticatedTestBase
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var body = await response.Content.ReadAsStringAsync();
-        body.Should().Contain("not found");
+        body.Should().Contain("Invalid EnvironmentId format");
     }
 
     [Fact]

--- a/tests/ReadyStackGo.IntegrationTests/UpgradeEndpointIntegrationTests.cs
+++ b/tests/ReadyStackGo.IntegrationTests/UpgradeEndpointIntegrationTests.cs
@@ -58,7 +58,7 @@ public class UpgradeEndpointIntegrationTests : AuthenticatedTestBase
 
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
         var body = await response.Content.ReadAsStringAsync();
-        body.Should().Contain("not found");
+        body.Should().Contain("Invalid EnvironmentId format");
     }
 
     [Fact]

--- a/tests/ReadyStackGo.UnitTests/Application/Hooks/DeployViaHookHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Hooks/DeployViaHookHandlerTests.cs
@@ -428,7 +428,7 @@ public class DeployViaHookHandlerTests
             CancellationToken.None);
 
         result.Success.Should().BeFalse();
-        result.Message.Should().Contain("not found");
+        result.Message.Should().Contain("Invalid EnvironmentId format");
     }
 
     [Fact]

--- a/tests/ReadyStackGo.UnitTests/Application/Hooks/RedeployStackHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Hooks/RedeployStackHandlerTests.cs
@@ -250,7 +250,7 @@ public class RedeployStackHandlerTests
             CancellationToken.None);
 
         result.Success.Should().BeFalse();
-        result.Message.Should().Contain("not found");
+        result.Message.Should().Contain("Invalid EnvironmentId format");
     }
 
     [Fact]
@@ -385,7 +385,7 @@ public class RedeployStackHandlerTests
         SetupSuccessfulDeploy();
 
         await _handler.Handle(
-            new RedeployStackCommand(TestStackName, TestEnvironmentId, null),
+            new RedeployStackCommand(TestStackName, TestEnvironmentId, Variables: null),
             CancellationToken.None);
 
         _mediatorMock.Verify(m => m.Send(
@@ -414,7 +414,7 @@ public class RedeployStackHandlerTests
         SetupSuccessfulDeploy();
 
         await _handler.Handle(
-            new RedeployStackCommand(TestStackName, TestEnvironmentId, webhookVars),
+            new RedeployStackCommand(TestStackName, TestEnvironmentId, Variables: webhookVars),
             CancellationToken.None);
 
         _mediatorMock.Verify(m => m.Send(
@@ -442,7 +442,7 @@ public class RedeployStackHandlerTests
         SetupSuccessfulDeploy();
 
         await _handler.Handle(
-            new RedeployStackCommand(TestStackName, TestEnvironmentId, webhookVars),
+            new RedeployStackCommand(TestStackName, TestEnvironmentId, Variables: webhookVars),
             CancellationToken.None);
 
         _mediatorMock.Verify(m => m.Send(
@@ -466,7 +466,7 @@ public class RedeployStackHandlerTests
         SetupSuccessfulDeploy();
 
         await _handler.Handle(
-            new RedeployStackCommand(TestStackName, TestEnvironmentId, webhookVars),
+            new RedeployStackCommand(TestStackName, TestEnvironmentId, Variables: webhookVars),
             CancellationToken.None);
 
         _mediatorMock.Verify(m => m.Send(
@@ -488,7 +488,7 @@ public class RedeployStackHandlerTests
         SetupSuccessfulDeploy();
 
         await _handler.Handle(
-            new RedeployStackCommand(TestStackName, TestEnvironmentId, webhookVars),
+            new RedeployStackCommand(TestStackName, TestEnvironmentId, Variables: webhookVars),
             CancellationToken.None);
 
         _mediatorMock.Verify(m => m.Send(
@@ -567,7 +567,7 @@ public class RedeployStackHandlerTests
         var variables = new Dictionary<string, string> { ["BUILD_NUM"] = "42" };
 
         await _handler.Handle(
-            new RedeployStackCommand(null, TestEnvironmentId, variables, ProductId: "test.product"),
+            new RedeployStackCommand(null, TestEnvironmentId, Variables: variables, ProductId: "test.product"),
             CancellationToken.None);
 
         _mediatorMock.Verify(m => m.Send(
@@ -619,7 +619,7 @@ public class RedeployStackHandlerTests
             CancellationToken.None);
 
         result.Success.Should().BeFalse();
-        result.Message.Should().Contain("not found");
+        result.Message.Should().Contain("Invalid EnvironmentId format");
     }
 
     [Fact]

--- a/tests/ReadyStackGo.UnitTests/Application/Hooks/RestartContainersViaHookHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Hooks/RestartContainersViaHookHandlerTests.cs
@@ -138,7 +138,7 @@ public class RestartContainersViaHookHandlerTests
             CancellationToken.None);
 
         result.Success.Should().BeFalse();
-        result.Message.Should().Contain("not found");
+        result.Message.Should().Contain("Invalid EnvironmentId format");
     }
 
     [Fact]

--- a/tests/ReadyStackGo.UnitTests/Application/Hooks/StopContainersViaHookHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Hooks/StopContainersViaHookHandlerTests.cs
@@ -138,7 +138,7 @@ public class StopContainersViaHookHandlerTests
             CancellationToken.None);
 
         result.Success.Should().BeFalse();
-        result.Message.Should().Contain("not found");
+        result.Message.Should().Contain("Invalid EnvironmentId format");
     }
 
     [Fact]

--- a/tests/ReadyStackGo.UnitTests/Application/Hooks/UpgradeViaHookHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Hooks/UpgradeViaHookHandlerTests.cs
@@ -123,7 +123,7 @@ public class UpgradeViaHookHandlerTests
         var variables = new Dictionary<string, string> { ["NEW_VAR"] = "value" };
 
         await _handler.Handle(
-            new UpgradeViaHookCommand(TestStackName, "2.0.0", TestEnvironmentId, variables),
+            new UpgradeViaHookCommand(TestStackName, "2.0.0", TestEnvironmentId, Variables: variables),
             CancellationToken.None);
 
         _mediatorMock.Verify(m => m.Send(
@@ -268,7 +268,7 @@ public class UpgradeViaHookHandlerTests
             CancellationToken.None);
 
         result.Success.Should().BeFalse();
-        result.Message.Should().Contain("not found");
+        result.Message.Should().Contain("Invalid EnvironmentId format");
     }
 
     #endregion


### PR DESCRIPTION
## Summary

Refactors the environment resolution in hook endpoints to use **separate fields** instead of overloading `environmentId`:

### Before (v0.54)
```json
{"stackName": "my-stack", "environmentId": "Test"}
```
`environmentId` accepted both GUID and name — ambiguous.

### After
```json
{"stackName": "my-stack", "environmentName": "Test"}
{"stackName": "my-stack", "environmentId": "482afa5a-..."}
```
- `environmentId`: GUID only (strict validation, clear error if not a valid GUID)
- `environmentName`: case-insensitive name lookup
- Priority: `environmentId` > `environmentName` > API Key `env_id` claim

### Changes
- `EnvironmentResolver.Resolve()` now takes separate `environmentId` and `environmentName` parameters
- All 5 hook request records have new `EnvironmentName` field
- All 5 hook commands have new `EnvironmentName` parameter
- All 5 endpoints pass both fields