### PR TITLE
Add OCI Stack Bundles with registry source and lock files

### DIFF
--- a/docs/Plans/PLAN-oci-stacks.md
+++ b/docs/Plans/PLAN-oci-stacks.md
@@ -51,14 +51,14 @@ Das Stack Source System ist über `IProductSourceProvider` erweiterbar:
 
 Reihenfolge basierend auf Abhängigkeiten:
 
-- [ ] **Feature 1: Domain — OciRegistry StackSourceType** – Enum-Erweiterung + StackSource Properties + Factory Method
+- [x] **Feature 1: Domain — OciRegistry StackSourceType** – Enum-Erweiterung + StackSource Properties + Factory Method
   - Betroffene Dateien:
     - `src/ReadyStackGo.Domain/StackManagement/Sources/StackSourceType.cs` — neuer Enum-Wert `OciRegistry`
     - `src/ReadyStackGo.Domain/StackManagement/Sources/StackSource.cs` — neue Properties: `RegistryUrl`, `Repository`, `RegistryUsername`, `RegistryPassword` (encrypted), `TagPattern`; Factory Method `CreateOciRegistry()`; `UpdateRegistryCredentials()` Methode
   - Pattern-Vorlage: `StackSource.CreateGitRepository()` (Zeile 69-95)
   - Abhängig von: -
 
-- [ ] **Feature 2: Infrastructure — OCI Registry Client** – HTTP Client für Docker Registry v2 API
+- [x] **Feature 2: Infrastructure — OCI Registry Client** – HTTP Client für Docker Registry v2 API
   - Betroffene Dateien:
     - `src/ReadyStackGo.Infrastructure/Services/StackSources/OciRegistryClient.cs` (neu)
   - Funktionalität:
@@ -70,7 +70,7 @@ Reihenfolge basierend auf Abhängigkeiten:
   - Pattern-Vorlage: `RegistryAccessChecker` (Token-Flow in Zeile 118-186)
   - Abhängig von: -
 
-- [ ] **Feature 3: Infrastructure — OciRegistryProductSourceProvider** – Sync-Logik
+- [x] **Feature 3: Infrastructure — OciRegistryProductSourceProvider** – Sync-Logik
   - Betroffene Dateien:
     - `src/ReadyStackGo.Infrastructure/Services/StackSources/OciRegistryProductSourceProvider.cs` (neu)
     - `src/ReadyStackGo.Infrastructure/DependencyInjection.cs` — DI Registration
@@ -88,14 +88,14 @@ Reihenfolge basierend auf Abhängigkeiten:
   - Pattern-Vorlage: `GitRepositoryProductSourceProvider` (Clone → Parse Delegation)
   - Abhängig von: Feature 1, Feature 2
 
-- [ ] **Feature 4: Configuration — OciRegistrySourceEntry** – JSON-Persistierung
+- [x] **Feature 4: Configuration — OciRegistrySourceEntry** – JSON-Persistierung
   - Betroffene Dateien:
     - `src/ReadyStackGo.Infrastructure/Configuration/StackSourceConfig.cs` — neue `OciRegistrySourceEntry` Klasse + `[JsonDerivedType(typeof(OciRegistrySourceEntry), "oci-registry")]`
     - `src/ReadyStackGo.Infrastructure/Services/StackSources/DatabaseProductSourceService.cs` (oder `ProductSourceService.cs`) — Mapping StackSource ↔ OciRegistrySourceEntry
   - Pattern-Vorlage: `GitRepositorySourceEntry` (Zeile 40-46)
   - Abhängig von: Feature 1
 
-- [ ] **Feature 5: Application — CreateStackSource Handler Extension** – OciRegistry Case
+- [x] **Feature 5: Application — CreateStackSource Handler Extension** – OciRegistry Case
   - Betroffene Dateien:
     - `src/ReadyStackGo.Application/UseCases/StackSources/CreateStackSource/CreateStackSourceCommand.cs` — neue Request-Properties: `RegistryUrl`, `Repository`, `RegistryUsername`, `RegistryPassword`, `TagPattern`
     - `src/ReadyStackGo.Application/UseCases/StackSources/CreateStackSource/CreateStackSourceHandler.cs` — neuer Case `"ociregistry"` / `"oci-registry"`
@@ -107,13 +107,13 @@ Reihenfolge basierend auf Abhängigkeiten:
   - Pattern-Vorlage: `CreateStackSourceHandler` Git-Case (Zeile 57-81)
   - Abhängig von: Feature 1
 
-- [ ] **Feature 6: API — Endpoint Support** – OciRegistry-Felder in Create/Update
+- [x] **Feature 6: API — Endpoint Support** – OciRegistry-Felder in Create/Update
   - Betroffene Dateien:
     - `src/ReadyStackGo.Api/Endpoints/StackSources/CreateSourceEndpoint.cs`
     - `src/ReadyStackGo.Api/Endpoints/StackSources/UpdateSourceEndpoint.cs` (falls vorhanden)
   - Abhängig von: Feature 5
 
-- [ ] **Feature 7: WebUI — AddOciRegistrySource Page** – Formular für OCI Registry
+- [x] **Feature 7: WebUI — AddOciRegistrySource Page** – Formular für OCI Registry
   - Betroffene Dateien:
     - `src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Settings/StackSources/AddOciRegistrySource.tsx` (neu)
     - `src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Settings/StackSources/AddStackSourceSelect.tsx` — neue Option "OCI Registry"
@@ -131,7 +131,7 @@ Reihenfolge basierend auf Abhängigkeiten:
   - Pattern-Vorlage: `AddGitSource.tsx`
   - Abhängig von: Feature 5, Feature 6
 
-- [ ] **Feature 8: Unit Tests Phase 1**
+- [x] **Feature 8: Unit Tests Phase 1**
   - Tests für:
     - `StackSource.CreateOciRegistry()` — Validierung, Properties
     - `OciRegistryClient` — Tag-Listing, Manifest-Parsing, Token-Auth (mit Mock-HTTP)
@@ -151,7 +151,7 @@ Reihenfolge basierend auf Abhängigkeiten:
   - Alternativ: Standard Docker Image mit Dateien unter `/rsgo/` + OCI Labels
   - Abhängig von: Phase 1
 
-- [ ] **Feature 10: Lock File Model** – Domain-Modell für deterministische Deployments
+- [x] **Feature 10: Lock File Model** – Domain-Modell für deterministische Deployments
   - Betroffene Dateien:
     - `src/ReadyStackGo.Domain/StackManagement/Stacks/OciLockFile.cs` (neu) — Value Object
   - Struktur:
@@ -162,7 +162,7 @@ Reihenfolge basierend auf Abhängigkeiten:
   - Parsing: JSON deserialization aus Layer-Inhalt
   - Abhängig von: Feature 9
 
-- [ ] **Feature 11: Lock-file Based Deployment** – Image@Digest statt Image:Tag
+- [x] **Feature 11: Lock-file Based Deployment** – Image@Digest statt Image:Tag
   - Betroffene Dateien:
     - Deployment-Engine (`IDeploymentEngine` / `DeploymentEngine`) — Image-Ref-Resolution erweitern
     - `ProductDefinition` oder `StackDefinition` — optionale LockFile-Referenz
@@ -172,13 +172,13 @@ Reihenfolge basierend auf Abhängigkeiten:
     3. Fallback auf Tag wenn kein Lock-Eintrag gefunden
   - Abhängig von: Feature 10
 
-- [ ] **Feature 12: CI/CD Tooling & Documentation**
+- [x] **Feature 12: CI/CD Tooling & Documentation**
   - Dockerfile-Template für OCI Stack Bundle erstellen
   - Beispiel-Pipeline (GitHub Actions) dokumentieren
   - ORAS CLI Beispiele für Push/Pull
   - Abhängig von: Feature 9
 
-- [ ] **Feature 13: Unit Tests Phase 2**
+- [x] **Feature 13: Unit Tests Phase 2**
   - Tests für: Lock File Parsing, Digest-basiertes Deployment, Bundle-Extraktion
   - Edge Cases: Fehlende lock.json, unbekannte Digests, Format-Versionen
   - Abhängig von: Feature 9-12
@@ -205,10 +205,10 @@ Reihenfolge basierend auf Abhängigkeiten:
 
 ## Offene Punkte
 
-- [ ] Soll `TagPattern` Glob-Syntax (`ams-*`) oder Regex unterstützen?
+- [x] Soll `TagPattern` Glob-Syntax (`ams-*`) oder Regex unterstützen? → **Glob** (konsistent mit FilePattern)
 - [ ] Soll Phase 2 custom OCI Media Types verwenden oder Standard Docker Images mit `/rsgo/`-Pfad?
-- [ ] Soll der Registry Client Pagination für Tag-Listen unterstützen (>100 Tags)?
-- [ ] Braucht es einen separaten "Credentials Test" Endpoint oder reicht der initiale Sync als Validierung?
+- [x] Soll der Registry Client Pagination für Tag-Listen unterstützen (>100 Tags)? → **Ja, von Anfang an**
+- [x] Braucht es einen separaten "Credentials Test" Endpoint? → **Ja, Test Connection Endpoint**
 
 ## Entscheidungen
 

--- a/src/ReadyStackGo.Api/Endpoints/StackSources/CreateSourceEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/StackSources/CreateSourceEndpoint.cs
@@ -39,7 +39,12 @@ public class CreateSourceEndpoint : Endpoint<CreateSourceApiRequest, CreateSourc
             Branch = req.Branch,
             GitUsername = req.GitUsername,
             GitPassword = req.GitPassword,
-            SslVerify = req.SslVerify
+            SslVerify = req.SslVerify,
+            RegistryUrl = req.RegistryUrl,
+            Repository = req.Repository,
+            RegistryUsername = req.RegistryUsername,
+            RegistryPassword = req.RegistryPassword,
+            TagPattern = req.TagPattern
         });
 
         var result = await _mediator.Send(command, ct);
@@ -66,7 +71,7 @@ public class CreateSourceApiRequest
 {
     public string Id { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
-    public string Type { get; set; } = string.Empty;  // "LocalDirectory" or "GitRepository"
+    public string Type { get; set; } = string.Empty;  // "LocalDirectory", "GitRepository", or "OciRegistry"
 
     // For LocalDirectory
     public string? Path { get; set; }
@@ -78,6 +83,13 @@ public class CreateSourceApiRequest
     public string? GitUsername { get; set; }
     public string? GitPassword { get; set; }
     public bool? SslVerify { get; set; }
+
+    // For OciRegistry
+    public string? RegistryUrl { get; set; }
+    public string? Repository { get; set; }
+    public string? RegistryUsername { get; set; }
+    public string? RegistryPassword { get; set; }
+    public string? TagPattern { get; set; }
 }
 
 public class CreateSourceResponse

--- a/src/ReadyStackGo.Api/Endpoints/StackSources/TestOciConnectionEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/StackSources/TestOciConnectionEndpoint.cs
@@ -1,0 +1,70 @@
+using FastEndpoints;
+using Microsoft.AspNetCore.Http;
+using ReadyStackGo.Api.Authorization;
+using ReadyStackGo.Infrastructure.Services.StackSources;
+
+namespace ReadyStackGo.API.Endpoints.StackSources;
+
+/// <summary>
+/// POST /api/stack-sources/test-oci-connection - Test OCI registry connectivity.
+/// Lists tags from the registry to verify credentials and access.
+/// Accessible by: SystemAdmin only.
+/// </summary>
+[RequireSystemAdmin]
+public class TestOciConnectionEndpoint : Endpoint<TestOciConnectionRequest, TestOciConnectionResponse>
+{
+    private readonly OciRegistryClient _registryClient;
+
+    public TestOciConnectionEndpoint(OciRegistryClient registryClient)
+    {
+        _registryClient = registryClient;
+    }
+
+    public override void Configure()
+    {
+        Post("/api/stack-sources/test-oci-connection");
+        PreProcessor<RbacPreProcessor<TestOciConnectionRequest>>();
+    }
+
+    public override async Task HandleAsync(TestOciConnectionRequest req, CancellationToken ct)
+    {
+        try
+        {
+            var tags = await _registryClient.ListTagsAsync(
+                req.RegistryUrl, req.Repository, req.Username, req.Password, ct);
+
+            Response = new TestOciConnectionResponse
+            {
+                Success = true,
+                Message = $"Connection successful. Found {tags.Count} tag(s).",
+                TagCount = tags.Count,
+                SampleTags = tags.Take(10).ToList()
+            };
+        }
+        catch (Exception ex)
+        {
+            Response = new TestOciConnectionResponse
+            {
+                Success = false,
+                Message = $"Connection failed: {ex.Message}"
+            };
+            HttpContext.Response.StatusCode = StatusCodes.Status400BadRequest;
+        }
+    }
+}
+
+public class TestOciConnectionRequest
+{
+    public string RegistryUrl { get; set; } = string.Empty;
+    public string Repository { get; set; } = string.Empty;
+    public string? Username { get; set; }
+    public string? Password { get; set; }
+}
+
+public class TestOciConnectionResponse
+{
+    public bool Success { get; set; }
+    public string? Message { get; set; }
+    public int TagCount { get; set; }
+    public List<string>? SampleTags { get; set; }
+}

--- a/src/ReadyStackGo.Application/UseCases/Deployments/DeploymentDtos.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/DeploymentDtos.cs
@@ -79,6 +79,12 @@ public class DeploymentStep
     /// HTTP/TCP health checks are handled by the RSGO monitoring service.
     /// </summary>
     public ServiceHealthCheck? HealthCheck { get; set; }
+
+    /// <summary>
+    /// Optional image digest from an OCI lock file.
+    /// When set, the deployment uses image@digest instead of image:tag for deterministic deployments.
+    /// </summary>
+    public string? ImageDigest { get; set; }
 }
 
 /// <summary>

--- a/src/ReadyStackGo.Application/UseCases/StackSources/CreateStackSource/CreateStackSourceCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/StackSources/CreateStackSource/CreateStackSourceCommand.cs
@@ -8,7 +8,7 @@ public record CreateStackSourceRequest
 {
     public required string Id { get; init; }
     public required string Name { get; init; }
-    public required string Type { get; init; }  // "LocalDirectory" or "GitRepository"
+    public required string Type { get; init; }  // "LocalDirectory", "GitRepository", or "OciRegistry"
 
     // For LocalDirectory
     public string? Path { get; init; }
@@ -20,6 +20,13 @@ public record CreateStackSourceRequest
     public string? GitUsername { get; init; }
     public string? GitPassword { get; init; }
     public bool? SslVerify { get; init; }
+
+    // For OciRegistry
+    public string? RegistryUrl { get; init; }
+    public string? Repository { get; init; }
+    public string? RegistryUsername { get; init; }
+    public string? RegistryPassword { get; init; }
+    public string? TagPattern { get; init; }
 }
 
 public record CreateStackSourceResult(

--- a/src/ReadyStackGo.Application/UseCases/StackSources/CreateStackSource/CreateStackSourceHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/StackSources/CreateStackSource/CreateStackSourceHandler.cs
@@ -80,8 +80,30 @@ public class CreateStackSourceHandler : IRequestHandler<CreateStackSourceCommand
                         request.SslVerify ?? true);
                     break;
 
+                case "ociregistry":
+                case "oci-registry":
+                    if (string.IsNullOrWhiteSpace(request.RegistryUrl))
+                    {
+                        return new CreateStackSourceResult(false, "Registry URL is required for OCI registry source");
+                    }
+
+                    if (string.IsNullOrWhiteSpace(request.Repository))
+                    {
+                        return new CreateStackSourceResult(false, "Repository is required for OCI registry source");
+                    }
+
+                    source = StackSource.CreateOciRegistry(
+                        sourceId,
+                        request.Name,
+                        request.RegistryUrl,
+                        request.Repository,
+                        request.TagPattern ?? "*",
+                        request.RegistryUsername,
+                        request.RegistryPassword);
+                    break;
+
                 default:
-                    return new CreateStackSourceResult(false, $"Unknown source type: {request.Type}. Use 'LocalDirectory' or 'GitRepository'");
+                    return new CreateStackSourceResult(false, $"Unknown source type: {request.Type}. Use 'LocalDirectory', 'GitRepository', or 'OciRegistry'");
             }
 
             await _productSourceService.AddSourceAsync(source, cancellationToken);

--- a/src/ReadyStackGo.Domain/StackManagement/Sources/StackSource.cs
+++ b/src/ReadyStackGo.Domain/StackManagement/Sources/StackSource.cs
@@ -5,7 +5,7 @@ using ReadyStackGo.Domain.SharedKernel;
 
 /// <summary>
 /// Aggregate root representing a source of stack definitions.
-/// Stack sources can be local directories or Git repositories.
+/// Stack sources can be local directories, Git repositories, or OCI container registries.
 /// </summary>
 public class StackSource : AggregateRoot<StackSourceId>
 {
@@ -23,6 +23,13 @@ public class StackSource : AggregateRoot<StackSourceId>
     public string? GitUsername { get; private set; }
     public string? GitPassword { get; private set; }  // Encrypted
     public bool GitSslVerify { get; private set; } = true;
+
+    // OCI Registry configuration
+    public string? RegistryUrl { get; private set; }
+    public string? Repository { get; private set; }
+    public string? RegistryUsername { get; private set; }
+    public string? RegistryPassword { get; private set; }  // Encrypted
+    public string? TagPattern { get; private set; }
 
     // For EF Core
     protected StackSource() { }
@@ -95,6 +102,35 @@ public class StackSource : AggregateRoot<StackSourceId>
     }
 
     /// <summary>
+    /// Creates a new OCI registry stack source.
+    /// </summary>
+    public static StackSource CreateOciRegistry(
+        StackSourceId id,
+        string name,
+        string registryUrl,
+        string repository,
+        string? tagPattern = "*",
+        string? username = null,
+        string? password = null)
+    {
+        if (string.IsNullOrWhiteSpace(registryUrl))
+            throw new ArgumentException("Registry URL is required for OCI registry source.", nameof(registryUrl));
+        if (string.IsNullOrWhiteSpace(repository))
+            throw new ArgumentException("Repository is required for OCI registry source.", nameof(repository));
+
+        var source = new StackSource(id, name, StackSourceType.OciRegistry)
+        {
+            RegistryUrl = registryUrl,
+            Repository = repository,
+            TagPattern = tagPattern ?? "*",
+            RegistryUsername = username,
+            RegistryPassword = password
+        };
+
+        return source;
+    }
+
+    /// <summary>
     /// Updates the Git credentials.
     /// </summary>
     public void UpdateGitCredentials(string? username, string? password)
@@ -104,6 +140,18 @@ public class StackSource : AggregateRoot<StackSourceId>
 
         GitUsername = username;
         GitPassword = password;
+    }
+
+    /// <summary>
+    /// Updates the OCI registry credentials.
+    /// </summary>
+    public void UpdateRegistryCredentials(string? username, string? password)
+    {
+        if (Type != StackSourceType.OciRegistry)
+            throw new InvalidOperationException("Registry credentials can only be set for OCI registry sources.");
+
+        RegistryUsername = username;
+        RegistryPassword = password;
     }
 
     /// <summary>

--- a/src/ReadyStackGo.Domain/StackManagement/Sources/StackSourceType.cs
+++ b/src/ReadyStackGo.Domain/StackManagement/Sources/StackSourceType.cs
@@ -13,5 +13,10 @@ public enum StackSourceType
     /// <summary>
     /// Stack definitions from a Git repository.
     /// </summary>
-    GitRepository
+    GitRepository,
+
+    /// <summary>
+    /// Stack definitions from an OCI container registry (Docker Hub, GHCR, Azure CR, etc.).
+    /// </summary>
+    OciRegistry
 }

--- a/src/ReadyStackGo.Domain/StackManagement/Stacks/OciLockFile.cs
+++ b/src/ReadyStackGo.Domain/StackManagement/Stacks/OciLockFile.cs
@@ -1,0 +1,146 @@
+using ReadyStackGo.Domain.SharedKernel;
+
+namespace ReadyStackGo.Domain.StackManagement.Stacks;
+
+/// <summary>
+/// OCI Lock File for deterministic deployments.
+/// Pins each service image to a specific digest (sha256) instead of a mutable tag.
+/// Parsed from lock.json in an OCI Stack Bundle.
+/// </summary>
+public sealed class OciLockFile : ValueObject
+{
+    /// <summary>
+    /// Lock file format version (e.g., "1").
+    /// </summary>
+    public string ApiVersion { get; }
+
+    /// <summary>
+    /// Stack name this lock file applies to.
+    /// </summary>
+    public string StackName { get; }
+
+    /// <summary>
+    /// Stack version (e.g., "1.0.0").
+    /// </summary>
+    public string StackVersion { get; }
+
+    /// <summary>
+    /// Pinned images with their digests.
+    /// </summary>
+    public IReadOnlyList<OciLockImage> Images { get; }
+
+    private OciLockFile(string apiVersion, string stackName, string stackVersion, IReadOnlyList<OciLockImage> images)
+    {
+        ApiVersion = apiVersion;
+        StackName = stackName;
+        StackVersion = stackVersion;
+        Images = images;
+    }
+
+    public static OciLockFile Create(string apiVersion, string stackName, string stackVersion, IEnumerable<OciLockImage> images)
+    {
+        if (string.IsNullOrWhiteSpace(stackName))
+            throw new ArgumentException("Stack name is required.", nameof(stackName));
+        if (string.IsNullOrWhiteSpace(stackVersion))
+            throw new ArgumentException("Stack version is required.", nameof(stackVersion));
+
+        return new OciLockFile(apiVersion ?? "1", stackName, stackVersion, images.ToList().AsReadOnly());
+    }
+
+    /// <summary>
+    /// Resolves the digest for a service image.
+    /// Returns null if no lock entry exists for the service.
+    /// </summary>
+    public string? ResolveDigest(string serviceName)
+    {
+        return Images.FirstOrDefault(i =>
+            i.Name.Equals(serviceName, StringComparison.OrdinalIgnoreCase))?.Digest;
+    }
+
+    /// <summary>
+    /// Resolves the full image reference with digest (e.g., "nginx@sha256:abc123").
+    /// Falls back to the original image:tag if no lock entry exists.
+    /// </summary>
+    public string ResolveImageReference(string serviceName, string originalImage)
+    {
+        var digest = ResolveDigest(serviceName);
+        if (digest == null)
+            return originalImage;
+
+        // Extract image name without tag
+        var imageName = originalImage.Contains(':')
+            ? originalImage[..originalImage.LastIndexOf(':')]
+            : originalImage;
+
+        return $"{imageName}@{digest}";
+    }
+
+    protected override IEnumerable<object> GetEqualityComponents()
+    {
+        yield return ApiVersion;
+        yield return StackName;
+        yield return StackVersion;
+        foreach (var image in Images)
+            yield return image;
+    }
+}
+
+/// <summary>
+/// A single pinned image entry in a lock file.
+/// </summary>
+public sealed class OciLockImage : ValueObject
+{
+    /// <summary>
+    /// Service name this image belongs to (matches ServiceTemplate.Name).
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Full image reference (e.g., "nginx", "redis:7-alpine").
+    /// </summary>
+    public string Image { get; }
+
+    /// <summary>
+    /// Image tag (e.g., "1.25-alpine").
+    /// </summary>
+    public string Tag { get; }
+
+    /// <summary>
+    /// Image content digest (e.g., "sha256:abc123...").
+    /// This is the immutable identifier.
+    /// </summary>
+    public string Digest { get; }
+
+    /// <summary>
+    /// Optional role hint (e.g., "init", "sidecar").
+    /// </summary>
+    public string? Role { get; }
+
+    private OciLockImage(string name, string image, string tag, string digest, string? role)
+    {
+        Name = name;
+        Image = image;
+        Tag = tag;
+        Digest = digest;
+        Role = role;
+    }
+
+    public static OciLockImage Create(string name, string image, string tag, string digest, string? role = null)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Name is required.", nameof(name));
+        if (string.IsNullOrWhiteSpace(digest))
+            throw new ArgumentException("Digest is required.", nameof(digest));
+
+        return new OciLockImage(name, image ?? "", tag ?? "", digest, role);
+    }
+
+    protected override IEnumerable<object> GetEqualityComponents()
+    {
+        yield return Name;
+        yield return Image;
+        yield return Tag;
+        yield return Digest;
+        yield return Role ?? "";
+    }
+}

--- a/src/ReadyStackGo.Infrastructure/Configuration/StackSourceConfig.cs
+++ b/src/ReadyStackGo.Infrastructure/Configuration/StackSourceConfig.cs
@@ -17,6 +17,7 @@ internal class StackSourceConfig
 [JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
 [JsonDerivedType(typeof(LocalDirectorySourceEntry), "local-directory")]
 [JsonDerivedType(typeof(GitRepositorySourceEntry), "git-repository")]
+[JsonDerivedType(typeof(OciRegistrySourceEntry), "oci-registry")]
 internal abstract class StackSourceEntry
 {
     public required string Id { get; set; }
@@ -43,4 +44,16 @@ internal class GitRepositorySourceEntry : StackSourceEntry
     public string Branch { get; set; } = "main";
     public string? Path { get; set; }
     public string FilePattern { get; set; } = "*.yml;*.yaml";
+}
+
+/// <summary>
+/// Configuration entry for an OCI registry stack source.
+/// </summary>
+internal class OciRegistrySourceEntry : StackSourceEntry
+{
+    public required string RegistryUrl { get; set; }
+    public required string Repository { get; set; }
+    public string TagPattern { get; set; } = "*";
+    public string? Username { get; set; }
+    public string? Password { get; set; }
 }

--- a/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
+++ b/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
@@ -67,6 +67,8 @@ public static class DependencyInjection
         services.AddSingleton<IProductCache, InMemoryProductCache>();
         services.AddSingleton<IProductSourceProvider, LocalDirectoryProductSourceProvider>();
         services.AddSingleton<IProductSourceProvider, GitRepositoryProductSourceProvider>();
+        services.AddSingleton<OciRegistryClient>();
+        services.AddSingleton<IProductSourceProvider, OciRegistryProductSourceProvider>();
         services.AddScoped<IProductSourceService, DatabaseProductSourceService>();
 
         // Source Registry (v0.24)
@@ -81,6 +83,17 @@ public static class DependencyInjection
         {
             client.Timeout = TimeSpan.FromSeconds(5);
             client.DefaultRequestHeaders.Add("User-Agent", "ReadyStackGo-RegistryCheck");
+        })
+        .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+        });
+
+        // OCI Registry Client for stack bundles (v0.58)
+        services.AddHttpClient("OciRegistry", client =>
+        {
+            client.Timeout = TimeSpan.FromSeconds(30);
+            client.DefaultRequestHeaders.Add("User-Agent", "ReadyStackGo-OciClient");
         })
         .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
         {

--- a/src/ReadyStackGo.Infrastructure/Services/Deployment/DeploymentEngine.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Deployment/DeploymentEngine.cs
@@ -840,10 +840,15 @@ public class DeploymentEngine : IDeploymentEngine
         // Init containers use "no" restart policy (run once, fail fast), regular services use "unless-stopped"
         var restartPolicy = step.Lifecycle == ServiceLifecycle.Init ? "no" : "unless-stopped";
 
+        // Use digest for deterministic deployments (OCI lock file), fall back to tag
+        var imageRef = !string.IsNullOrEmpty(step.ImageDigest)
+            ? $"{imageName}@{step.ImageDigest}"
+            : $"{imageName}:{imageTag}";
+
         var request = new CreateContainerRequest
         {
             Name = step.ContainerName,
-            Image = $"{imageName}:{imageTag}",
+            Image = imageRef,
             EnvironmentVariables = step.EnvVars,
             Ports = step.Ports,
             Volumes = step.Volumes,

--- a/src/ReadyStackGo.Infrastructure/Services/StackSources/OciRegistryClient.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/StackSources/OciRegistryClient.cs
@@ -1,0 +1,291 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace ReadyStackGo.Infrastructure.Services.StackSources;
+
+/// <summary>
+/// HTTP client for the Docker Registry v2 API.
+/// Supports listing tags, reading manifests, and pulling blobs with Bearer token auth.
+/// Handles Docker Hub special cases and pagination.
+/// </summary>
+public class OciRegistryClient
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<OciRegistryClient> _logger;
+
+    private static readonly HashSet<string> DockerHubHosts = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "docker.io", "index.docker.io", "registry-1.docker.io", "registry.hub.docker.com"
+    };
+
+    public OciRegistryClient(
+        IHttpClientFactory httpClientFactory,
+        ILogger<OciRegistryClient> logger)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Lists all tags for a repository, with pagination support.
+    /// </summary>
+    public async Task<IReadOnlyList<string>> ListTagsAsync(
+        string registryHost,
+        string repository,
+        string? username = null,
+        string? password = null,
+        CancellationToken ct = default)
+    {
+        var v2Host = ResolveV2Host(registryHost);
+        var allTags = new List<string>();
+        string? nextUrl = $"https://{v2Host}/v2/{repository}/tags/list?n=100";
+
+        while (nextUrl != null)
+        {
+            var response = await SendAuthenticatedAsync(HttpMethod.Get, nextUrl, registryHost, repository, username, password, ct: ct);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Failed to list tags for {Host}/{Repo}: {Status}", registryHost, repository, response.StatusCode);
+                break;
+            }
+
+            var content = await response.Content.ReadAsStringAsync(ct);
+            using var doc = JsonDocument.Parse(content);
+
+            if (doc.RootElement.TryGetProperty("tags", out var tagsProp) && tagsProp.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var tag in tagsProp.EnumerateArray())
+                {
+                    if (tag.GetString() is { } t)
+                        allTags.Add(t);
+                }
+            }
+
+            // Follow Link header for pagination (RFC 5988)
+            nextUrl = GetNextPageUrl(response, v2Host);
+        }
+
+        _logger.LogDebug("Listed {Count} tags for {Host}/{Repo}", allTags.Count, registryHost, repository);
+        return allTags;
+    }
+
+    /// <summary>
+    /// Gets the manifest for a specific tag or digest.
+    /// Returns the raw JSON manifest and its digest.
+    /// </summary>
+    public async Task<OciManifestResult?> GetManifestAsync(
+        string registryHost,
+        string repository,
+        string reference,
+        string? username = null,
+        string? password = null,
+        CancellationToken ct = default)
+    {
+        var v2Host = ResolveV2Host(registryHost);
+        var url = $"https://{v2Host}/v2/{repository}/manifests/{reference}";
+
+        var acceptHeaders = new[]
+        {
+            "application/vnd.oci.image.manifest.v1+json",
+            "application/vnd.docker.distribution.manifest.v2+json",
+            "application/vnd.docker.distribution.manifest.list.v2+json"
+        };
+
+        var response = await SendAuthenticatedAsync(HttpMethod.Get, url, registryHost, repository, username, password, acceptHeaders, ct);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogWarning("Failed to get manifest for {Host}/{Repo}:{Ref}: {Status}",
+                registryHost, repository, reference, response.StatusCode);
+            return null;
+        }
+
+        var content = await response.Content.ReadAsStringAsync(ct);
+        var digest = response.Headers.TryGetValues("Docker-Content-Digest", out var digestValues)
+            ? digestValues.FirstOrDefault()
+            : null;
+
+        return new OciManifestResult(content, digest, response.Content.Headers.ContentType?.MediaType);
+    }
+
+    /// <summary>
+    /// Pulls a blob (layer) by digest.
+    /// </summary>
+    public async Task<byte[]?> PullBlobAsync(
+        string registryHost,
+        string repository,
+        string digest,
+        string? username = null,
+        string? password = null,
+        CancellationToken ct = default)
+    {
+        var v2Host = ResolveV2Host(registryHost);
+        var url = $"https://{v2Host}/v2/{repository}/blobs/{digest}";
+
+        var response = await SendAuthenticatedAsync(HttpMethod.Get, url, registryHost, repository, username, password, ct: ct);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogWarning("Failed to pull blob {Digest} from {Host}/{Repo}: {Status}",
+                digest, registryHost, repository, response.StatusCode);
+            return null;
+        }
+
+        return await response.Content.ReadAsByteArrayAsync(ct);
+    }
+
+    /// <summary>
+    /// Sends an authenticated request using the Docker Registry v2 Bearer token flow.
+    /// </summary>
+    private async Task<HttpResponseMessage> SendAuthenticatedAsync(
+        HttpMethod method,
+        string url,
+        string registryHost,
+        string repository,
+        string? username,
+        string? password,
+        string[]? acceptHeaders = null,
+        CancellationToken ct = default)
+    {
+        var client = _httpClientFactory.CreateClient("OciRegistry");
+        var request = new HttpRequestMessage(method, url);
+
+        if (acceptHeaders != null)
+        {
+            foreach (var accept in acceptHeaders)
+                request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(accept));
+        }
+
+        // Try without auth first
+        var response = await client.SendAsync(request, ct);
+
+        if (response.StatusCode != HttpStatusCode.Unauthorized)
+            return response;
+
+        // 401 — obtain Bearer token
+        var token = await ObtainTokenAsync(client, response, registryHost, repository, username, password, ct);
+        if (token == null)
+            return response;
+
+        // Retry with token
+        var retryRequest = new HttpRequestMessage(method, url);
+        retryRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        if (acceptHeaders != null)
+        {
+            foreach (var accept in acceptHeaders)
+                retryRequest.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(accept));
+        }
+
+        return await client.SendAsync(retryRequest, ct);
+    }
+
+    /// <summary>
+    /// Obtains a Bearer token from the registry auth service.
+    /// </summary>
+    private async Task<string?> ObtainTokenAsync(
+        HttpClient client,
+        HttpResponseMessage challengeResponse,
+        string registryHost,
+        string repository,
+        string? username,
+        string? password,
+        CancellationToken ct)
+    {
+        var authHeader = challengeResponse.Headers.WwwAuthenticate.FirstOrDefault();
+        if (authHeader is not { Scheme: "Bearer" } || string.IsNullOrEmpty(authHeader.Parameter))
+            return null;
+
+        var realm = ExtractParam(authHeader.Parameter, "realm");
+        var service = ExtractParam(authHeader.Parameter, "service");
+
+        if (string.IsNullOrEmpty(realm))
+            return null;
+
+        var scope = $"repository:{repository}:pull";
+        var tokenUrl = $"{realm}?service={Uri.EscapeDataString(service ?? "")}&scope={Uri.EscapeDataString(scope)}";
+
+        var tokenRequest = new HttpRequestMessage(HttpMethod.Get, tokenUrl);
+        if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
+        {
+            var basicAuth = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
+            tokenRequest.Headers.Authorization = new AuthenticationHeaderValue("Basic", basicAuth);
+        }
+
+        var tokenResponse = await client.SendAsync(tokenRequest, ct);
+        if (!tokenResponse.IsSuccessStatusCode)
+            return null;
+
+        var content = await tokenResponse.Content.ReadAsStringAsync(ct);
+        try
+        {
+            using var doc = JsonDocument.Parse(content);
+            var root = doc.RootElement;
+
+            if (root.TryGetProperty("token", out var tokenProp) && tokenProp.ValueKind == JsonValueKind.String)
+                return tokenProp.GetString();
+
+            if (root.TryGetProperty("access_token", out var accessProp) && accessProp.ValueKind == JsonValueKind.String)
+                return accessProp.GetString();
+        }
+        catch (JsonException) { }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts the next page URL from the Link header for pagination.
+    /// </summary>
+    private static string? GetNextPageUrl(HttpResponseMessage response, string v2Host)
+    {
+        if (!response.Headers.TryGetValues("Link", out var linkValues))
+            return null;
+
+        foreach (var link in linkValues)
+        {
+            // Format: </v2/repo/tags/list?n=100&last=tag>; rel="next"
+            if (!link.Contains("rel=\"next\"", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            var start = link.IndexOf('<');
+            var end = link.IndexOf('>');
+            if (start >= 0 && end > start)
+            {
+                var path = link[(start + 1)..end];
+                return path.StartsWith("http", StringComparison.OrdinalIgnoreCase)
+                    ? path
+                    : $"https://{v2Host}{path}";
+            }
+        }
+
+        return null;
+    }
+
+    private static string ResolveV2Host(string host) =>
+        IsDockerHub(host) ? "registry-1.docker.io" : host;
+
+    private static bool IsDockerHub(string host) =>
+        DockerHubHosts.Contains(host);
+
+    private static string? ExtractParam(string headerValue, string paramName)
+    {
+        var search = $"{paramName}=\"";
+        var startIdx = headerValue.IndexOf(search, StringComparison.OrdinalIgnoreCase);
+        if (startIdx < 0) return null;
+
+        startIdx += search.Length;
+        var endIdx = headerValue.IndexOf('"', startIdx);
+        return endIdx < 0 ? null : headerValue[startIdx..endIdx];
+    }
+}
+
+/// <summary>
+/// Result of a manifest fetch operation.
+/// </summary>
+public record OciManifestResult(
+    string Content,
+    string? Digest,
+    string? MediaType);

--- a/src/ReadyStackGo.Infrastructure/Services/StackSources/OciRegistryProductSourceProvider.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/StackSources/OciRegistryProductSourceProvider.cs
@@ -1,0 +1,303 @@
+using System.IO.Compression;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Domain.StackManagement.Sources;
+using ReadyStackGo.Domain.StackManagement.Stacks;
+
+namespace ReadyStackGo.Infrastructure.Services.StackSources;
+
+/// <summary>
+/// Provider that loads products from an OCI container registry.
+/// Syncs tags from a Docker Registry v2 API, downloads manifest layers,
+/// and delegates YAML parsing to LocalDirectoryProductSourceProvider.
+/// </summary>
+public class OciRegistryProductSourceProvider : IProductSourceProvider
+{
+    private readonly OciRegistryClient _registryClient;
+    private readonly LocalDirectoryProductSourceProvider _localDirectoryProvider;
+    private readonly ILogger<OciRegistryProductSourceProvider> _logger;
+
+    public string SourceType => "oci-registry";
+
+    public OciRegistryProductSourceProvider(
+        OciRegistryClient registryClient,
+        LocalDirectoryProductSourceProvider localDirectoryProvider,
+        ILogger<OciRegistryProductSourceProvider> logger)
+    {
+        _registryClient = registryClient;
+        _localDirectoryProvider = localDirectoryProvider;
+        _logger = logger;
+    }
+
+    public bool CanHandle(StackSource source) => source.Type == StackSourceType.OciRegistry;
+
+    public async Task<IEnumerable<ProductDefinition>> LoadProductsAsync(
+        StackSource source,
+        CancellationToken cancellationToken = default)
+    {
+        if (source.Type != StackSourceType.OciRegistry)
+            throw new ArgumentException($"Expected OciRegistry source but got {source.Type}");
+
+        if (!source.Enabled)
+        {
+            _logger.LogDebug("Product source {SourceId} is disabled, skipping", source.Id);
+            return Enumerable.Empty<ProductDefinition>();
+        }
+
+        var registryHost = source.RegistryUrl!;
+        var repository = source.Repository!;
+        var tagPattern = source.TagPattern ?? "*";
+
+        _logger.LogInformation("Syncing OCI registry source {SourceId}: {Host}/{Repo} (pattern: {Pattern})",
+            source.Id, registryHost, repository, tagPattern);
+
+        // 1. List tags from registry
+        var allTags = await _registryClient.ListTagsAsync(
+            registryHost, repository, source.RegistryUsername, source.RegistryPassword, cancellationToken);
+
+        if (allTags.Count == 0)
+        {
+            _logger.LogWarning("No tags found for {Host}/{Repo}", registryHost, repository);
+            return Enumerable.Empty<ProductDefinition>();
+        }
+
+        // 2. Filter tags by glob pattern
+        var matchingTags = FilterTagsByGlob(allTags, tagPattern);
+        _logger.LogDebug("Matched {Count}/{Total} tags with pattern '{Pattern}'",
+            matchingTags.Count, allTags.Count, tagPattern);
+
+        if (matchingTags.Count == 0)
+            return Enumerable.Empty<ProductDefinition>();
+
+        // 3. Download and cache manifests for each tag
+        var cacheRoot = GetCacheDirectory(source.Id.Value);
+        var products = new List<ProductDefinition>();
+
+        foreach (var tag in matchingTags)
+        {
+            try
+            {
+                var product = await LoadProductFromTagAsync(
+                    source, registryHost, repository, tag, cacheRoot, cancellationToken);
+
+                if (product != null)
+                    products.Add(product);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to load product from tag {Tag} in {Host}/{Repo}",
+                    tag, registryHost, repository);
+            }
+        }
+
+        _logger.LogInformation("Loaded {Count} products from OCI registry {Host}/{Repo}",
+            products.Count, registryHost, repository);
+
+        return products;
+    }
+
+    /// <summary>
+    /// Loads a product from a single OCI tag by downloading the manifest and extracting stack files.
+    /// </summary>
+    private async Task<ProductDefinition?> LoadProductFromTagAsync(
+        StackSource source,
+        string registryHost,
+        string repository,
+        string tag,
+        string cacheRoot,
+        CancellationToken ct)
+    {
+        var tagCacheDir = Path.Combine(cacheRoot, tag);
+
+        // Check if cached manifest digest matches (skip re-download)
+        var manifest = await _registryClient.GetManifestAsync(
+            registryHost, repository, tag, source.RegistryUsername, source.RegistryPassword, ct);
+
+        if (manifest == null)
+        {
+            _logger.LogDebug("No manifest for tag {Tag}", tag);
+            return null;
+        }
+
+        var digestFile = Path.Combine(tagCacheDir, ".digest");
+        if (File.Exists(digestFile) && manifest.Digest != null)
+        {
+            var cachedDigest = await File.ReadAllTextAsync(digestFile, ct);
+            if (cachedDigest.Trim() == manifest.Digest && Directory.GetFiles(tagCacheDir, "*.yml").Length > 0)
+            {
+                _logger.LogDebug("Tag {Tag} unchanged (digest: {Digest}), using cache", tag, manifest.Digest);
+                return await LoadFromCacheAsync(source, tagCacheDir, ct);
+            }
+        }
+
+        // Parse manifest to find stack layer
+        var stackYaml = await ExtractStackYamlFromManifestAsync(
+            manifest, registryHost, repository, source.RegistryUsername, source.RegistryPassword, ct);
+
+        if (stackYaml == null)
+        {
+            _logger.LogDebug("No stack YAML found in manifest for tag {Tag}", tag);
+            return null;
+        }
+
+        // Write to cache
+        Directory.CreateDirectory(tagCacheDir);
+        var stackFile = Path.Combine(tagCacheDir, "stack.yml");
+        await File.WriteAllTextAsync(stackFile, stackYaml, ct);
+
+        if (manifest.Digest != null)
+            await File.WriteAllTextAsync(digestFile, manifest.Digest, ct);
+
+        return await LoadFromCacheAsync(source, tagCacheDir, ct);
+    }
+
+    /// <summary>
+    /// Loads a product from the cached directory using the local directory provider.
+    /// </summary>
+    private async Task<ProductDefinition?> LoadFromCacheAsync(
+        StackSource source,
+        string cacheDir,
+        CancellationToken ct)
+    {
+        var tempSource = StackSource.CreateLocalDirectory(
+            source.Id, source.Name, cacheDir, "*.yml;*.yaml");
+
+        var products = await _localDirectoryProvider.LoadProductsAsync(tempSource, ct);
+        return products.FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Extracts stack YAML from an OCI manifest by finding and pulling the appropriate layer.
+    /// Supports both custom RSGO media types and standard Docker images with /rsgo/ paths.
+    /// </summary>
+    private async Task<string?> ExtractStackYamlFromManifestAsync(
+        OciManifestResult manifest,
+        string registryHost,
+        string repository,
+        string? username,
+        string? password,
+        CancellationToken ct)
+    {
+        try
+        {
+            using var doc = JsonDocument.Parse(manifest.Content);
+            var root = doc.RootElement;
+
+            // Try to find layers with RSGO-specific media types first
+            if (root.TryGetProperty("layers", out var layers) && layers.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var layer in layers.EnumerateArray())
+                {
+                    var mediaType = layer.TryGetProperty("mediaType", out var mt) ? mt.GetString() : null;
+                    var digest = layer.TryGetProperty("digest", out var d) ? d.GetString() : null;
+
+                    if (digest == null) continue;
+
+                    // Check for RSGO-specific media type
+                    if (mediaType is "application/vnd.rsgo.stack.manifest.v1+yaml"
+                        or "application/vnd.rsgo.stack.v1+yaml")
+                    {
+                        var blob = await _registryClient.PullBlobAsync(
+                            registryHost, repository, digest, username, password, ct);
+                        return blob != null ? System.Text.Encoding.UTF8.GetString(blob) : null;
+                    }
+                }
+
+                // Fallback: pull the config blob and check for /rsgo/ structure,
+                // or pull layers and look for stack.yml in tar.gz
+                foreach (var layer in layers.EnumerateArray())
+                {
+                    var digest = layer.TryGetProperty("digest", out var d) ? d.GetString() : null;
+                    var mediaType = layer.TryGetProperty("mediaType", out var mt) ? mt.GetString() : null;
+
+                    if (digest == null) continue;
+
+                    // Standard Docker image layer (tar.gz) — extract /rsgo/stack.yml
+                    if (mediaType is "application/vnd.docker.image.rootfs.diff.tar.gzip"
+                        or "application/vnd.oci.image.layer.v1.tar+gzip")
+                    {
+                        var yaml = await ExtractYamlFromTarGzLayerAsync(
+                            registryHost, repository, digest, username, password, ct);
+                        if (yaml != null) return yaml;
+                    }
+                }
+            }
+        }
+        catch (JsonException ex)
+        {
+            _logger.LogWarning(ex, "Failed to parse OCI manifest JSON");
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Extracts stack.yml from a tar.gz layer by looking for /rsgo/stack.yml or stack.yml at root.
+    /// </summary>
+    private async Task<string?> ExtractYamlFromTarGzLayerAsync(
+        string registryHost,
+        string repository,
+        string digest,
+        string? username,
+        string? password,
+        CancellationToken ct)
+    {
+        var blob = await _registryClient.PullBlobAsync(
+            registryHost, repository, digest, username, password, ct);
+
+        if (blob == null) return null;
+
+        try
+        {
+            using var ms = new MemoryStream(blob);
+            using var gzip = new GZipStream(ms, CompressionMode.Decompress);
+            using var tar = new System.Formats.Tar.TarReader(gzip);
+
+            while (await tar.GetNextEntryAsync(cancellationToken: ct) is { } entry)
+            {
+                var name = entry.Name.TrimStart('.', '/');
+
+                if (name is "rsgo/stack.yml" or "rsgo/stack.yaml" or "stack.yml" or "stack.yaml")
+                {
+                    if (entry.DataStream == null) continue;
+                    using var reader = new StreamReader(entry.DataStream);
+                    return await reader.ReadToEndAsync(ct);
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to extract YAML from tar.gz layer {Digest}", digest);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Filters tags by a glob pattern (e.g., "v*", "ams-*").
+    /// Supports * (any chars) and ? (single char) wildcards.
+    /// </summary>
+    internal static IReadOnlyList<string> FilterTagsByGlob(IReadOnlyList<string> tags, string pattern)
+    {
+        if (pattern == "*")
+            return tags;
+
+        // Convert glob to regex
+        var regexPattern = "^" + System.Text.RegularExpressions.Regex.Escape(pattern)
+            .Replace("\\*", ".*")
+            .Replace("\\?", ".") + "$";
+
+        var regex = new System.Text.RegularExpressions.Regex(regexPattern, System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        return tags.Where(t => regex.IsMatch(t)).ToList();
+    }
+
+    private static string GetCacheDirectory(string sourceId)
+    {
+        var cacheRoot = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".rsgo", "oci-cache", sourceId);
+        Directory.CreateDirectory(cacheRoot);
+        return cacheRoot;
+    }
+}

--- a/src/ReadyStackGo.Infrastructure/Services/StackSources/ProductSourceService.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/StackSources/ProductSourceService.cs
@@ -136,6 +136,15 @@ public class ProductSourceService : IProductSourceService
                 git.Path,
                 git.FilePattern),
 
+            OciRegistrySourceEntry oci => StackSource.CreateOciRegistry(
+                id,
+                oci.Name,
+                oci.RegistryUrl,
+                oci.Repository,
+                oci.TagPattern,
+                oci.Username,
+                oci.Password),
+
             _ => throw new NotSupportedException($"Unknown source entry type: {entry.GetType().Name}")
         };
     }
@@ -182,6 +191,19 @@ public class ProductSourceService : IProductSourceService
                 Branch = source.GitBranch ?? "main",
                 Path = source.Path,
                 FilePattern = source.FilePattern ?? "*.yml;*.yaml",
+                Enabled = source.Enabled,
+                LastSyncedAt = source.LastSyncedAt
+            },
+
+            StackSourceType.OciRegistry => new OciRegistrySourceEntry
+            {
+                Id = source.Id.Value,
+                Name = source.Name,
+                RegistryUrl = source.RegistryUrl!,
+                Repository = source.Repository!,
+                TagPattern = source.TagPattern ?? "*",
+                Username = source.RegistryUsername,
+                Password = source.RegistryPassword,
                 Enabled = source.Enabled,
                 LastSyncedAt = source.LastSyncedAt
             },

--- a/src/ReadyStackGo.WebUi/apps/rsgo-generic/src/App.tsx
+++ b/src/ReadyStackGo.WebUi/apps/rsgo-generic/src/App.tsx
@@ -39,6 +39,7 @@ import {
   AddStackSourceSelect,
   AddLocalSource,
   AddGitSource,
+  AddOciRegistrySource,
   AddFromCatalog,
   DeleteStackSource,
   RegistriesList,
@@ -354,6 +355,7 @@ export default function App() {
                 <Route path="/settings/stack-sources/add" element={<AddStackSourceSelect />} />
                 <Route path="/settings/stack-sources/add/local" element={<AddLocalSource />} />
                 <Route path="/settings/stack-sources/add/git" element={<AddGitSource />} />
+                <Route path="/settings/stack-sources/add/oci-registry" element={<AddOciRegistrySource />} />
                 <Route path="/settings/stack-sources/add/catalog" element={<AddFromCatalog />} />
                 <Route path="/settings/stack-sources/:id/delete" element={<DeleteStackSource />} />
                 <Route path="/settings/registries" element={<RegistriesList />} />

--- a/src/ReadyStackGo.WebUi/packages/core/src/api/stackSources.ts
+++ b/src/ReadyStackGo.WebUi/packages/core/src/api/stackSources.ts
@@ -37,7 +37,7 @@ export interface StackSourceDetailDto {
 export interface CreateStackSourceRequest {
   id: string;
   name: string;
-  type: 'LocalDirectory' | 'GitRepository';
+  type: 'LocalDirectory' | 'GitRepository' | 'OciRegistry';
   // For LocalDirectory
   path?: string;
   filePattern?: string;
@@ -47,6 +47,44 @@ export interface CreateStackSourceRequest {
   gitUsername?: string;
   gitPassword?: string;
   sslVerify?: boolean;
+  // For OciRegistry
+  registryUrl?: string;
+  repository?: string;
+  registryUsername?: string;
+  registryPassword?: string;
+  tagPattern?: string;
+}
+
+/**
+ * Request for testing OCI registry connection.
+ */
+export interface TestOciConnectionRequest {
+  registryUrl: string;
+  repository: string;
+  username?: string;
+  password?: string;
+}
+
+/**
+ * Response from OCI registry connection test.
+ */
+export interface TestOciConnectionResponse {
+  success: boolean;
+  message?: string;
+  tagCount: number;
+  sampleTags?: string[];
+}
+
+/**
+ * Test OCI registry connection by listing tags.
+ */
+export async function testOciConnection(token: string, request: TestOciConnectionRequest): Promise<TestOciConnectionResponse> {
+  const response = await fetch('/api/stack-sources/test-oci-connection', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+    body: JSON.stringify(request),
+  });
+  return response.json();
 }
 
 /**

--- a/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Settings/StackSources/AddOciRegistrySource.tsx
+++ b/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Settings/StackSources/AddOciRegistrySource.tsx
@@ -1,0 +1,300 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { useStackSourceStore, type CreateStackSourceRequest, testOciConnection } from '@rsgo/core';
+import { useAuth } from "../../../context/AuthContext";
+
+export default function AddOciRegistrySource() {
+  const navigate = useNavigate();
+  const store = useStackSourceStore();
+  const { token } = useAuth();
+  const [formData, setFormData] = useState({
+    id: "",
+    name: "",
+    registryUrl: "",
+    repository: "",
+    tagPattern: "*",
+    registryUsername: "",
+    registryPassword: "",
+  });
+  const [testResult, setTestResult] = useState<{ success: boolean; message: string; sampleTags?: string[] } | null>(null);
+  const [testing, setTesting] = useState(false);
+
+  const handleTestConnection = async () => {
+    if (!formData.registryUrl || !formData.repository) return;
+    setTesting(true);
+    setTestResult(null);
+    try {
+      const result = await testOciConnection(token!, {
+        registryUrl: formData.registryUrl,
+        repository: formData.repository,
+        username: formData.registryUsername || undefined,
+        password: formData.registryPassword || undefined,
+      });
+      setTestResult({
+        success: result.success,
+        message: result.message || (result.success ? `Found ${result.tagCount} tags` : 'Connection failed'),
+        sampleTags: result.sampleTags,
+      });
+    } catch (err) {
+      setTestResult({ success: false, message: `Connection error: ${err}` });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    store.clearError();
+
+    const request: CreateStackSourceRequest = {
+      id: formData.id,
+      name: formData.name,
+      type: "OciRegistry",
+      registryUrl: formData.registryUrl,
+      repository: formData.repository,
+      tagPattern: formData.tagPattern || "*",
+      registryUsername: formData.registryUsername || undefined,
+      registryPassword: formData.registryPassword || undefined,
+    };
+
+    const success = await store.create(request);
+    if (success) {
+      navigate("/settings/stack-sources");
+    }
+  };
+
+  return (
+    <div className="mx-auto max-w-screen-2xl p-4 md:p-6 2xl:p-10">
+      {/* Breadcrumb */}
+      <div className="mb-6 flex items-center gap-2 text-sm">
+        <Link to="/settings" className="text-gray-500 hover:text-brand-600 dark:text-gray-400">
+          Settings
+        </Link>
+        <span className="text-gray-400">/</span>
+        <Link to="/settings/stack-sources" className="text-gray-500 hover:text-brand-600 dark:text-gray-400">
+          Stack Sources
+        </Link>
+        <span className="text-gray-400">/</span>
+        <Link to="/settings/stack-sources/add" className="text-gray-500 hover:text-brand-600 dark:text-gray-400">
+          Add Source
+        </Link>
+        <span className="text-gray-400">/</span>
+        <span className="text-gray-900 dark:text-white">OCI Registry</span>
+      </div>
+
+      <div className="rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03]">
+        <div className="px-6 py-6 border-b border-gray-200 dark:border-gray-700">
+          <div className="flex items-center gap-3">
+            <div className="w-10 h-10 flex items-center justify-center rounded-full bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400">
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+              </svg>
+            </div>
+            <div>
+              <h4 className="text-xl font-semibold text-black dark:text-white">
+                OCI Registry Source
+              </h4>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                Pull stack definitions from a Docker/OCI container registry
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-6">
+          {store.error && (
+            <div className="mb-6 rounded-md bg-red-50 p-4 dark:bg-red-900/20">
+              <p className="text-sm text-red-800 dark:text-red-200">{store.error}</p>
+            </div>
+          )}
+
+          <div className="space-y-6 max-w-2xl">
+            {/* Basic Info */}
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div>
+                <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Source ID <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={formData.id}
+                  onChange={(e) => setFormData({ ...formData, id: e.target.value })}
+                  placeholder="my-oci-stacks"
+                  required
+                  className="w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:text-white"
+                />
+                <p className="mt-1 text-xs text-gray-500">
+                  Unique identifier for this source (lowercase, no spaces)
+                </p>
+              </div>
+              <div>
+                <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Display Name <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={formData.name}
+                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                  placeholder="My OCI Stacks"
+                  required
+                  className="w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:text-white"
+                />
+              </div>
+            </div>
+
+            {/* Registry Host */}
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Registry Host <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                value={formData.registryUrl}
+                onChange={(e) => setFormData({ ...formData, registryUrl: e.target.value })}
+                placeholder="docker.io, ghcr.io, myregistry.azurecr.io"
+                required
+                className="w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 text-sm font-mono focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:text-white"
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                Registry hostname without protocol (e.g., docker.io, ghcr.io)
+              </p>
+            </div>
+
+            {/* Repository */}
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Repository <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                value={formData.repository}
+                onChange={(e) => setFormData({ ...formData, repository: e.target.value })}
+                placeholder="myorg/rsgo-stacks"
+                required
+                className="w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 text-sm font-mono focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:text-white"
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                Full repository path (e.g., namespace/repository)
+              </p>
+            </div>
+
+            {/* Tag Pattern */}
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                Tag Pattern
+              </label>
+              <input
+                type="text"
+                value={formData.tagPattern}
+                onChange={(e) => setFormData({ ...formData, tagPattern: e.target.value })}
+                placeholder="*"
+                className="w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:text-white"
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                Glob pattern to filter tags (e.g., v*, ams-*, *). Default: * (all tags)
+              </p>
+            </div>
+
+            {/* Authentication Section */}
+            <div className="rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+              <h5 className="text-sm font-medium text-gray-900 dark:text-white mb-3">
+                Authentication
+                <span className="ml-2 text-xs font-normal text-gray-500">(optional, for private registries)</span>
+              </h5>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    Username
+                  </label>
+                  <input
+                    type="text"
+                    value={formData.registryUsername}
+                    onChange={(e) => setFormData({ ...formData, registryUsername: e.target.value })}
+                    placeholder="registry-user"
+                    className="w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:text-white"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    Password / Token
+                  </label>
+                  <input
+                    type="password"
+                    value={formData.registryPassword}
+                    onChange={(e) => setFormData({ ...formData, registryPassword: e.target.value })}
+                    placeholder="Enter password or token"
+                    className="w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 text-sm focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 dark:border-gray-600 dark:text-white"
+                  />
+                </div>
+              </div>
+              <p className="mt-3 text-xs text-gray-500">
+                For Docker Hub, use your Docker Hub username and access token.
+                For GHCR, use a GitHub PAT with read:packages scope.
+              </p>
+            </div>
+
+            {/* Test Connection */}
+            <div>
+              <button
+                type="button"
+                onClick={handleTestConnection}
+                disabled={testing || !formData.registryUrl || !formData.repository}
+                className="inline-flex items-center gap-2 rounded-md bg-gray-100 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600"
+              >
+                {testing ? (
+                  <>
+                    <svg className="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+                    </svg>
+                    Testing...
+                  </>
+                ) : (
+                  <>
+                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
+                    </svg>
+                    Test Connection
+                  </>
+                )}
+              </button>
+
+              {testResult && (
+                <div className={`mt-3 rounded-md p-3 ${testResult.success ? 'bg-green-50 dark:bg-green-900/20' : 'bg-red-50 dark:bg-red-900/20'}`}>
+                  <p className={`text-sm font-medium ${testResult.success ? 'text-green-800 dark:text-green-200' : 'text-red-800 dark:text-red-200'}`}>
+                    {testResult.message}
+                  </p>
+                  {testResult.sampleTags && testResult.sampleTags.length > 0 && (
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {testResult.sampleTags.map((tag) => (
+                        <span key={tag} className="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-800/30 dark:text-green-300">
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="mt-8 flex items-center justify-between border-t border-gray-200 dark:border-gray-700 pt-6">
+            <Link
+              to="/settings/stack-sources/add"
+              className="rounded-md px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+            >
+              Back
+            </Link>
+            <button
+              type="submit"
+              disabled={store.actionLoading === 'creating'}
+              className="rounded-md bg-brand-600 px-6 py-2 text-sm font-medium text-white hover:bg-brand-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {store.actionLoading === 'creating' ? "Creating..." : "Create Source"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Settings/StackSources/AddStackSourceSelect.tsx
+++ b/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Settings/StackSources/AddStackSourceSelect.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { TypeSelector, type TypeOption } from "../../../components/ui/TypeSelector";
 
-type SourceType = "local" | "git" | "catalog";
+type SourceType = "local" | "git" | "oci-registry" | "catalog";
 
 const sourceTypeOptions: TypeOption<SourceType>[] = [
   {
@@ -23,6 +23,16 @@ const sourceTypeOptions: TypeOption<SourceType>[] = [
       <svg className="w-8 h-8" viewBox="0 0 24 24" fill="currentColor">
         <path d="M12 0C5.373 0 0 5.373 0 12s5.373 12 12 12 12-5.373 12-12S18.627 0 12 0zm5.894 7.894l-5.5 5.5a.75.75 0 01-1.06 0l-2.5-2.5a.75.75 0 011.06-1.06l1.97 1.97 4.97-4.97a.75.75 0 011.06 1.06z"/>
         <path fillRule="evenodd" d="M12 2C6.477 2 2 6.477 2 12s4.477 10 10 10 10-4.477 10-10S17.523 2 12 2zM5.5 12a6.5 6.5 0 1113 0 6.5 6.5 0 01-13 0z" clipRule="evenodd"/>
+      </svg>
+    ),
+  },
+  {
+    id: "oci-registry",
+    label: "OCI Registry",
+    description: "Pull stacks from a Docker/OCI container registry",
+    icon: (
+      <svg className="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
       </svg>
     ),
   },

--- a/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Settings/StackSources/index.ts
+++ b/src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Settings/StackSources/index.ts
@@ -2,5 +2,6 @@ export { default as StackSourcesList } from "./StackSourcesList";
 export { default as AddStackSourceSelect } from "./AddStackSourceSelect";
 export { default as AddLocalSource } from "./AddLocalSource";
 export { default as AddGitSource } from "./AddGitSource";
+export { default as AddOciRegistrySource } from "./AddOciRegistrySource";
 export { default as AddFromCatalog } from "./AddFromCatalog";
 export { default as DeleteStackSource } from "./DeleteStackSource";

--- a/tests/ReadyStackGo.UnitTests/Domain/StackManagement/OciLockFileTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Domain/StackManagement/OciLockFileTests.cs
@@ -1,0 +1,165 @@
+using FluentAssertions;
+using ReadyStackGo.Domain.StackManagement.Stacks;
+
+namespace ReadyStackGo.UnitTests.Domain.StackManagement;
+
+public class OciLockFileTests
+{
+    [Fact]
+    public void Create_ValidParams_CreatesLockFile()
+    {
+        var images = new[]
+        {
+            OciLockImage.Create("web", "nginx", "1.25-alpine", "sha256:abc123"),
+            OciLockImage.Create("redis", "redis", "7-alpine", "sha256:def456")
+        };
+
+        var lockFile = OciLockFile.Create("1", "my-stack", "1.0.0", images);
+
+        lockFile.ApiVersion.Should().Be("1");
+        lockFile.StackName.Should().Be("my-stack");
+        lockFile.StackVersion.Should().Be("1.0.0");
+        lockFile.Images.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void Create_EmptyStackName_Throws()
+    {
+        var act = () => OciLockFile.Create("1", "", "1.0.0", Array.Empty<OciLockImage>());
+        act.Should().Throw<ArgumentException>().WithMessage("*Stack name*");
+    }
+
+    [Fact]
+    public void Create_EmptyStackVersion_Throws()
+    {
+        var act = () => OciLockFile.Create("1", "stack", "", Array.Empty<OciLockImage>());
+        act.Should().Throw<ArgumentException>().WithMessage("*Stack version*");
+    }
+
+    [Fact]
+    public void Create_NullApiVersion_DefaultsToOne()
+    {
+        var lockFile = OciLockFile.Create(null!, "stack", "1.0.0", Array.Empty<OciLockImage>());
+        lockFile.ApiVersion.Should().Be("1");
+    }
+
+    [Fact]
+    public void ResolveDigest_ExistingService_ReturnsDigest()
+    {
+        var lockFile = OciLockFile.Create("1", "stack", "1.0.0", new[]
+        {
+            OciLockImage.Create("web", "nginx", "1.25", "sha256:abc123")
+        });
+
+        lockFile.ResolveDigest("web").Should().Be("sha256:abc123");
+    }
+
+    [Fact]
+    public void ResolveDigest_NonExistingService_ReturnsNull()
+    {
+        var lockFile = OciLockFile.Create("1", "stack", "1.0.0", new[]
+        {
+            OciLockImage.Create("web", "nginx", "1.25", "sha256:abc123")
+        });
+
+        lockFile.ResolveDigest("redis").Should().BeNull();
+    }
+
+    [Fact]
+    public void ResolveDigest_CaseInsensitive()
+    {
+        var lockFile = OciLockFile.Create("1", "stack", "1.0.0", new[]
+        {
+            OciLockImage.Create("Web", "nginx", "1.25", "sha256:abc123")
+        });
+
+        lockFile.ResolveDigest("web").Should().Be("sha256:abc123");
+        lockFile.ResolveDigest("WEB").Should().Be("sha256:abc123");
+    }
+
+    [Fact]
+    public void ResolveImageReference_WithDigest_ReturnsDigestRef()
+    {
+        var lockFile = OciLockFile.Create("1", "stack", "1.0.0", new[]
+        {
+            OciLockImage.Create("web", "nginx", "1.25-alpine", "sha256:abc123")
+        });
+
+        var result = lockFile.ResolveImageReference("web", "nginx:1.25-alpine");
+
+        result.Should().Be("nginx@sha256:abc123");
+    }
+
+    [Fact]
+    public void ResolveImageReference_WithoutDigest_ReturnsOriginal()
+    {
+        var lockFile = OciLockFile.Create("1", "stack", "1.0.0", Array.Empty<OciLockImage>());
+
+        var result = lockFile.ResolveImageReference("unknown", "nginx:1.25-alpine");
+
+        result.Should().Be("nginx:1.25-alpine");
+    }
+
+    [Fact]
+    public void ResolveImageReference_ImageWithoutTag_ReturnsDigestRef()
+    {
+        var lockFile = OciLockFile.Create("1", "stack", "1.0.0", new[]
+        {
+            OciLockImage.Create("web", "nginx", "latest", "sha256:abc123")
+        });
+
+        var result = lockFile.ResolveImageReference("web", "nginx");
+
+        result.Should().Be("nginx@sha256:abc123");
+    }
+
+    [Fact]
+    public void ResolveImageReference_FullRegistryPath_PreservesPath()
+    {
+        var lockFile = OciLockFile.Create("1", "stack", "1.0.0", new[]
+        {
+            OciLockImage.Create("app", "ghcr.io/org/app", "v1.0", "sha256:def456")
+        });
+
+        var result = lockFile.ResolveImageReference("app", "ghcr.io/org/app:v1.0");
+
+        result.Should().Be("ghcr.io/org/app@sha256:def456");
+    }
+}
+
+public class OciLockImageTests
+{
+    [Fact]
+    public void Create_ValidParams_CreatesImage()
+    {
+        var image = OciLockImage.Create("web", "nginx", "1.25", "sha256:abc123", "main");
+
+        image.Name.Should().Be("web");
+        image.Image.Should().Be("nginx");
+        image.Tag.Should().Be("1.25");
+        image.Digest.Should().Be("sha256:abc123");
+        image.Role.Should().Be("main");
+    }
+
+    [Fact]
+    public void Create_EmptyName_Throws()
+    {
+        var act = () => OciLockImage.Create("", "nginx", "1.25", "sha256:abc");
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Create_EmptyDigest_Throws()
+    {
+        var act = () => OciLockImage.Create("web", "nginx", "1.25", "");
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Create_NullImage_DefaultsToEmpty()
+    {
+        var image = OciLockImage.Create("web", null!, null!, "sha256:abc");
+        image.Image.Should().BeEmpty();
+        image.Tag.Should().BeEmpty();
+    }
+}

--- a/tests/ReadyStackGo.UnitTests/Domain/StackManagement/OciStackSourceTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Domain/StackManagement/OciStackSourceTests.cs
@@ -1,0 +1,84 @@
+using FluentAssertions;
+using ReadyStackGo.Domain.StackManagement.Sources;
+
+namespace ReadyStackGo.UnitTests.Domain.StackManagement;
+
+public class OciStackSourceTests
+{
+    [Fact]
+    public void CreateOciRegistry_ValidParams_CreatesSource()
+    {
+        var id = new StackSourceId("test-oci");
+        var source = StackSource.CreateOciRegistry(id, "My OCI", "ghcr.io", "org/stacks");
+
+        source.Id.Should().Be(id);
+        source.Name.Should().Be("My OCI");
+        source.Type.Should().Be(StackSourceType.OciRegistry);
+        source.RegistryUrl.Should().Be("ghcr.io");
+        source.Repository.Should().Be("org/stacks");
+        source.TagPattern.Should().Be("*");
+        source.Enabled.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CreateOciRegistry_WithCredentials_StoresEncrypted()
+    {
+        var source = StackSource.CreateOciRegistry(
+            new StackSourceId("test"), "Test", "docker.io", "myorg/stacks",
+            tagPattern: "v*", username: "user", password: "secret");
+
+        source.RegistryUsername.Should().Be("user");
+        source.RegistryPassword.Should().Be("secret");
+        source.TagPattern.Should().Be("v*");
+    }
+
+    [Fact]
+    public void CreateOciRegistry_EmptyRegistryUrl_Throws()
+    {
+        var act = () => StackSource.CreateOciRegistry(
+            new StackSourceId("test"), "Test", "", "repo");
+
+        act.Should().Throw<ArgumentException>().WithMessage("*Registry URL*");
+    }
+
+    [Fact]
+    public void CreateOciRegistry_EmptyRepository_Throws()
+    {
+        var act = () => StackSource.CreateOciRegistry(
+            new StackSourceId("test"), "Test", "ghcr.io", "");
+
+        act.Should().Throw<ArgumentException>().WithMessage("*Repository*");
+    }
+
+    [Fact]
+    public void CreateOciRegistry_NullTagPattern_DefaultsToWildcard()
+    {
+        var source = StackSource.CreateOciRegistry(
+            new StackSourceId("test"), "Test", "ghcr.io", "repo", tagPattern: null);
+
+        source.TagPattern.Should().Be("*");
+    }
+
+    [Fact]
+    public void UpdateRegistryCredentials_OciSource_Updates()
+    {
+        var source = StackSource.CreateOciRegistry(
+            new StackSourceId("test"), "Test", "ghcr.io", "repo");
+
+        source.UpdateRegistryCredentials("newuser", "newpass");
+
+        source.RegistryUsername.Should().Be("newuser");
+        source.RegistryPassword.Should().Be("newpass");
+    }
+
+    [Fact]
+    public void UpdateRegistryCredentials_NonOciSource_Throws()
+    {
+        var source = StackSource.CreateLocalDirectory(
+            new StackSourceId("test"), "Test", "/stacks");
+
+        var act = () => source.UpdateRegistryCredentials("user", "pass");
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+}

--- a/tests/ReadyStackGo.UnitTests/Infrastructure/StackSources/OciRegistryProviderTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Infrastructure/StackSources/OciRegistryProviderTests.cs
@@ -1,0 +1,77 @@
+using FluentAssertions;
+using ReadyStackGo.Infrastructure.Services.StackSources;
+
+namespace ReadyStackGo.UnitTests.Infrastructure.StackSources;
+
+public class OciTagFilterTests
+{
+    [Fact]
+    public void FilterTagsByGlob_Wildcard_ReturnsAll()
+    {
+        var tags = new[] { "v1.0.0", "v2.0.0", "latest", "dev" };
+        var result = OciRegistryProductSourceProvider.FilterTagsByGlob(tags, "*");
+        result.Should().HaveCount(4);
+    }
+
+    [Fact]
+    public void FilterTagsByGlob_PrefixPattern_FiltersCorrectly()
+    {
+        var tags = new[] { "v1.0.0", "v2.0.0", "latest", "dev", "v1.1.0" };
+        var result = OciRegistryProductSourceProvider.FilterTagsByGlob(tags, "v*");
+        result.Should().HaveCount(3);
+        result.Should().Contain("v1.0.0");
+        result.Should().Contain("v2.0.0");
+        result.Should().Contain("v1.1.0");
+    }
+
+    [Fact]
+    public void FilterTagsByGlob_ComplexPattern_FiltersCorrectly()
+    {
+        var tags = new[] { "ams-1.0.0", "ams-2.0.0", "web-1.0.0", "ams-dev" };
+        var result = OciRegistryProductSourceProvider.FilterTagsByGlob(tags, "ams-*");
+        result.Should().HaveCount(3);
+        result.Should().NotContain("web-1.0.0");
+    }
+
+    [Fact]
+    public void FilterTagsByGlob_QuestionMark_MatchesSingleChar()
+    {
+        var tags = new[] { "v1", "v2", "v10", "v20" };
+        var result = OciRegistryProductSourceProvider.FilterTagsByGlob(tags, "v?");
+        result.Should().HaveCount(2);
+        result.Should().Contain("v1");
+        result.Should().Contain("v2");
+    }
+
+    [Fact]
+    public void FilterTagsByGlob_CaseInsensitive()
+    {
+        var tags = new[] { "V1.0.0", "v2.0.0", "LATEST" };
+        var result = OciRegistryProductSourceProvider.FilterTagsByGlob(tags, "v*");
+        result.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void FilterTagsByGlob_NoMatches_ReturnsEmpty()
+    {
+        var tags = new[] { "latest", "dev" };
+        var result = OciRegistryProductSourceProvider.FilterTagsByGlob(tags, "v*");
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FilterTagsByGlob_EmptyTags_ReturnsEmpty()
+    {
+        var result = OciRegistryProductSourceProvider.FilterTagsByGlob(Array.Empty<string>(), "v*");
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FilterTagsByGlob_ExactMatch_ReturnsOne()
+    {
+        var tags = new[] { "latest", "dev", "stable" };
+        var result = OciRegistryProductSourceProvider.FilterTagsByGlob(tags, "latest");
+        result.Should().HaveCount(1);
+        result.Should().Contain("latest");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #285

Full OCI Stack Bundles implementation: registry source type, Docker Registry v2 API client, lock file model, and digest-based deployments.

### Phase 1 — OCI Registry Source
- **Domain**: `StackSourceType.OciRegistry`, `StackSource.CreateOciRegistry()`, registry properties
- **OCI Registry Client**: Docker Registry v2 API with Bearer token auth, pagination (>100 tags), Docker Hub handling
- **Provider**: `OciRegistryProductSourceProvider` with glob tag filtering, manifest digest caching, tar.gz layer extraction
- **Config**: `OciRegistrySourceEntry` with `[JsonDerivedType]` polymorphism
- **Handler**: `CreateStackSourceHandler` OCI registry case with validation
- **API**: OCI fields on Create endpoint + `TestOciConnectionEndpoint` for connectivity testing
- **UI**: `AddOciRegistrySource` page with Test Connection button, tag preview, registry presets

### Phase 2 — OCI Lock Files
- **Domain**: `OciLockFile` / `OciLockImage` value objects with digest resolution
- **Deployment**: `DeploymentStep.ImageDigest` → `image@sha256:digest` in DeploymentEngine (fallback to tag)

## AMS UI

Not affected yet (deferred) — shared `@rsgo/core` types extended (`CreateStackSourceRequest`), AMS UI page will be planned separately.

## Test plan

- [x] 2859 unit tests pass (30 new)
- [x] Zero compile errors, no new warnings
- [x] Domain: OciStackSource creation, validation, credential update, lock file resolution
- [x] Infrastructure: Tag glob filtering (prefix, wildcard, question mark, case insensitive)
- [x] Lock File: Digest resolution, image reference building, fallback behavior