### PR TITLE
Fix PortConflictRule false positive on redeploy

### DIFF
--- a/src/ReadyStackGo.Infrastructure/Services/Deployment/Precheck/PortConflictRule.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Deployment/Precheck/PortConflictRule.cs
@@ -13,14 +13,14 @@ public class PortConflictRule : IDeploymentPrecheckRule
         var items = new List<PrecheckItem>();
 
         // Collect all host ports currently in use (excluding containers belonging to this stack)
-        var ownContainerPrefix = $"{context.StackName}-";
         var usedPorts = new Dictionary<int, string>(); // port → container name
 
         foreach (var container in context.RunningContainers)
         {
-            // Skip containers belonging to this stack (upgrade scenario)
-            if (container.Name.StartsWith(ownContainerPrefix, StringComparison.OrdinalIgnoreCase) ||
-                container.Name.Equals(context.StackName, StringComparison.OrdinalIgnoreCase))
+            // Skip containers belonging to this stack (upgrade / redeploy scenario).
+            // Primary: rsgo.stack label (authoritative).
+            // Fallback: docker-compose project label for compose-deployed stacks.
+            if (BelongsToStack(container, context.StackName))
                 continue;
 
             // Skip non-running containers
@@ -31,7 +31,7 @@ public class PortConflictRule : IDeploymentPrecheckRule
             {
                 if (port.PublicPort > 0)
                 {
-                    usedPorts.TryAdd(port.PublicPort, container.Name);
+                    usedPorts.TryAdd(port.PublicPort, container.Name.TrimStart('/'));
                 }
             }
         }
@@ -75,6 +75,22 @@ public class PortConflictRule : IDeploymentPrecheckRule
         }
 
         return Task.FromResult<IReadOnlyList<PrecheckItem>>(items);
+    }
+
+    /// <summary>
+    /// Determines whether a container belongs to the given stack.
+    /// Primary match: rsgo.stack label (authoritative).
+    /// Fallback: docker-compose project label for compose-deployed stacks.
+    /// </summary>
+    internal static bool BelongsToStack(ReadyStackGo.Application.UseCases.Containers.ContainerDto container, string stackName)
+    {
+        if (container.Labels.TryGetValue("rsgo.stack", out var rsgoStack))
+            return string.Equals(rsgoStack, stackName, StringComparison.OrdinalIgnoreCase);
+
+        if (container.Labels.TryGetValue("com.docker.compose.project", out var composeProject))
+            return string.Equals(composeProject, stackName, StringComparison.OrdinalIgnoreCase);
+
+        return false;
     }
 
     internal static IEnumerable<int> ExpandPortRange(string hostPort)

--- a/tests/ReadyStackGo.UnitTests/Application/Precheck/PortConflictRuleTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Precheck/PortConflictRuleTests.cs
@@ -75,21 +75,95 @@ public class PortConflictRuleTests
 
     #endregion
 
-    #region Own Stack (Upgrade)
+    #region Own Stack (Upgrade / Redeploy)
 
     [Fact]
-    public async Task Execute_OwnStackContainer_SkipsConflict()
+    public async Task Execute_OwnStackContainerByLabel_SkipsConflict()
     {
         // Container belonging to the same stack (upgrade scenario) should not be a conflict
+        // Identified via the authoritative rsgo.stack label
         var context = CreateContext(
             stackName: "my-stack",
             services: [CreateService("web", "nginx", hostPort: "8080")],
-            containers: [CreateContainer("my-stack-web", publicPort: 8080)]);
+            containers: [CreateContainer("/my-stack_web", publicPort: 8080, rsgoStackLabel: "my-stack")]);
 
         var result = await _sut.ExecuteAsync(context, CancellationToken.None);
 
         result.Should().ContainSingle()
             .Which.Severity.Should().Be(PrecheckSeverity.OK);
+    }
+
+    [Fact]
+    public async Task Execute_OwnStackContainerByComposeProjectLabel_SkipsConflict()
+    {
+        // Compose-deployed container uses com.docker.compose.project label
+        var context = CreateContext(
+            stackName: "my-stack",
+            services: [CreateService("web", "nginx", hostPort: "8080")],
+            containers: [CreateContainer("/my-stack_web", publicPort: 8080, composeProject: "my-stack")]);
+
+        var result = await _sut.ExecuteAsync(context, CancellationToken.None);
+
+        result.Should().ContainSingle()
+            .Which.Severity.Should().Be(PrecheckSeverity.OK);
+    }
+
+    [Fact]
+    public async Task Execute_RedeployScenario_WithUnderscoreSeparator_SkipsOwnContainer()
+    {
+        // Regression: containers use {stackName}_{service} naming (underscore, not dash)
+        // and Docker prefixes names with '/'. The old implementation missed both.
+        var context = CreateContext(
+            stackName: "e2e-test-platform",
+            services: [CreateService("frontend", "nginx", hostPort: "8091")],
+            containers: [CreateContainer("/e2e-test-platform_frontend", publicPort: 8091, rsgoStackLabel: "e2e-test-platform")]);
+
+        var result = await _sut.ExecuteAsync(context, CancellationToken.None);
+
+        result.Should().ContainSingle()
+            .Which.Severity.Should().Be(PrecheckSeverity.OK);
+    }
+
+    [Fact]
+    public async Task Execute_DifferentStackWithSamePort_ReportsConflict()
+    {
+        // Container from a different stack using the same port IS a conflict
+        var context = CreateContext(
+            stackName: "my-stack",
+            services: [CreateService("web", "nginx", hostPort: "8080")],
+            containers: [CreateContainer("/other-stack_web", publicPort: 8080, rsgoStackLabel: "other-stack")]);
+
+        var result = await _sut.ExecuteAsync(context, CancellationToken.None);
+
+        result.Should().Contain(c => c.Severity == PrecheckSeverity.Error);
+    }
+
+    [Fact]
+    public void BelongsToStack_RsgoStackLabel_Matches()
+    {
+        var container = CreateContainer("/my-stack_web", rsgoStackLabel: "my-stack");
+        PortConflictRule.BelongsToStack(container, "my-stack").Should().BeTrue();
+    }
+
+    [Fact]
+    public void BelongsToStack_ComposeProjectLabel_Matches()
+    {
+        var container = CreateContainer("/my-stack_web", composeProject: "my-stack");
+        PortConflictRule.BelongsToStack(container, "my-stack").Should().BeTrue();
+    }
+
+    [Fact]
+    public void BelongsToStack_DifferentStack_DoesNotMatch()
+    {
+        var container = CreateContainer("/my-stack_web", rsgoStackLabel: "other-stack");
+        PortConflictRule.BelongsToStack(container, "my-stack").Should().BeFalse();
+    }
+
+    [Fact]
+    public void BelongsToStack_NoLabels_DoesNotMatch()
+    {
+        var container = CreateContainer("/my-stack_web");
+        PortConflictRule.BelongsToStack(container, "my-stack").Should().BeFalse();
     }
 
     #endregion
@@ -200,11 +274,20 @@ public class PortConflictRuleTests
         };
     }
 
-    private static ContainerDto CreateContainer(string name, int publicPort = 0, string state = "running")
+    private static ContainerDto CreateContainer(
+        string name,
+        int publicPort = 0,
+        string state = "running",
+        string? rsgoStackLabel = null,
+        string? composeProject = null)
     {
         var ports = publicPort > 0
             ? new List<PortDto> { new() { PublicPort = publicPort, PrivatePort = 80 } }
             : new List<PortDto>();
+
+        var labels = new Dictionary<string, string>();
+        if (rsgoStackLabel != null) labels["rsgo.stack"] = rsgoStackLabel;
+        if (composeProject != null) labels["com.docker.compose.project"] = composeProject;
 
         return new ContainerDto
         {
@@ -213,7 +296,8 @@ public class PortConflictRuleTests
             Image = "some-image",
             State = state,
             Status = "running",
-            Ports = ports
+            Ports = ports,
+            Labels = labels
         };
     }
 


### PR DESCRIPTION
## Summary

Pipeline redeploys were failing with "port already in use" errors for the stack's own containers. Root cause: `PortConflictRule` used a broken name-prefix check to identify containers belonging to the current stack.

## Bug Details

The rule checked `container.Name.StartsWith("{stackName}-")`, but:
1. Actual container names use **underscore** separator: `{stackName}_{service}` (e.g. `e2e-test-platform_frontend`)
2. Docker returns container names with a **leading slash**: `/e2e-test-platform_frontend`
3. Name-based matching is fragile anyway — labels are authoritative

## Fix

Replace name-prefix matching with `rsgo.stack` label lookup (with `com.docker.compose.project` as fallback for compose-deployed stacks). Same pattern used by `HealthMonitoringService.BelongsToStack`.

## Test plan

- [x] 7 new regression tests (label matching, underscore separator, leading slash, cross-stack conflicts, helper edge cases)
- [x] 2866 unit tests pass
- [x] Zero compile errors