### PR TITLE
Ensure rsgo-net management network survives self-updates

### DIFF
--- a/src/ReadyStackGo.Api/BackgroundServices/HealthCollectorBackgroundService.cs
+++ b/src/ReadyStackGo.Api/BackgroundServices/HealthCollectorBackgroundService.cs
@@ -33,6 +33,9 @@ public class HealthCollectorBackgroundService : BackgroundService
         // Initial delay to let the application start up
         await Task.Delay(TimeSpan.FromSeconds(_options.InitialDelaySeconds), stoppingToken);
 
+        // Ensure this container is connected to the management network
+        await EnsureManagementNetworkAsync();
+
         while (!stoppingToken.IsCancellationRequested)
         {
             try
@@ -76,6 +79,81 @@ public class HealthCollectorBackgroundService : BackgroundService
         await healthCollector.CollectAllHealthAsync(stoppingToken);
 
         _logger.LogDebug("Health collection cycle completed");
+    }
+
+    /// <summary>
+    /// Ensures this container is connected to the rsgo-net management network.
+    /// Repairs the connection if it was lost (e.g., after a self-update that didn't preserve it).
+    /// </summary>
+    private async Task EnsureManagementNetworkAsync()
+    {
+        const string managementNetwork = "rsgo-net";
+
+        // Only relevant when running inside Docker
+        var hostname = Environment.GetEnvironmentVariable("HOSTNAME");
+        if (string.IsNullOrEmpty(hostname))
+        {
+            _logger.LogDebug("Not running in Docker, skipping management network check");
+            return;
+        }
+
+        try
+        {
+            using var scope = _serviceProvider.CreateScope();
+            var dockerService = scope.ServiceProvider.GetRequiredService<ISelfUpdateService>();
+
+            // ISelfUpdateService has access to the local Docker client
+            // Use it to check and connect our container to rsgo-net
+            var docker = GetLocalDockerClient();
+
+            // Check if rsgo-net exists
+            try
+            {
+                await docker.Networks.InspectNetworkAsync(managementNetwork);
+            }
+            catch (Docker.DotNet.DockerNetworkNotFoundException)
+            {
+                _logger.LogInformation("Creating management network {Network}", managementNetwork);
+                await docker.Networks.CreateNetworkAsync(new Docker.DotNet.Models.NetworksCreateParameters
+                {
+                    Name = managementNetwork,
+                    Driver = "bridge"
+                });
+            }
+
+            // Check if this container is already on the network
+            var inspection = await docker.Containers.InspectContainerAsync(hostname);
+            if (inspection.NetworkSettings?.Networks?.ContainsKey(managementNetwork) == true)
+            {
+                _logger.LogDebug("Container is already connected to {Network}", managementNetwork);
+                docker.Dispose();
+                return;
+            }
+
+            // Connect this container to rsgo-net
+            await docker.Networks.ConnectNetworkAsync(managementNetwork, new Docker.DotNet.Models.NetworkConnectParameters
+            {
+                Container = hostname
+            });
+
+            _logger.LogWarning(
+                "Container was not on {Network} — connected automatically. Health checks should now work correctly",
+                managementNetwork);
+
+            docker.Dispose();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to ensure management network connectivity. Health checks may not work for HTTP-checked services");
+        }
+    }
+
+    private static Docker.DotNet.DockerClient GetLocalDockerClient()
+    {
+        var socketUri = OperatingSystem.IsWindows()
+            ? new Uri("npipe://./pipe/docker_engine")
+            : new Uri("unix:///var/run/docker.sock");
+        return new Docker.DotNet.DockerClientConfiguration(socketUri).CreateClient();
     }
 
     private void CleanupOldSnapshots()

--- a/src/ReadyStackGo.Infrastructure.Docker/SelfUpdateService.cs
+++ b/src/ReadyStackGo.Infrastructure.Docker/SelfUpdateService.cs
@@ -18,6 +18,12 @@ public class SelfUpdateService : ISelfUpdateService, IDisposable
     private const string DefaultImage = "wiesenwischer/readystackgo";
     private const string HelperImage = "wiesenwischer/rsgo-updater";
     private const string HelperImageTag = "latest";
+
+    /// <summary>
+    /// Network shared between RSGO and all deployed containers.
+    /// Must match DeploymentEngine.ManagementNetwork.
+    /// </summary>
+    private const string ManagementNetwork = "rsgo-net";
     private const string UpdateContainerSuffix = "-update";
     private const int PullStallTimeoutSeconds = 180; // cancel if no pull progress for 3 minutes
 
@@ -351,29 +357,50 @@ public class SelfUpdateService : ISelfUpdateService, IDisposable
 
     /// <summary>
     /// Connects the new container to any additional networks beyond the primary one.
+    /// Always ensures the management network (rsgo-net) is included, even if the
+    /// old container had lost it — prevents a self-perpetuating network disconnect.
     /// </summary>
     private async Task ConnectAdditionalNetworks(
         ContainerInspectResponse inspection, string newContainerId)
     {
-        if (inspection.NetworkSettings?.Networks == null)
-            return;
-
         var primaryNetwork = inspection.HostConfig.NetworkMode ?? "bridge";
 
-        foreach (var (networkName, endpoint) in inspection.NetworkSettings.Networks)
-        {
-            if (networkName == primaryNetwork)
-                continue;
+        // Collect networks from old container + ensure management network
+        var networksToConnect = new Dictionary<string, EndpointSettings?>();
 
+        if (inspection.NetworkSettings?.Networks != null)
+        {
+            foreach (var (networkName, endpoint) in inspection.NetworkSettings.Networks)
+            {
+                if (networkName != primaryNetwork)
+                {
+                    networksToConnect[networkName] = endpoint;
+                }
+            }
+        }
+
+        // Always include the management network for health check DNS resolution
+        if (!networksToConnect.ContainsKey(ManagementNetwork) && primaryNetwork != ManagementNetwork)
+        {
+            networksToConnect[ManagementNetwork] = null;
+            _logger.LogInformation(
+                "Old container was not on {Network} — adding it to ensure health check connectivity",
+                ManagementNetwork);
+        }
+
+        // Ensure the management network exists
+        await EnsureNetworkExistsAsync(ManagementNetwork);
+
+        foreach (var (networkName, endpoint) in networksToConnect)
+        {
             try
             {
                 await _client.Networks.ConnectNetworkAsync(networkName, new NetworkConnectParameters
                 {
                     Container = newContainerId,
-                    EndpointConfig = new EndpointSettings
-                    {
-                        Aliases = endpoint.Aliases
-                    }
+                    EndpointConfig = endpoint != null
+                        ? new EndpointSettings { Aliases = endpoint.Aliases }
+                        : new EndpointSettings()
                 });
 
                 _logger.LogDebug("Connected update container to network {Network}", networkName);
@@ -382,6 +409,26 @@ public class SelfUpdateService : ISelfUpdateService, IDisposable
             {
                 _logger.LogWarning(ex, "Failed to connect update container to network {Network}", networkName);
             }
+        }
+    }
+
+    /// <summary>
+    /// Ensures a Docker network exists, creating it if necessary.
+    /// </summary>
+    private async Task EnsureNetworkExistsAsync(string networkName)
+    {
+        try
+        {
+            await _client.Networks.InspectNetworkAsync(networkName);
+        }
+        catch (DockerNetworkNotFoundException)
+        {
+            _logger.LogInformation("Creating Docker network {Network}", networkName);
+            await _client.Networks.CreateNetworkAsync(new NetworksCreateParameters
+            {
+                Name = networkName,
+                Driver = "bridge"
+            });
         }
     }
 


### PR DESCRIPTION
## Summary

Two-layer fix for the rsgo-net disconnect problem:

1. **SelfUpdateService**: Always connects new container to rsgo-net, even if old container lost it. Creates the network if needed.
2. **Startup check**: HealthCollectorBackgroundService auto-connects to rsgo-net on startup if missing. Repairs existing installations.

## AMS UI: not affected (backend-only)

Closes #330