### PR TITLE
Fix: wire maintenance observer config onto ProductDeployment

### DIFF
--- a/src/ReadyStackGo.Application/Services/MaintenanceObserverConfigMapper.cs
+++ b/src/ReadyStackGo.Application/Services/MaintenanceObserverConfigMapper.cs
@@ -1,0 +1,140 @@
+using ReadyStackGo.Domain.Deployment.Observers;
+using ReadyStackGo.Domain.StackManagement.Manifests;
+
+namespace ReadyStackGo.Application.Services;
+
+/// <summary>
+/// Maps a RsgoMaintenanceObserver (StackManagement domain) to a MaintenanceObserverConfig
+/// (Deployment domain), resolving ${VAR} placeholders against a variable dictionary.
+/// </summary>
+public static class MaintenanceObserverConfigMapper
+{
+    public static MaintenanceObserverConfig? Map(
+        RsgoMaintenanceObserver? source,
+        IReadOnlyDictionary<string, string> variables)
+    {
+        if (source == null)
+            return null;
+
+        if (!ObserverType.TryFromValue(source.Type, out var observerType) || observerType == null)
+            return null;
+
+        var pollingInterval = ParseTimeSpan(source.PollingInterval) ?? TimeSpan.FromSeconds(30);
+
+        IObserverSettings settings;
+
+        if (observerType == ObserverType.SqlExtendedProperty)
+        {
+            var connectionString = ResolveConnectionString(source, variables);
+            if (string.IsNullOrEmpty(connectionString))
+                return null;
+
+            settings = SqlObserverSettings.ForExtendedProperty(
+                source.PropertyName ?? throw new InvalidOperationException("PropertyName required"),
+                connectionString);
+        }
+        else if (observerType == ObserverType.SqlQuery)
+        {
+            var connectionString = ResolveConnectionString(source, variables);
+            if (string.IsNullOrEmpty(connectionString))
+                return null;
+
+            settings = SqlObserverSettings.ForQuery(
+                source.Query ?? throw new InvalidOperationException("Query required"),
+                connectionString);
+        }
+        else if (observerType == ObserverType.Http)
+        {
+            var timeout = ParseTimeSpan(source.Timeout) ?? TimeSpan.FromSeconds(10);
+            var url = ResolveVariables(
+                source.Url ?? throw new InvalidOperationException("URL required"), variables);
+            if (string.IsNullOrEmpty(url))
+                return null;
+
+            settings = HttpObserverSettings.Create(
+                url,
+                source.Method ?? "GET",
+                null,
+                timeout,
+                source.JsonPath);
+        }
+        else if (observerType == ObserverType.File)
+        {
+            var mode = source.Mode?.ToLowerInvariant() == "content"
+                ? FileCheckMode.Content
+                : FileCheckMode.Exists;
+
+            var path = ResolveVariables(
+                source.Path ?? throw new InvalidOperationException("Path required"), variables);
+            if (string.IsNullOrEmpty(path))
+                return null;
+
+            settings = mode == FileCheckMode.Content
+                ? FileObserverSettings.ForContent(path, source.ContentPattern)
+                : FileObserverSettings.ForExistence(path);
+        }
+        else
+        {
+            return null;
+        }
+
+        return MaintenanceObserverConfig.Create(
+            observerType,
+            pollingInterval,
+            source.MaintenanceValue,
+            source.NormalValue,
+            settings);
+    }
+
+    private static string? ResolveConnectionString(
+        RsgoMaintenanceObserver source,
+        IReadOnlyDictionary<string, string> variables)
+    {
+        if (!string.IsNullOrEmpty(source.ConnectionString))
+            return ResolveVariables(source.ConnectionString, variables);
+
+        if (!string.IsNullOrEmpty(source.ConnectionName) &&
+            variables.TryGetValue(source.ConnectionName, out var connectionString))
+        {
+            return connectionString;
+        }
+
+        return null;
+    }
+
+    private static string? ResolveVariables(string template, IReadOnlyDictionary<string, string> variables)
+    {
+        if (string.IsNullOrEmpty(template))
+            return template;
+
+        var result = template;
+        foreach (var kvp in variables)
+        {
+            result = result.Replace($"${{{kvp.Key}}}", kvp.Value);
+        }
+
+        if (result.Contains("${"))
+            return null;
+
+        return result;
+    }
+
+    private static TimeSpan? ParseTimeSpan(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return null;
+
+        value = value.Trim().ToLowerInvariant();
+
+        if (value.EndsWith('s') && int.TryParse(value[..^1], out var seconds))
+            return TimeSpan.FromSeconds(seconds);
+
+        if (value.EndsWith('m') && int.TryParse(value[..^1], out var minutes))
+            return TimeSpan.FromMinutes(minutes);
+
+        if (value.EndsWith('h') && int.TryParse(value[..^1], out var hours))
+            return TimeSpan.FromHours(hours);
+
+        return null;
+    }
+}

--- a/src/ReadyStackGo.Application/UseCases/Deployments/DeployProduct/DeployProductHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/DeployProduct/DeployProductHandler.cs
@@ -117,6 +117,24 @@ public class DeployProductHandler : IRequestHandler<DeployProductCommand, Deploy
             request.SharedVariables,
             request.ContinueOnError);
 
+        // Resolve and attach the product-level maintenance observer config.
+        // Without this the MaintenanceObserverService has no config to poll.
+        var observerConfig = MaintenanceObserverConfigMapper.Map(
+            product.MaintenanceObserver, request.SharedVariables);
+        if (observerConfig != null)
+        {
+            productDeployment.SetMaintenanceObserverConfig(observerConfig);
+            _logger.LogInformation(
+                "Product deployment {ProductDeploymentId} wired maintenance observer type={ObserverType}",
+                productDeploymentId, observerConfig.Type.Value);
+        }
+        else if (product.MaintenanceObserver != null)
+        {
+            _logger.LogWarning(
+                "Product {ProductName} defines maintenanceObserver but it could not be mapped (unresolved variables?) — observer disabled",
+                product.Name);
+        }
+
         _repository.Add(productDeployment);
         _repository.SaveChanges();
 

--- a/src/ReadyStackGo.Application/UseCases/Deployments/DeployStack/DeployStackHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/DeployStack/DeployStackHandler.cs
@@ -2,8 +2,6 @@ using MediatR;
 using Microsoft.Extensions.Logging;
 using ReadyStackGo.Application.Notifications;
 using ReadyStackGo.Application.Services;
-using ReadyStackGo.Domain.Deployment.Observers;
-using ReadyStackGo.Domain.StackManagement.Manifests;
 using ReadyStackGo.Domain.StackManagement.Stacks;
 using RuntimeConfig = ReadyStackGo.Domain.Deployment.RuntimeConfig;
 
@@ -52,9 +50,8 @@ public class DeployStackHandler : IRequestHandler<DeployStackCommand, DeployStac
             : null;
 
         // Map MaintenanceObserver from StackManagement to Deployment domain model
-        var observerConfig = product?.MaintenanceObserver != null
-            ? MapToDeploymentObserverConfig(product.MaintenanceObserver, request.Variables)
-            : null;
+        var observerConfig = MaintenanceObserverConfigMapper.Map(
+            product?.MaintenanceObserver, request.Variables);
 
         // Extract health check configurations from services
         var healthCheckConfigs = ExtractHealthCheckConfigs(stackDefinition.Services);
@@ -193,148 +190,6 @@ public class DeployStackHandler : IRequestHandler<DeployStackCommand, DeployStac
                 ? $"{parts[0]}:{parts[1]}"
                 : stackId;
         }
-        return null;
-    }
-
-    /// <summary>
-    /// Maps RsgoMaintenanceObserver (StackManagement domain) to MaintenanceObserverConfig (Deployment domain).
-    /// This is the boundary mapping between bounded contexts.
-    /// </summary>
-    private static MaintenanceObserverConfig? MapToDeploymentObserverConfig(
-        RsgoMaintenanceObserver source,
-        Dictionary<string, string> deploymentVariables)
-    {
-        // Parse observer type
-        if (!ObserverType.TryFromValue(source.Type, out var observerType) || observerType == null)
-        {
-            return null;
-        }
-
-        // Parse polling interval
-        var pollingInterval = ParseTimeSpan(source.PollingInterval) ?? TimeSpan.FromSeconds(30);
-
-        // Create type-specific settings
-        IObserverSettings settings;
-
-        if (observerType == ObserverType.SqlExtendedProperty)
-        {
-            var connectionString = ResolveConnectionString(source, deploymentVariables);
-            if (string.IsNullOrEmpty(connectionString))
-                return null;
-
-            settings = SqlObserverSettings.ForExtendedProperty(
-                source.PropertyName ?? throw new InvalidOperationException("PropertyName required"),
-                connectionString);
-        }
-        else if (observerType == ObserverType.SqlQuery)
-        {
-            var connectionString = ResolveConnectionString(source, deploymentVariables);
-            if (string.IsNullOrEmpty(connectionString))
-                return null;
-
-            settings = SqlObserverSettings.ForQuery(
-                source.Query ?? throw new InvalidOperationException("Query required"),
-                connectionString);
-        }
-        else if (observerType == ObserverType.Http)
-        {
-            var timeout = ParseTimeSpan(source.Timeout) ?? TimeSpan.FromSeconds(10);
-            settings = HttpObserverSettings.Create(
-                source.Url ?? throw new InvalidOperationException("URL required"),
-                source.Method ?? "GET",
-                null, // Headers not in RsgoMaintenanceObserver
-                timeout,
-                source.JsonPath);
-        }
-        else if (observerType == ObserverType.File)
-        {
-            var mode = source.Mode?.ToLowerInvariant() == "content"
-                ? FileCheckMode.Content
-                : FileCheckMode.Exists;
-
-            settings = mode == FileCheckMode.Content
-                ? FileObserverSettings.ForContent(
-                    source.Path ?? throw new InvalidOperationException("Path required"),
-                    source.ContentPattern)
-                : FileObserverSettings.ForExistence(
-                    source.Path ?? throw new InvalidOperationException("Path required"));
-        }
-        else
-        {
-            return null;
-        }
-
-        return MaintenanceObserverConfig.Create(
-            observerType,
-            pollingInterval,
-            source.MaintenanceValue,
-            source.NormalValue,
-            settings);
-    }
-
-    /// <summary>
-    /// Resolves connection string from direct value or variable reference.
-    /// </summary>
-    private static string? ResolveConnectionString(
-        RsgoMaintenanceObserver source,
-        Dictionary<string, string> variables)
-    {
-        // Direct connection string - resolve variables if present
-        if (!string.IsNullOrEmpty(source.ConnectionString))
-        {
-            return ResolveVariables(source.ConnectionString, variables);
-        }
-
-        // Connection name - look up in deployment variables
-        if (!string.IsNullOrEmpty(source.ConnectionName) &&
-            variables.TryGetValue(source.ConnectionName, out var connectionString))
-        {
-            return connectionString;
-        }
-
-        return null;
-    }
-
-    /// <summary>
-    /// Resolves ${VAR_NAME} placeholders in a template string.
-    /// </summary>
-    private static string? ResolveVariables(string template, Dictionary<string, string> variables)
-    {
-        if (string.IsNullOrEmpty(template))
-            return template;
-
-        var result = template;
-        foreach (var kvp in variables)
-        {
-            result = result.Replace($"${{{kvp.Key}}}", kvp.Value);
-        }
-
-        // Check if any unresolved placeholders remain
-        if (result.Contains("${"))
-            return null;
-
-        return result;
-    }
-
-    /// <summary>
-    /// Parses time span strings like "30s", "1m", "5m", "1h".
-    /// </summary>
-    private static TimeSpan? ParseTimeSpan(string? value)
-    {
-        if (string.IsNullOrEmpty(value))
-            return null;
-
-        value = value.Trim().ToLowerInvariant();
-
-        if (value.EndsWith('s') && int.TryParse(value[..^1], out var seconds))
-            return TimeSpan.FromSeconds(seconds);
-
-        if (value.EndsWith('m') && int.TryParse(value[..^1], out var minutes))
-            return TimeSpan.FromMinutes(minutes);
-
-        if (value.EndsWith('h') && int.TryParse(value[..^1], out var hours))
-            return TimeSpan.FromHours(hours);
-
         return null;
     }
 

--- a/src/ReadyStackGo.Application/UseCases/Deployments/RedeployProduct/RedeployProductHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/RedeployProduct/RedeployProductHandler.cs
@@ -16,6 +16,7 @@ namespace ReadyStackGo.Application.UseCases.Deployments.RedeployProduct;
 public class RedeployProductHandler : IRequestHandler<RedeployProductCommand, DeployProductResponse>
 {
     private readonly IProductDeploymentRepository _repository;
+    private readonly IProductSourceService _productSourceService;
     private readonly IMediator _mediator;
     private readonly IDeploymentService _deploymentService;
     private readonly IDeploymentNotificationService? _notificationService;
@@ -25,6 +26,7 @@ public class RedeployProductHandler : IRequestHandler<RedeployProductCommand, De
 
     public RedeployProductHandler(
         IProductDeploymentRepository repository,
+        IProductSourceService productSourceService,
         IMediator mediator,
         IDeploymentService deploymentService,
         ILogger<RedeployProductHandler> logger,
@@ -33,6 +35,7 @@ public class RedeployProductHandler : IRequestHandler<RedeployProductCommand, De
         TimeProvider? timeProvider = null)
     {
         _repository = repository;
+        _productSourceService = productSourceService;
         _mediator = mediator;
         _deploymentService = deploymentService;
         _logger = logger;
@@ -70,6 +73,34 @@ public class RedeployProductHandler : IRequestHandler<RedeployProductCommand, De
         catch (InvalidOperationException ex)
         {
             return DeployProductResponse.Failed(ex.Message);
+        }
+
+        // Re-resolve the product-level maintenance observer from the current catalog.
+        // This is how stack.yaml edits to maintenance.observer take effect on redeploy.
+        if (!string.IsNullOrEmpty(productDeployment.ProductId))
+        {
+            var product = await _productSourceService.GetProductAsync(
+                productDeployment.ProductId, cancellationToken);
+            if (product != null)
+            {
+                var observerVariables = BuildObserverVariables(productDeployment, request.VariableOverrides);
+                var observerConfig = MaintenanceObserverConfigMapper.Map(
+                    product.MaintenanceObserver, observerVariables);
+                productDeployment.SetMaintenanceObserverConfig(observerConfig);
+
+                if (observerConfig != null)
+                {
+                    _logger.LogInformation(
+                        "Redeploy {ProductDeploymentId} refreshed maintenance observer type={ObserverType}",
+                        productDeployment.Id, observerConfig.Type.Value);
+                }
+                else if (product.MaintenanceObserver != null)
+                {
+                    _logger.LogWarning(
+                        "Product {ProductName} defines maintenanceObserver but it could not be mapped on redeploy (unresolved variables?) — observer disabled",
+                        productDeployment.ProductName);
+                }
+            }
         }
 
         _repository.Update(productDeployment);
@@ -259,6 +290,25 @@ public class RedeployProductHandler : IRequestHandler<RedeployProductCommand, De
             SessionId = sessionId,
             StackResults = stackResults
         };
+    }
+
+    // Merge shared variables with redeploy overrides for observer placeholder resolution.
+    // Observer is product-level, so we only use shared values — not per-stack overrides.
+    private static Dictionary<string, string> BuildObserverVariables(
+        ProductDeployment productDeployment,
+        IReadOnlyDictionary<string, string>? overrides)
+    {
+        var merged = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var kvp in productDeployment.SharedVariables)
+            merged[kvp.Key] = kvp.Value;
+
+        if (overrides != null)
+        {
+            foreach (var kvp in overrides)
+                merged[kvp.Key] = kvp.Value;
+        }
+
+        return merged;
     }
 
     private static void FinalizeProductStatus(ProductDeployment productDeployment)

--- a/tests/ReadyStackGo.UnitTests/Application/Deployments/DeployProductHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Deployments/DeployProductHandlerTests.cs
@@ -864,4 +864,111 @@ public class DeployProductHandlerTests
     }
 
     #endregion
+
+    #region Maintenance Observer Wiring
+
+    [Fact]
+    public async Task Handle_ProductHasResolvableObserver_SetsConfigOnProductDeployment()
+    {
+        var product = CreateProductWithObserver(
+            new global::ReadyStackGo.Domain.StackManagement.Manifests.RsgoMaintenanceObserver
+            {
+                Type = "sqlExtendedProperty",
+                PropertyName = "ams-MaintenanceMode",
+                ConnectionString = "Server=${DB_SERVER};Database=${DB_NAME};",
+                MaintenanceValue = "1",
+                NormalValue = "0",
+                PollingInterval = "30s"
+            });
+
+        SetupProductFound(product);
+        SetupNoExistingDeployment();
+        SetupAllStacksSucceed();
+
+        ProductDeployment? captured = null;
+        _repositoryMock
+            .Setup(r => r.Add(It.IsAny<ProductDeployment>()))
+            .Callback<ProductDeployment>(pd => captured = pd);
+
+        var cmd = CreateCommand(product, new Dictionary<string, string>
+        {
+            ["DB_SERVER"] = "sqldev2017",
+            ["DB_NAME"] = "dev-amsproject"
+        });
+
+        await _handler.Handle(cmd, CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.MaintenanceObserverConfig.Should().NotBeNull(
+            "the product-level observer must be wired onto the ProductDeployment or MaintenanceObserverService has nothing to poll");
+        captured.MaintenanceObserverConfig!.Type.Value.Should().Be("sqlExtendedProperty");
+        captured.MaintenanceObserverConfig.MaintenanceValue.Should().Be("1");
+    }
+
+    [Fact]
+    public async Task Handle_ObserverConnectionStringUnresolvable_LeavesConfigNull()
+    {
+        var product = CreateProductWithObserver(
+            new global::ReadyStackGo.Domain.StackManagement.Manifests.RsgoMaintenanceObserver
+            {
+                Type = "sqlExtendedProperty",
+                PropertyName = "ams-MaintenanceMode",
+                ConnectionString = "Server=${DB_SERVER};Database=${DB_NAME};",
+                MaintenanceValue = "1"
+            });
+
+        SetupProductFound(product);
+        SetupNoExistingDeployment();
+        SetupAllStacksSucceed();
+
+        ProductDeployment? captured = null;
+        _repositoryMock
+            .Setup(r => r.Add(It.IsAny<ProductDeployment>()))
+            .Callback<ProductDeployment>(pd => captured = pd);
+
+        // DB_NAME intentionally missing — mapper must refuse to produce a config.
+        var cmd = CreateCommand(product, new Dictionary<string, string>
+        {
+            ["DB_SERVER"] = "sqldev2017"
+        });
+
+        await _handler.Handle(cmd, CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.MaintenanceObserverConfig.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ProductHasNoObserver_LeavesConfigNull()
+    {
+        var product = CreateTestProduct(1);
+        SetupProductFound(product);
+        SetupNoExistingDeployment();
+        SetupAllStacksSucceed();
+
+        ProductDeployment? captured = null;
+        _repositoryMock
+            .Setup(r => r.Add(It.IsAny<ProductDeployment>()))
+            .Callback<ProductDeployment>(pd => captured = pd);
+
+        await _handler.Handle(CreateCommand(product), CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.MaintenanceObserverConfig.Should().BeNull();
+    }
+
+    private static ProductDefinition CreateProductWithObserver(
+        global::ReadyStackGo.Domain.StackManagement.Manifests.RsgoMaintenanceObserver observer)
+    {
+        var baseProduct = CreateTestProduct(1);
+        return new ProductDefinition(
+            sourceId: "stacks",
+            name: baseProduct.Name,
+            displayName: baseProduct.DisplayName,
+            stacks: baseProduct.Stacks,
+            productVersion: baseProduct.ProductVersion,
+            maintenanceObserver: observer);
+    }
+
+    #endregion
 }

--- a/tests/ReadyStackGo.UnitTests/Application/Deployments/RedeployProductHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Deployments/RedeployProductHandlerTests.cs
@@ -17,6 +17,7 @@ namespace ReadyStackGo.UnitTests.Application.Deployments;
 public class RedeployProductHandlerTests
 {
     private readonly Mock<IProductDeploymentRepository> _repositoryMock;
+    private readonly Mock<IProductSourceService> _productSourceServiceMock;
     private readonly Mock<IMediator> _mediatorMock;
     private readonly Mock<IDeploymentService> _deploymentServiceMock;
     private readonly Mock<ILogger<RedeployProductHandler>> _loggerMock;
@@ -28,6 +29,7 @@ public class RedeployProductHandlerTests
     public RedeployProductHandlerTests()
     {
         _repositoryMock = new Mock<IProductDeploymentRepository>();
+        _productSourceServiceMock = new Mock<IProductSourceService>();
         _mediatorMock = new Mock<IMediator>();
         _deploymentServiceMock = new Mock<IDeploymentService>();
         _loggerMock = new Mock<ILogger<RedeployProductHandler>>();
@@ -45,6 +47,7 @@ public class RedeployProductHandlerTests
 
         _handler = new RedeployProductHandler(
             _repositoryMock.Object,
+            _productSourceServiceMock.Object,
             _mediatorMock.Object,
             _deploymentServiceMock.Object,
             _loggerMock.Object,
@@ -340,6 +343,135 @@ public class RedeployProductHandlerTests
         var result = await _handler.Handle(command, CancellationToken.None);
 
         result.SessionId.Should().StartWith("product-redeploy-");
+    }
+
+    #endregion
+
+    #region Maintenance Observer Refresh
+
+    [Fact]
+    public async Task Handle_ReResolvesMaintenanceObserverFromCatalog()
+    {
+        var pd = CreateRunningDeploymentWithSharedVars(new Dictionary<string, string>
+        {
+            ["DB_SERVER"] = "sqldev2017",
+            ["DB_NAME"] = "dev-amsproject"
+        });
+        SetupDeploymentFound(pd);
+
+        _productSourceServiceMock
+            .Setup(s => s.GetProductAsync(pd.ProductId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateCatalogProductWithObserver(pd.ProductId));
+
+        var command = CreateCommand(pd.Id.Value.ToString());
+        await _handler.Handle(command, CancellationToken.None);
+
+        pd.MaintenanceObserverConfig.Should().NotBeNull(
+            "redeploy must re-read maintenance observer from the catalog so stack.yaml edits take effect");
+        pd.MaintenanceObserverConfig!.Type.Value.Should().Be("sqlExtendedProperty");
+    }
+
+    [Fact]
+    public async Task Handle_ObserverRemovedFromCatalog_ClearsConfig()
+    {
+        var pd = CreateRunningDeploymentWithSharedVars(new Dictionary<string, string>());
+        // Pre-seed an existing observer — simulating the old catalog state.
+        pd.SetMaintenanceObserverConfig(global::ReadyStackGo.Domain.Deployment.Observers.MaintenanceObserverConfig.Create(
+            global::ReadyStackGo.Domain.Deployment.Observers.ObserverType.File,
+            TimeSpan.FromSeconds(30),
+            "1",
+            "0",
+            global::ReadyStackGo.Domain.Deployment.Observers.FileObserverSettings.ForExistence("/tmp/x")));
+        SetupDeploymentFound(pd);
+
+        // Catalog returns product without observer.
+        _productSourceServiceMock
+            .Setup(s => s.GetProductAsync(pd.ProductId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateCatalogProductWithoutObserver(pd.ProductId));
+
+        var command = CreateCommand(pd.Id.Value.ToString());
+        await _handler.Handle(command, CancellationToken.None);
+
+        pd.MaintenanceObserverConfig.Should().BeNull(
+            "observer removed from the catalog must also be removed from the ProductDeployment");
+    }
+
+    private static ProductDeployment CreateRunningDeploymentWithSharedVars(Dictionary<string, string> sharedVars)
+    {
+        var pd = ProductDeployment.InitiateDeployment(
+            ProductDeploymentId.NewId(), EnvironmentId.NewId(),
+            "stacks:testproduct", "stacks:testproduct:1.0.0",
+            "testproduct", "Test Product", "1.0.0",
+            UserId.NewId(), "test-deploy",
+            CreateStackConfigs(1),
+            sharedVars);
+
+        pd.StartStack("stack-0", DeploymentId.NewId());
+        pd.CompleteStack("stack-0");
+        return pd;
+    }
+
+    private static global::ReadyStackGo.Domain.StackManagement.Stacks.ProductDefinition CreateCatalogProductWithObserver(string productId)
+    {
+        var stack = new global::ReadyStackGo.Domain.StackManagement.Stacks.StackDefinition(
+            "stacks",
+            "stack-0",
+            new global::ReadyStackGo.Domain.StackManagement.Stacks.ProductId(productId),
+            services: new[]
+            {
+                new global::ReadyStackGo.Domain.StackManagement.Stacks.ServiceTemplate
+                {
+                    Name = "svc", Image = "test:latest"
+                }
+            },
+            variables: Array.Empty<global::ReadyStackGo.Domain.StackManagement.Stacks.Variable>(),
+            productName: "testproduct",
+            productDisplayName: "Test Product",
+            productVersion: "1.0.0");
+
+        return new global::ReadyStackGo.Domain.StackManagement.Stacks.ProductDefinition(
+            sourceId: "stacks",
+            name: "testproduct",
+            displayName: "Test Product",
+            stacks: new[] { stack },
+            productVersion: "1.0.0",
+            maintenanceObserver: new global::ReadyStackGo.Domain.StackManagement.Manifests.RsgoMaintenanceObserver
+            {
+                Type = "sqlExtendedProperty",
+                PropertyName = "ams-MaintenanceMode",
+                ConnectionString = "Server=${DB_SERVER};Database=${DB_NAME};",
+                MaintenanceValue = "1",
+                NormalValue = "0",
+                PollingInterval = "30s"
+            },
+            productId: productId);
+    }
+
+    private static global::ReadyStackGo.Domain.StackManagement.Stacks.ProductDefinition CreateCatalogProductWithoutObserver(string productId)
+    {
+        var stack = new global::ReadyStackGo.Domain.StackManagement.Stacks.StackDefinition(
+            "stacks",
+            "stack-0",
+            new global::ReadyStackGo.Domain.StackManagement.Stacks.ProductId(productId),
+            services: new[]
+            {
+                new global::ReadyStackGo.Domain.StackManagement.Stacks.ServiceTemplate
+                {
+                    Name = "svc", Image = "test:latest"
+                }
+            },
+            variables: Array.Empty<global::ReadyStackGo.Domain.StackManagement.Stacks.Variable>(),
+            productName: "testproduct",
+            productDisplayName: "Test Product",
+            productVersion: "1.0.0");
+
+        return new global::ReadyStackGo.Domain.StackManagement.Stacks.ProductDefinition(
+            sourceId: "stacks",
+            name: "testproduct",
+            displayName: "Test Product",
+            stacks: new[] { stack },
+            productVersion: "1.0.0",
+            productId: productId);
     }
 
     #endregion


### PR DESCRIPTION
## Summary

- `MaintenanceObserverService` reads `productDeployment.MaintenanceObserverConfig`, but `ProductDeployment.SetMaintenanceObserverConfig` had zero production callers. `DeployStackHandler` mapped the config correctly but only wrote it to the stack-level `Deployment` entity, which nothing reads.
- Result: no observer was ever instantiated for any product. `maintenance.observer` blocks in `stack.yaml` were silently ignored regardless of content, so `ChangeProductOperationMode` via observer never fired.
- Extract `MaintenanceObserverConfigMapper` as a shared helper in `Application.Services`, wire it from `DeployProductHandler` (initial deploy) and `RedeployProductHandler` (refresh from catalog so `stack.yaml` edits take effect on redeploy).

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test` — 2877/2877 passing
- [x] New tests: `DeployProductHandler` sets observer config on the ProductDeployment when resolvable; leaves it null when placeholders cannot be resolved; leaves it null when no observer defined
- [x] New tests: `RedeployProductHandler` re-reads observer config from catalog on redeploy; clears config when observer removed from catalog
- [ ] Manual: deploy ams.project with `sqlExtendedProperty` observer, flip the extended property, confirm the product transitions into maintenance within the polling interval