### PR TITLE
Fix slow health summary endpoint

### DIFF
--- a/docs/Plans/PLAN-product-updates.md
+++ b/docs/Plans/PLAN-product-updates.md
@@ -1,0 +1,125 @@
+<!-- GitHub Epic: #367 -->
+# Phase: Product Updates & Release Notes (v0.63)
+
+## Ziel
+
+Sichtbar machen, wenn eine neuere Version eines installierten Produkts verfügbar ist, und die Release Notes direkt im UI zugänglich machen. Entscheidung "upgraden ja/nein" bekommt damit Kontext.
+
+Heute bleibt ein auf v1.0.2 installiertes Produkt auch nach Sync einer v1.1.0 stumm — weder Badge, noch Notification, noch Release-Notes. Diese Phase schließt die Lücke.
+
+## Analyse
+
+### Bestehende Architektur
+
+- **ProductDeployment-Aggregate** ([ProductDeployment.cs:32](../../src/ReadyStackGo.Domain/Deployment/ProductDeployments/ProductDeployment.cs#L32)) hält `ProductVersion` (installiert) und `PreviousVersion`. Kein Feld für "verfügbare/neueste Version" — das kommt aus dem Katalog.
+- **ProductDefinition** ([ProductDefinition.cs:53](../../src/ReadyStackGo.Domain/StackManagement/Stacks/ProductDefinition.cs#L53)) trägt pro Katalog-Eintrag genau eine `ProductVersion`. Sync-Zyklen überschreiben, es gibt keine Versions-Historie pro Produkt.
+- **Source-Sync** ([SyncStackSourcesHandler.cs](../../src/ReadyStackGo.Application/UseCases/StackSources/SyncStackSources/SyncStackSourcesHandler.cs)) lädt `ProductDefinition`s. Eine Source kann heute mehrere Versionen desselben Produkts nebeneinander halten (anders als "immer nur eine" — das ist eine Einschränkung, die wir adressieren müssen).
+- **RSGO-Self-Update-Muster** ([GetVersionHandler.cs:59-92](../../src/ReadyStackGo.Application/UseCases/System/GetVersion/GetVersionHandler.cs#L59-L92)) zeigt das exakte Pattern, das wir für Produkte spiegeln: `IVersionCheckService.GetLatestVersionAsync()` → `IsNewerVersion()` (SemVer) → `ExistsAsync(type, metadataKey, metadataValue)` gegen Duplikat → einmalige `Notification` mit `metadata["latestVersion"]`.
+- **Notification-Factory** ([NotificationFactory.cs](../../src/ReadyStackGo.Application/Notifications/NotificationFactory.cs)) hat `CreateProductDeploymentResult` als nächstliegende Vorlage. Kein Helper für ProductUpdateAvailable — der kommt in dieser Phase dazu. Enum `NotificationType` ([Notification.cs](../../src/ReadyStackGo.Application/Notifications/Notification.cs)) wird um `ProductUpdateAvailable` erweitert.
+- **ProductDeployment UI** ([ProductDeploymentDetail.tsx:128-130](../../src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Deployments/ProductDeploymentDetail.tsx#L128)) zeigt die installierte Version als Badge; der "View in Catalog"-Button verweist zurück auf den Katalog. An diese Stelle kommt der Update-Badge.
+
+### Betroffene Bounded Contexts
+
+- **Domain**
+  - Neues Value Object `AvailableVersion` (Version + optional `ReleaseNotesUrl` + optional `ChangelogMarkdown`) oder Felder direkt an `ProductDefinition`.
+  - Neuer Domain-Service/-Query `ProductUpdateAvailability` (vergleicht installiert vs. neueste im Katalog).
+  - Neuer Notification-Type `ProductUpdateAvailable`.
+- **Application**
+  - Query `GetProductUpdateStatus(productDeploymentId)` → `{ currentVersion, latestVersion?, hasUpdate, releaseNotesUrl?, changelogMarkdown? }`.
+  - Background-Check beim Source-Sync: nach erfolgreichem `SyncStackSources`/`SyncSingleSource` wird pro betroffenem `ProductDeployment` geprüft, ob es eine neuere Version gibt; falls ja → einmalige Notification.
+  - `NotificationFactory.CreateProductUpdateAvailable(...)` mit Metadata-Key `productDeploymentId:latestVersion` für Dedup.
+- **Infrastructure**
+  - Stack-Source-Loader (Git, OCI) liest zusätzlich `releaseNotesUrl` aus dem YAML und sucht nach `CHANGELOG.md` neben der Stack-Definition; beides wird an der `ProductDefinition` gespeichert.
+- **API**
+  - `GET /api/product-deployments/{id}/update-status` → JSON wie oben.
+  - `GET /api/product-deployments/{id}/release-notes?version=X.Y.Z` → entweder serverseitig gefetchte Markdown-Source (bei CHANGELOG.md) oder nur die URL (bei `releaseNotesUrl`) — frontend entscheidet dann zwischen Embed und externem Link.
+- **WebUi (rsgo-generic)**
+  - `ProductDeploymentDetail`: Update-Badge neben Versions-Badge; Klick öffnet Release-Notes-Viewer oder externen Link.
+  - `ProductDeployments`/Dashboard-Liste: Indikator (Punkt/Badge) auf Deployments mit verfügbarem Update.
+  - Neue Komponente `ReleaseNotesViewer` — rendert Markdown (reuse `@rsgo/core` Markdown-Util falls vorhanden, sonst `react-markdown` oder `marked` — Library-Entscheidung siehe "Offene Punkte").
+
+### YAML-Schema-Änderung
+
+Ergänzt in `ProductDefinition` YAML:
+```yaml
+productVersion: "1.1.0"
+releaseNotesUrl: "https://github.com/org/product/releases/tag/v1.1.0"   # optional
+# Konvention: liegt CHANGELOG.md im gleichen Verzeichnis → wird automatisch
+# beim Sync eingelesen und bevorzugt vor releaseNotesUrl im Viewer angezeigt.
+```
+
+## AMS UI Counterpart
+
+**Ja — AMS-Counterpart wird als eigenes PLAN file angelegt** (`C:\proj\ReadyStackGo.Ams\docs\Plans\PLAN-product-updates.md`). Shared Hooks (`useProductUpdateStatus`, `useReleaseNotes`) kommen in `@rsgo/core`; Pages/Komponenten werden im AMS-Distribution mit ConsistentUI/Lit reimplementiert.
+
+## Features / Schritte
+
+Reihenfolge basierend auf Abhängigkeiten:
+
+- [ ] **Feature 1: YAML-Schema + Source-Loader**
+  - `ProductDefinition` bekommt `ReleaseNotesUrl?` und `ChangelogMarkdown?`.
+  - Git-Source-Loader und OCI-Source-Loader lesen beides beim Sync.
+  - Betroffene Dateien: `src/ReadyStackGo.Domain/StackManagement/Stacks/ProductDefinition.cs`, alle Source-Loader unter `src/ReadyStackGo.Infrastructure/StackSources/`.
+  - Pattern-Vorlage: bestehender `ProductDefinition`-Parser.
+  - Abhängig von: —
+- [ ] **Feature 2: Update-Status-Query**
+  - Query `GetProductUpdateStatus` + Handler; vergleicht installiert vs. neueste verfügbare Version via SemVer (reuse `IsNewerVersion` aus [VersionCheckService.cs:94](../../src/ReadyStackGo.Infrastructure/Services/VersionCheckService.cs#L94) — extrahieren oder wiederverwenden).
+  - API-Endpoint `GET /api/product-deployments/{id}/update-status`.
+  - Betroffene Dateien: `src/ReadyStackGo.Application/UseCases/ProductDeployments/GetUpdateStatus/...`, `src/ReadyStackGo.Api/Endpoints/ProductDeployments/GetUpdateStatusEndpoint.cs`.
+  - Abhängig von: Feature 1.
+- [ ] **Feature 3: Release-Notes-Endpoint**
+  - `GET /api/product-deployments/{id}/release-notes?version=X.Y.Z` liefert `{ mode: "markdown" | "url", content: "...", url?: "..." }`.
+  - Betroffene Dateien: `src/ReadyStackGo.Api/Endpoints/ProductDeployments/GetReleaseNotesEndpoint.cs`, Query-Handler.
+  - Abhängig von: Feature 1.
+- [ ] **Feature 4: Update-Notification + Dedup**
+  - Neuer `NotificationType.ProductUpdateAvailable` + `NotificationFactory.CreateProductUpdateAvailable`.
+  - Hook am Ende von `SyncStackSourcesHandler`/`SyncSingleSourceEndpoint`: iteriert aktive `ProductDeployment`s, prüft `GetProductUpdateStatus`, ruft bei neuer Version `AddAsync` (mit `ExistsAsync`-Dedup auf `{productDeploymentId}:{latestVersion}`).
+  - Betroffene Dateien: `src/ReadyStackGo.Application/Notifications/Notification.cs`, `NotificationFactory.cs`, Sync-Handler.
+  - Pattern-Vorlage: [GetVersionHandler.cs:59-92](../../src/ReadyStackGo.Application/UseCases/System/GetVersion/GetVersionHandler.cs#L59).
+  - Abhängig von: Feature 2.
+- [ ] **Feature 5: UI — `@rsgo/core` Hooks + API-Client**
+  - `notificationsApi`-Parallele: `productUpdatesApi.getStatus(id)`, `productUpdatesApi.getReleaseNotes(id, version)`.
+  - Hooks: `useProductUpdateStatus(id)`, `useReleaseNotes(id, version)`.
+  - Betroffene Dateien: `src/ReadyStackGo.WebUi/packages/core/src/api/productUpdates.ts`, `hooks/useProductUpdateStatus.ts`, `hooks/useReleaseNotes.ts`.
+  - Abhängig von: Features 2–3.
+- [ ] **Feature 6: UI — Badge + Viewer + Dashboard**
+  - Update-Badge neben Versions-Badge in `ProductDeploymentDetail.tsx`.
+  - Neue Komponente `ReleaseNotesViewer` (Modal oder Seiten-Sektion).
+  - Dashboard/Overview: Indikator auf Zeilen mit `hasUpdate: true`.
+  - Betroffene Dateien: `src/ReadyStackGo.WebUi/packages/ui-generic/src/pages/Deployments/ProductDeploymentDetail.tsx`, `src/ReadyStackGo.WebUi/packages/ui-generic/src/components/ReleaseNotesViewer.tsx`, Dashboard-Liste.
+  - Abhängig von: Feature 5.
+- [ ] **Feature 7: AMS UI Counterpart** — separates PLAN file im AMS Repo, parallel zu Features 5-6 mit ConsistentUI/Lit-Komponenten.
+- [ ] **Dokumentation & Website** — Wiki-Seite "Product Updates", Public-Website-Update (DE/EN), Roadmap-Eintrag, Beispiel-YAML mit `releaseNotesUrl` in `docs/Reference/`.
+- [ ] **Phase abschließen** — Alle Tests grün, v0.63-Release-Notes, PR gegen main.
+
+## Test-Strategie
+
+- **Unit Tests**
+  - `ProductDefinitionParser`: parst `releaseNotesUrl`, findet `CHANGELOG.md` beim Sync; kein Wert → null-Felder.
+  - SemVer-Compare: v1.0.2 < v1.1.0, v1.10.0 > v1.9.9, Prerelease (v1.1.0-rc1) vs. Stable, identische Version → kein Update.
+  - `NotificationFactory.CreateProductUpdateAvailable`: Severity, Title/Message, Metadata-Keys.
+  - Dedup: `ExistsAsync({productDeploymentId}:{latestVersion})` unterdrückt Zweit-Sync.
+- **Integration Tests**
+  - `/api/product-deployments/{id}/update-status`: Response-Shape, 404 bei unbekannter ID, leerer Katalog → `hasUpdate: false`.
+  - `/api/product-deployments/{id}/release-notes?version=X`: Markdown-Mode bei CHANGELOG.md vorhanden, URL-Mode bei nur `releaseNotesUrl`, 404 sonst.
+- **E2E Tests** (Playwright)
+  - Zwei Produkte im Katalog (v1.0.0 + v1.1.0), ein Deployment auf v1.0.0 → nach Sync: Update-Badge auf Detail-Seite, Dashboard-Indicator, ein Notification-Eintrag.
+  - Klick auf Badge öffnet `ReleaseNotesViewer` mit gerendertem Markdown.
+  - Zweiter Sync → keine zweite Notification (Dedup verifiziert).
+
+## Offene Punkte
+
+- [ ] **Markdown-Library**: `react-markdown` (sicher, modular) vs. `marked` (schlank, weniger Deps). Entscheidung beim ersten Implementierungs-PR.
+- [ ] **Release-Notes-Aggregation**: Wenn zwischen installiert (v1.0.2) und neuester (v1.3.0) mehrere Versionen liegen — alle Changelogs anzeigen oder nur die der Ziel-Version? Empfehlung: nur Ziel-Version; Aggregation als Folge-Feature.
+- [ ] **Multi-Version im Katalog**: Heute hält `ProductDefinition` eine Version. Muss der Sync mehrere Versions-Einträge pro Produkt speichern? Klärung beim Refinement von Feature 1.
+- [ ] **Sicherheit Release-Notes-Viewer**: Externe URLs sollen nicht serverseitig gefetcht werden (SSRF-Risiko). CHANGELOG.md aus eigenen Sources ist ok; externe URLs werden nur als Link gerendert, nicht im Viewer embedded.
+
+## Entscheidungen
+
+| Entscheidung | Optionen | Gewählt | Begründung |
+|---|---|---|---|
+| Milestone | v0.60 / v1.0 / v0.63 | **v0.63** | v0.60 bereits als "Complete Health Check Support" vergeben und geschlossen; v0.61/v0.62 ebenso. v0.63 ist der nächste freie. |
+| Release-Notes-Quelle | URL / Markdown / Git-Tag / CHANGELOG.md | **URL + CHANGELOG.md** | Vom User gewählt. Source-agnostisch, einfach, CHANGELOG.md als etablierte Konvention. |
+| UI-Scope | Badge / Badge+Notif / Komplett | **Komplett** | Vom User gewählt: Badge + Notification + Dashboard + Release-Notes-Viewer. |
+| Update-Scope | Strikt SemVer-newer / Alle ≠ installiert | **Strikt newer** | Vom User gewählt. Konsistent zum RSGO-self-update, kein Downgrade-Noise. |
+| AMS-Counterpart | Ja / Deferred / Nein / Teilweise | **Ja (eigener PLAN)** | UI-Komponenten betroffen; separates PLAN im AMS-Repo, shared Hooks in `@rsgo/core`. |

--- a/src/ReadyStackGo.Api/BackgroundServices/HealthCollectorBackgroundService.cs
+++ b/src/ReadyStackGo.Api/BackgroundServices/HealthCollectorBackgroundService.cs
@@ -213,7 +213,9 @@ public class HealthCollectorOptions
     /// <summary>
     /// Number of days to retain health snapshots.
     /// Snapshots older than this are automatically deleted.
-    /// Default: 30 days.
+    /// Default: 7 days. With a 30s collection interval this still produces ~20k snapshots
+    /// per deployment; longer retention is unnecessary because the UI history view
+    /// only requests the latest 50 snapshots per deployment.
     /// </summary>
-    public int RetentionDays { get; set; } = 30;
+    public int RetentionDays { get; set; } = 7;
 }

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Configurations/HealthSnapshotConfiguration.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Configurations/HealthSnapshotConfiguration.cs
@@ -109,9 +109,13 @@ public class HealthSnapshotConfiguration : IEntityTypeConfiguration<HealthSnapsh
 
         // Indexes for efficient querying
         builder.HasIndex(h => h.DeploymentId);
-        builder.HasIndex(h => h.EnvironmentId);
         builder.HasIndex(h => h.CapturedAtUtc);
         builder.HasIndex(h => new { h.DeploymentId, h.CapturedAtUtc });
+
+        // Composite index covering the "latest snapshot per deployment in environment"
+        // query in HealthSnapshotRepository.GetLatestForEnvironment. Replaces the
+        // single-column EnvironmentId index, which is now redundant.
+        builder.HasIndex(h => new { h.EnvironmentId, h.DeploymentId, h.CapturedAtUtc });
 
         // Ignore domain events (not persisted)
         builder.Ignore(h => h.DomainEvents);

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Migrations/20260505093951_AddHealthSnapshotsCompositeIndex.Designer.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Migrations/20260505093951_AddHealthSnapshotsCompositeIndex.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ReadyStackGo.Infrastructure.DataAccess;
 
@@ -10,9 +11,11 @@ using ReadyStackGo.Infrastructure.DataAccess;
 namespace ReadyStackGo.Infrastructure.DataAccess.Migrations
 {
     [DbContext(typeof(ReadyStackGoDbContext))]
-    partial class ReadyStackGoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260505093951_AddHealthSnapshotsCompositeIndex")]
+    partial class AddHealthSnapshotsCompositeIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.0");

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Migrations/20260505093951_AddHealthSnapshotsCompositeIndex.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Migrations/20260505093951_AddHealthSnapshotsCompositeIndex.cs
@@ -10,27 +10,29 @@ namespace ReadyStackGo.Infrastructure.DataAccess.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(
-                name: "IX_HealthSnapshots_EnvironmentId",
-                table: "HealthSnapshots");
+            // Use IF EXISTS / IF NOT EXISTS so the migration is safe against
+            // legacy databases where the baseline schema may not have produced the
+            // exact same set of indexes that the InitialCreate migration declares.
+            migrationBuilder.Sql(
+                "DROP INDEX IF EXISTS \"IX_HealthSnapshots_EnvironmentId\";");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_HealthSnapshots_EnvironmentId_DeploymentId_CapturedAtUtc",
-                table: "HealthSnapshots",
-                columns: new[] { "EnvironmentId", "DeploymentId", "CapturedAtUtc" });
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS " +
+                "\"IX_HealthSnapshots_EnvironmentId_DeploymentId_CapturedAtUtc\" " +
+                "ON \"HealthSnapshots\" (\"EnvironmentId\", \"DeploymentId\", \"CapturedAtUtc\");");
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropIndex(
-                name: "IX_HealthSnapshots_EnvironmentId_DeploymentId_CapturedAtUtc",
-                table: "HealthSnapshots");
+            migrationBuilder.Sql(
+                "DROP INDEX IF EXISTS " +
+                "\"IX_HealthSnapshots_EnvironmentId_DeploymentId_CapturedAtUtc\";");
 
-            migrationBuilder.CreateIndex(
-                name: "IX_HealthSnapshots_EnvironmentId",
-                table: "HealthSnapshots",
-                column: "EnvironmentId");
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS " +
+                "\"IX_HealthSnapshots_EnvironmentId\" " +
+                "ON \"HealthSnapshots\" (\"EnvironmentId\");");
         }
     }
 }

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Migrations/20260505093951_AddHealthSnapshotsCompositeIndex.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Migrations/20260505093951_AddHealthSnapshotsCompositeIndex.cs
@@ -1,0 +1,36 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ReadyStackGo.Infrastructure.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddHealthSnapshotsCompositeIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_HealthSnapshots_EnvironmentId",
+                table: "HealthSnapshots");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_HealthSnapshots_EnvironmentId_DeploymentId_CapturedAtUtc",
+                table: "HealthSnapshots",
+                columns: new[] { "EnvironmentId", "DeploymentId", "CapturedAtUtc" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_HealthSnapshots_EnvironmentId_DeploymentId_CapturedAtUtc",
+                table: "HealthSnapshots");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_HealthSnapshots_EnvironmentId",
+                table: "HealthSnapshots",
+                column: "EnvironmentId");
+        }
+    }
+}

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Repositories/HealthSnapshotRepository.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Repositories/HealthSnapshotRepository.cs
@@ -45,34 +45,34 @@ public class HealthSnapshotRepository : IHealthSnapshotRepository
     {
         // Use raw SQL to efficiently get the latest snapshot per deployment.
         // The EF GroupBy+First pattern causes client-side evaluation, loading ALL rows.
-        // Stale snapshots from removed deployments are cleaned up at the source
-        // (DeploymentService calls RemoveForDeployment when marking a deployment as removed).
-        var envId = environmentId.Value.ToString().ToUpperInvariant();
+        // Pass the Guid directly so EF Core uses its standard Guid-to-TEXT conversion;
+        // the resulting parameter binding allows the composite index
+        // IX_HealthSnapshots_EnvironmentId_DeploymentId_CapturedAtUtc to be used.
+        var envId = environmentId.Value;
 
         return _context.HealthSnapshots
-            .FromSqlRaw(
-                """
+            .FromSqlInterpolated(
+                $"""
                 SELECT h.*
                 FROM "HealthSnapshots" h
                 INNER JOIN (
                     SELECT "DeploymentId", MAX("CapturedAtUtc") AS "MaxDate"
                     FROM "HealthSnapshots"
-                    WHERE UPPER("EnvironmentId") = {0}
+                    WHERE "EnvironmentId" = {envId}
                     GROUP BY "DeploymentId"
                 ) latest ON h."DeploymentId" = latest."DeploymentId"
                     AND h."CapturedAtUtc" = latest."MaxDate"
-                WHERE UPPER(h."EnvironmentId") = {0}
-                """,
-                envId)
+                WHERE h."EnvironmentId" = {envId}
+                """)
             .ToList();
     }
 
     public void RemoveForDeployment(DeploymentId deploymentId)
     {
-        var id = deploymentId.Value.ToString().ToUpperInvariant();
+        var id = deploymentId.Value;
         _context.Database.ExecuteSql(
             $"""
-            DELETE FROM "HealthSnapshots" WHERE UPPER("DeploymentId") = {id}
+            DELETE FROM "HealthSnapshots" WHERE "DeploymentId" = {id}
             """);
     }
 
@@ -87,20 +87,20 @@ public class HealthSnapshotRepository : IHealthSnapshotRepository
 
     public IEnumerable<HealthSnapshot> GetTransitions(DeploymentId deploymentId)
     {
-        var id = deploymentId.Value.ToString().ToUpperInvariant();
+        var id = deploymentId.Value;
 
         // Use LAG() window function to find rows where OverallStatus changed.
         // Also include first snapshot (PrevStatus IS NULL) and latest (RowDesc = 1).
         return _context.HealthSnapshots
-            .FromSqlRaw(
-                """
+            .FromSqlInterpolated(
+                $"""
                 WITH ranked AS (
                     SELECT "Id",
                            "OverallStatus",
                            LAG("OverallStatus") OVER (ORDER BY "CapturedAtUtc") AS "PrevStatus",
                            ROW_NUMBER() OVER (ORDER BY "CapturedAtUtc" DESC) AS "RowDesc"
                     FROM "HealthSnapshots"
-                    WHERE UPPER("DeploymentId") = {0}
+                    WHERE "DeploymentId" = {id}
                 )
                 SELECT h.*
                 FROM "HealthSnapshots" h
@@ -109,8 +109,7 @@ public class HealthSnapshotRepository : IHealthSnapshotRepository
                    OR r."OverallStatus" != r."PrevStatus"
                    OR r."RowDesc" = 1
                 ORDER BY h."CapturedAtUtc" ASC
-                """,
-                id)
+                """)
             .ToList();
     }
 

--- a/tests/ReadyStackGo.UnitTests/Infrastructure/DataAccess/MigrationBaselineTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Infrastructure/DataAccess/MigrationBaselineTests.cs
@@ -135,6 +135,9 @@ public class MigrationBaselineTests
     {
         // Matches the InitialCreate baseline schema — includes the Version column
         // inherited from AggregateRoot for optimistic concurrency, but no OCI columns.
+        // Also creates the subset of other baseline tables/indexes that subsequent
+        // migrations may touch, so the legacy DB is a realistic stand-in for a real
+        // EnsureCreated()-era database (which would have all baseline tables).
         WithOpenConnection(connection, () =>
         {
             using var cmd = connection.CreateCommand();
@@ -155,6 +158,28 @@ public class MigrationBaselineTests
                     "GitSslVerify" INTEGER NOT NULL DEFAULT 1,
                     "Version" INTEGER NOT NULL DEFAULT 0
                 );
+
+                CREATE TABLE "HealthSnapshots" (
+                    "Id" TEXT NOT NULL PRIMARY KEY,
+                    "OrganizationId" TEXT NOT NULL,
+                    "EnvironmentId" TEXT NOT NULL,
+                    "DeploymentId" TEXT NOT NULL,
+                    "StackName" TEXT NOT NULL,
+                    "CapturedAtUtc" TEXT NOT NULL,
+                    "CurrentVersion" TEXT NULL,
+                    "TargetVersion" TEXT NULL,
+                    "OverallStatus" INTEGER NOT NULL,
+                    "OperationMode" INTEGER NOT NULL,
+                    "SelfHealthJson" TEXT NULL,
+                    "BusHealthJson" TEXT NULL,
+                    "InfraHealthJson" TEXT NULL,
+                    "Version" INTEGER NOT NULL DEFAULT 0
+                );
+                CREATE INDEX "IX_HealthSnapshots_DeploymentId" ON "HealthSnapshots" ("DeploymentId");
+                CREATE INDEX "IX_HealthSnapshots_EnvironmentId" ON "HealthSnapshots" ("EnvironmentId");
+                CREATE INDEX "IX_HealthSnapshots_CapturedAtUtc" ON "HealthSnapshots" ("CapturedAtUtc");
+                CREATE INDEX "IX_HealthSnapshots_DeploymentId_CapturedAtUtc"
+                    ON "HealthSnapshots" ("DeploymentId", "CapturedAtUtc");
                 """;
             cmd.ExecuteNonQuery();
             return 0;


### PR DESCRIPTION
## Summary

The `/api/health/{environmentId}` endpoint became progressively slower as the `HealthSnapshots` table grew on long-running instances (observed on `test-ux-dokker`: skeleton loaders never resolved).

Root cause: the raw SQL in `GetLatestForEnvironment` wrapped `EnvironmentId` in `UPPER()`, which prevents SQLite from using the index and forces a full table scan on every request. Compounded by the absence of a composite index covering the `(env, deployment, latest)` access pattern, and a 30-day default retention that lets the table grow large.

## Changes

- Remove `UPPER()` / `ToUpperInvariant()` from `GetLatestForEnvironment`, `RemoveForDeployment`, and `GetTransitions`. Guid parameters are passed via `FromSqlInterpolated` so EF Core's standard Guid-to-TEXT conversion is used on both sides of the comparison.
- Replace the single-column `EnvironmentId` index with a composite `(EnvironmentId, DeploymentId, CapturedAtUtc)` index that directly covers the "latest snapshot per deployment in environment" query.
- New EF Core migration `AddHealthSnapshotsCompositeIndex` performs the index swap.
- Lower default snapshot retention from 30 to 7 days. At a 30s collection interval this still yields ~20k snapshots per deployment, while the UI history view requests only the latest 50.

## Test plan

- [x] `dotnet build` clean (0 errors, 0 new warnings)
- [x] Unit + integration tests for health snapshots / environment summary pass (84 tests)
- [ ] Verify on `test-ux-dokker` that `/health` page loads quickly after deploy
- [ ] Confirm migration applies cleanly to existing instances