### PR TITLE
feat(snmp): SNMP listener backbone (Feature 1 of #377)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,13 @@ services:
     ports:
       - "8080:8080"
       - "8443:8443"
+      # SNMP agent — container listens on non-privileged 1161/udp so it works
+      # under non-root container runtimes (OpenShift restricted SCC, K8s
+      # runAsNonRoot, rootless Docker). Operators who want the classic SNMP
+      # port 161 reachable from outside can replace the mapping with
+      # "161:1161/udp" in a docker-compose.override.yml; the Docker daemon
+      # already runs as root and can bind the host's privileged port.
+      - "1161:1161/udp"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ~/.docker/config.json:/root/.docker/config.json:ro

--- a/docs/Plans/PLAN-snmp-agent.md
+++ b/docs/Plans/PLAN-snmp-agent.md
@@ -150,7 +150,7 @@ Trade-off dokumentieren: Bei schnellen Statuswechseln (Deploy gerade abgeschloss
 
 Reihenfolge basierend auf Abhängigkeiten:
 
-- [ ] **Feature 1: SNMP Listener Backbone** — Lextm.SharpSnmpLib einbinden, `SnmpAgent`-Service in `Infrastructure`, hostet UDP-Listener auf konfigurierbarem Port (Default UDP/1161, non-privileged → rootless-tauglich; im Compose-File auf `1161:1161/udp` gemappt, optional vom Operator auf `161:1161/udp` re-mappbar). Erst ohne echte OIDs — antwortet mit `noSuchObject` auf alles. End-to-End-Pfad damit erstmal stehend.
+- [x] **Feature 1: SNMP Listener Backbone** — Lextm.SharpSnmpLib einbinden, `SnmpAgent`-Service in `Infrastructure`, hostet UDP-Listener auf konfigurierbarem Port (Default UDP/1161, non-privileged → rootless-tauglich; im Compose-File auf `1161:1161/udp` gemappt, optional vom Operator auf `161:1161/udp` re-mappbar). Erst ohne echte OIDs — antwortet mit `noSuchObject` auf alles. End-to-End-Pfad damit erstmal stehend.
   - Betroffene Dateien: neue `src/ReadyStackGo.Infrastructure/Snmp/SnmpAgent.cs`, `Snmp/IOidTree.cs`, `Snmp/OidTreeBuilder.cs` (stub). `src/ReadyStackGo.Api/BackgroundServices/SnmpAgentBackgroundService.cs`.
   - Pattern-Vorlage: [HealthCollectorBackgroundService.cs](../../src/ReadyStackGo.Api/BackgroundServices/HealthCollectorBackgroundService.cs) für DI-Scope + Cancellation-Handling.
   - Abhängig von: -

--- a/src/ReadyStackGo.Api/BackgroundServices/SnmpAgentBackgroundService.cs
+++ b/src/ReadyStackGo.Api/BackgroundServices/SnmpAgentBackgroundService.cs
@@ -1,0 +1,55 @@
+using ReadyStackGo.Infrastructure.Snmp;
+
+namespace ReadyStackGo.Api.BackgroundServices;
+
+/// <summary>
+/// Hosts the <see cref="SnmpAgent"/> alongside the application lifetime. The
+/// agent is started when the host starts and stopped during shutdown.
+///
+/// The agent itself decides whether to actually bind a socket based on
+/// <see cref="SnmpAgentOptions.Enabled"/>; this service unconditionally calls
+/// Start/Stop so flipping the option (Feature 5) only requires a host restart.
+/// </summary>
+public sealed class SnmpAgentBackgroundService : BackgroundService
+{
+    private readonly SnmpAgent _agent;
+    private readonly ILogger<SnmpAgentBackgroundService> _logger;
+
+    public SnmpAgentBackgroundService(
+        SnmpAgent agent,
+        ILogger<SnmpAgentBackgroundService> logger)
+    {
+        _agent = agent;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        try
+        {
+            await _agent.StartAsync(stoppingToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to start SNMP agent");
+            return;
+        }
+
+        // Hold the service alive until shutdown; the agent does the work on its
+        // own background task once started.
+        try
+        {
+            await Task.Delay(Timeout.Infinite, stoppingToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+        {
+            // Expected on shutdown
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await _agent.StopAsync(cancellationToken).ConfigureAwait(false);
+        await base.StopAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/ReadyStackGo.Api/Program.cs
+++ b/src/ReadyStackGo.Api/Program.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Authentication;
 using ReadyStackGo.Infrastructure;
 using ReadyStackGo.Infrastructure.DataAccess;
 using ReadyStackGo.Infrastructure.Security.Authentication;
+using ReadyStackGo.Infrastructure.Snmp;
 
 namespace ReadyStackGo.Api;
 
@@ -125,6 +126,13 @@ public class Program
 
         // Certificate Expiry Notification Service
         builder.Services.AddHostedService<CertificateExpiryCheckService>();
+
+        // SNMP Agent Background Service (v0.64, Feature 1: listener backbone)
+        builder.Services.Configure<SnmpAgentOptions>(
+            builder.Configuration.GetSection(SnmpAgentOptions.SectionName));
+        builder.Services.AddSingleton<IOidTree, EmptyOidTree>();
+        builder.Services.AddSingleton<SnmpAgent>();
+        builder.Services.AddHostedService<SnmpAgentBackgroundService>();
 
         // Add CORS for development
         builder.Services.AddCors(options =>

--- a/src/ReadyStackGo.Api/appsettings.json
+++ b/src/ReadyStackGo.Api/appsettings.json
@@ -13,5 +13,11 @@
     "Issuer": "ReadyStackGo",
     "Audience": "ReadyStackGo",
     "ExpirationMinutes": 480
+  },
+  "Snmp": {
+    "Enabled": false,
+    "Port": 1161,
+    "ListenAddress": "0.0.0.0",
+    "RootOid": "1.3.6.1.4.1.99999.1"
   }
 }

--- a/src/ReadyStackGo.Infrastructure/ReadyStackGo.Infrastructure.csproj
+++ b/src/ReadyStackGo.Infrastructure/ReadyStackGo.Infrastructure.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Certes" Version="3.0.4" />
+    <PackageReference Include="Lextm.SharpSnmpLib" Version="12.5.7" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.*" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0" />

--- a/src/ReadyStackGo.Infrastructure/Snmp/EmptyOidTree.cs
+++ b/src/ReadyStackGo.Infrastructure/Snmp/EmptyOidTree.cs
@@ -1,0 +1,18 @@
+using Lextm.SharpSnmpLib;
+
+namespace ReadyStackGo.Infrastructure.Snmp;
+
+/// <summary>
+/// Stub OID tree that holds no managed objects. Every Get / GetNext returns null
+/// so the listener answers noSuchObject / endOfMibView.
+///
+/// Feature 1 ships with this implementation to prove the end-to-end UDP path is
+/// functional. Feature 2 replaces it with an OidTreeBuilder backed by the
+/// SnmpSnapshotProvider.
+/// </summary>
+public sealed class EmptyOidTree : IOidTree
+{
+    public ISnmpData? Get(ObjectIdentifier oid) => null;
+
+    public (ObjectIdentifier Oid, ISnmpData Value)? GetNext(ObjectIdentifier oid) => null;
+}

--- a/src/ReadyStackGo.Infrastructure/Snmp/IOidTree.cs
+++ b/src/ReadyStackGo.Infrastructure/Snmp/IOidTree.cs
@@ -1,0 +1,25 @@
+using Lextm.SharpSnmpLib;
+
+namespace ReadyStackGo.Infrastructure.Snmp;
+
+/// <summary>
+/// Read model that maps OIDs to their current values for SNMP GET / GETNEXT / WALK.
+///
+/// Feature 1 (this commit) ships only a stub that returns null for every lookup so
+/// the listener responds with noSuchObject. Feature 2 will replace this with an
+/// implementation backed by SnmpSnapshotProvider.
+/// </summary>
+public interface IOidTree
+{
+    /// <summary>
+    /// Look up the value for an exact OID. Returns null if the OID is not in the
+    /// managed object space (caller emits noSuchObject).
+    /// </summary>
+    ISnmpData? Get(ObjectIdentifier oid);
+
+    /// <summary>
+    /// Find the lexicographically next OID that has a value. Returns null when
+    /// there is no next object (caller emits endOfMibView).
+    /// </summary>
+    (ObjectIdentifier Oid, ISnmpData Value)? GetNext(ObjectIdentifier oid);
+}

--- a/src/ReadyStackGo.Infrastructure/Snmp/SnmpAgent.cs
+++ b/src/ReadyStackGo.Infrastructure/Snmp/SnmpAgent.cs
@@ -1,0 +1,237 @@
+using System.Net;
+using System.Net.Sockets;
+using Lextm.SharpSnmpLib;
+using Lextm.SharpSnmpLib.Messaging;
+using Lextm.SharpSnmpLib.Security;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace ReadyStackGo.Infrastructure.Snmp;
+
+/// <summary>
+/// UDP-based SNMP agent that listens for GET / GETNEXT / GETBULK requests and
+/// answers them out of the configured <see cref="IOidTree"/>.
+///
+/// Feature 1 scope: end-to-end UDP path with proper SNMP message
+/// encoding/decoding via SharpSnmpLib. The OID tree is empty so every request
+/// receives noSuchObject / endOfMibView. v2c community strings and v3
+/// auth/priv handling come in Features 3 and 4; this commit accepts any
+/// community and v1/v2c messages only.
+/// </summary>
+public sealed class SnmpAgent : IAsyncDisposable
+{
+    private readonly SnmpAgentOptions _options;
+    private readonly IOidTree _oidTree;
+    private readonly ILogger<SnmpAgent> _logger;
+    private readonly UserRegistry _userRegistry = new();
+
+    private UdpClient? _udpClient;
+    private CancellationTokenSource? _cts;
+    private Task? _receiveTask;
+
+    public SnmpAgent(
+        IOptions<SnmpAgentOptions> options,
+        IOidTree oidTree,
+        ILogger<SnmpAgent> logger)
+    {
+        _options = options.Value;
+        _oidTree = oidTree;
+        _logger = logger;
+    }
+
+    public bool IsRunning => _udpClient is not null;
+
+    public IPEndPoint? BoundEndpoint =>
+        _udpClient?.Client.LocalEndPoint as IPEndPoint;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (!_options.Enabled)
+        {
+            _logger.LogInformation("SNMP agent disabled via configuration (Snmp:Enabled = false)");
+            return Task.CompletedTask;
+        }
+
+        if (_udpClient is not null)
+        {
+            _logger.LogWarning("SNMP agent is already running on {Endpoint}", BoundEndpoint);
+            return Task.CompletedTask;
+        }
+
+        if (!IPAddress.TryParse(_options.ListenAddress, out var address))
+        {
+            throw new InvalidOperationException(
+                $"Snmp:ListenAddress '{_options.ListenAddress}' is not a valid IP address.");
+        }
+
+        var endpoint = new IPEndPoint(address, _options.Port);
+        _udpClient = new UdpClient(endpoint);
+        _cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _receiveTask = Task.Run(() => ReceiveLoopAsync(_cts.Token), _cts.Token);
+
+        _logger.LogInformation(
+            "SNMP agent listening on UDP {Address}:{Port} (root OID {RootOid})",
+            _options.ListenAddress, _options.Port, _options.RootOid);
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_cts is null)
+        {
+            return;
+        }
+
+        try
+        {
+            await _cts.CancelAsync().ConfigureAwait(false);
+            _udpClient?.Close();
+            if (_receiveTask is not null)
+            {
+                try
+                {
+                    await _receiveTask.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException) { /* expected */ }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Error while stopping SNMP agent");
+        }
+        finally
+        {
+            _udpClient?.Dispose();
+            _cts.Dispose();
+            _udpClient = null;
+            _cts = null;
+            _receiveTask = null;
+            _logger.LogInformation("SNMP agent stopped");
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync(CancellationToken.None).ConfigureAwait(false);
+    }
+
+    private async Task ReceiveLoopAsync(CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested && _udpClient is not null)
+        {
+            UdpReceiveResult result;
+            try
+            {
+                result = await _udpClient.ReceiveAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (ObjectDisposedException)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "SNMP agent receive loop error");
+                continue;
+            }
+
+            await ProcessDatagramAsync(result.Buffer, result.RemoteEndPoint, cancellationToken)
+                .ConfigureAwait(false);
+        }
+    }
+
+    private async Task ProcessDatagramAsync(byte[] buffer, IPEndPoint remote, CancellationToken ct)
+    {
+        IList<ISnmpMessage> messages;
+        try
+        {
+            messages = MessageFactory.ParseMessages(buffer, _userRegistry);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Discarded malformed SNMP datagram from {Remote}", remote);
+            return;
+        }
+
+        foreach (var message in messages)
+        {
+            try
+            {
+                var response = BuildResponse(message);
+                if (response is null)
+                {
+                    continue;
+                }
+
+                var responseBytes = response.ToBytes();
+                if (_udpClient is null)
+                {
+                    return;
+                }
+
+                await _udpClient
+                    .SendAsync(responseBytes, responseBytes.Length, remote)
+                    .WaitAsync(ct)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to answer SNMP request from {Remote}", remote);
+            }
+        }
+    }
+
+    private ISnmpMessage? BuildResponse(ISnmpMessage request)
+    {
+        // v3 (auth/priv) ships in Feature 4. For Feature 1 we handle v1/v2c only
+        // and ignore anything else.
+        if (request.Version != VersionCode.V1 && request.Version != VersionCode.V2)
+        {
+            return null;
+        }
+
+        var pdu = request.Pdu();
+        var responseVariables = new List<Variable>(pdu.Variables.Count);
+
+        foreach (var variable in pdu.Variables)
+        {
+            switch (pdu.TypeCode)
+            {
+                case SnmpType.GetRequestPdu:
+                    var value = _oidTree.Get(variable.Id);
+                    responseVariables.Add(new Variable(
+                        variable.Id,
+                        value ?? (ISnmpData)new NoSuchObject()));
+                    break;
+
+                case SnmpType.GetNextRequestPdu:
+                case SnmpType.GetBulkRequestPdu:
+                    var next = _oidTree.GetNext(variable.Id);
+                    if (next.HasValue)
+                    {
+                        responseVariables.Add(new Variable(next.Value.Oid, next.Value.Value));
+                    }
+                    else
+                    {
+                        responseVariables.Add(new Variable(variable.Id, new EndOfMibView()));
+                    }
+                    break;
+
+                default:
+                    // SET / TRAP / INFORM are not supported in this milestone.
+                    return null;
+            }
+        }
+
+        return new ResponseMessage(
+            request.RequestId(),
+            request.Version,
+            request.Community(),
+            ErrorCode.NoError,
+            0,
+            responseVariables);
+    }
+}

--- a/src/ReadyStackGo.Infrastructure/Snmp/SnmpAgentOptions.cs
+++ b/src/ReadyStackGo.Infrastructure/Snmp/SnmpAgentOptions.cs
@@ -1,0 +1,40 @@
+namespace ReadyStackGo.Infrastructure.Snmp;
+
+/// <summary>
+/// Configuration for the SNMP agent listener.
+///
+/// Defaults to UDP/1161 (non-privileged) so the container can run as a non-root
+/// user. Operators map host:161 → container:1161 in docker-compose.yml when they
+/// want monitoring tools to use the classic SNMP port without configuring a
+/// non-standard port.
+/// </summary>
+public class SnmpAgentOptions
+{
+    public const string SectionName = "Snmp";
+
+    /// <summary>
+    /// Whether the SNMP agent is enabled. Default: false — operators must opt in
+    /// explicitly via configuration or the settings UI (Feature 3+).
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// UDP port the agent listens on inside the container. Default 1161 to stay
+    /// out of the privileged port range. The classic SNMP port 161 is reachable
+    /// from outside via docker-compose port mapping.
+    /// </summary>
+    public int Port { get; set; } = 1161;
+
+    /// <summary>
+    /// IP address the listener binds to. Default "0.0.0.0" listens on all
+    /// interfaces inside the container.
+    /// </summary>
+    public string ListenAddress { get; set; } = "0.0.0.0";
+
+    /// <summary>
+    /// Root OID under which all RSGO managed objects live. Default is the
+    /// placeholder 1.3.6.1.4.1.99999.1; replaced with the assigned IANA Private
+    /// Enterprise Number once issued.
+    /// </summary>
+    public string RootOid { get; set; } = "1.3.6.1.4.1.99999.1";
+}

--- a/tests/ReadyStackGo.UnitTests/Infrastructure/Snmp/EmptyOidTreeTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Infrastructure/Snmp/EmptyOidTreeTests.cs
@@ -1,0 +1,28 @@
+using FluentAssertions;
+using Lextm.SharpSnmpLib;
+using ReadyStackGo.Infrastructure.Snmp;
+
+namespace ReadyStackGo.UnitTests.Infrastructure.Snmp;
+
+public class EmptyOidTreeTests
+{
+    [Fact]
+    public void Get_AnyOid_ReturnsNull()
+    {
+        var tree = new EmptyOidTree();
+
+        tree.Get(new ObjectIdentifier("1.3.6.1.4.1.99999.1.1.1.0")).Should().BeNull();
+        tree.Get(new ObjectIdentifier("1.3.6.1.4.1.99999.1.3.1.6.123.456")).Should().BeNull();
+        tree.Get(new ObjectIdentifier("0.0")).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetNext_AnyOid_ReturnsNull()
+    {
+        var tree = new EmptyOidTree();
+
+        tree.GetNext(new ObjectIdentifier("1.3.6.1.4.1.99999.1")).Should().BeNull();
+        tree.GetNext(new ObjectIdentifier("1.3.6.1.4.1.99999.1.4.1.4")).Should().BeNull();
+        tree.GetNext(new ObjectIdentifier("0.0")).Should().BeNull();
+    }
+}

--- a/tests/ReadyStackGo.UnitTests/Infrastructure/Snmp/SnmpAgentTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Infrastructure/Snmp/SnmpAgentTests.cs
@@ -1,0 +1,137 @@
+using System.Net;
+using FluentAssertions;
+using Lextm.SharpSnmpLib;
+using Lextm.SharpSnmpLib.Messaging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using ReadyStackGo.Infrastructure.Snmp;
+
+namespace ReadyStackGo.UnitTests.Infrastructure.Snmp;
+
+/// <summary>
+/// Validates the SNMP agent's UDP listener end-to-end by sending real SNMP v2c
+/// GET / GETNEXT messages with SharpSnmpLib and asserting on the decoded
+/// response. The agent's OID tree is the EmptyOidTree stub so every request
+/// must come back as noSuchObject / endOfMibView.
+/// </summary>
+public class SnmpAgentTests : IAsyncLifetime
+{
+    private SnmpAgent _agent = null!;
+    private int _port;
+
+    public async Task InitializeAsync()
+    {
+        _port = GetFreeUdpPort();
+        var options = Options.Create(new SnmpAgentOptions
+        {
+            Enabled = true,
+            Port = _port,
+            ListenAddress = "127.0.0.1",
+        });
+
+        _agent = new SnmpAgent(options, new EmptyOidTree(), NullLogger<SnmpAgent>.Instance);
+        await _agent.StartAsync(CancellationToken.None);
+        _agent.IsRunning.Should().BeTrue();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _agent.StopAsync(CancellationToken.None);
+        _agent.IsRunning.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Disabled_DoesNotBindSocket()
+    {
+        var disabledOptions = Options.Create(new SnmpAgentOptions { Enabled = false });
+        await using var idleAgent = new SnmpAgent(
+            disabledOptions, new EmptyOidTree(), NullLogger<SnmpAgent>.Instance);
+
+        await idleAgent.StartAsync(CancellationToken.None);
+
+        idleAgent.IsRunning.Should().BeFalse();
+        idleAgent.BoundEndpoint.Should().BeNull();
+    }
+
+    [Fact]
+    public void Start_BindsConfiguredEndpoint()
+    {
+        _agent.BoundEndpoint.Should().NotBeNull();
+        _agent.BoundEndpoint!.Address.Should().Be(IPAddress.Loopback);
+        _agent.BoundEndpoint.Port.Should().Be(_port);
+    }
+
+    [Fact]
+    public void Get_UnknownOid_ReturnsNoSuchObject()
+    {
+        var endpoint = new IPEndPoint(IPAddress.Loopback, _port);
+        var requested = new ObjectIdentifier("1.3.6.1.4.1.99999.1.1.1.0");
+
+        var result = Messenger.Get(
+            VersionCode.V2,
+            endpoint,
+            new OctetString("public"),
+            new List<Variable> { new(requested) },
+            timeout: 2000);
+
+        result.Should().HaveCount(1);
+        result[0].Id.Should().Be(requested);
+        result[0].Data.Should().BeOfType<NoSuchObject>();
+    }
+
+    [Fact]
+    public void Walk_OnEmptyTree_FindsNothing()
+    {
+        var endpoint = new IPEndPoint(IPAddress.Loopback, _port);
+        var collected = new List<Variable>();
+
+        var count = Messenger.Walk(
+            VersionCode.V2,
+            endpoint,
+            new OctetString("public"),
+            new ObjectIdentifier("1.3.6.1.4.1.99999.1"),
+            collected,
+            timeout: 2000,
+            WalkMode.WithinSubtree);
+
+        // EmptyOidTree never has a "next" OID, so the walk stops immediately with
+        // endOfMibView — no variables get collected.
+        count.Should().Be(0);
+        collected.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Start_WhenAlreadyRunning_IsNoOp()
+    {
+        // First StartAsync happened in InitializeAsync. Second one must not throw.
+        await _agent.StartAsync(CancellationToken.None);
+
+        _agent.IsRunning.Should().BeTrue();
+        _agent.BoundEndpoint!.Port.Should().Be(_port);
+    }
+
+    [Fact]
+    public async Task Start_InvalidListenAddress_Throws()
+    {
+        var options = Options.Create(new SnmpAgentOptions
+        {
+            Enabled = true,
+            Port = GetFreeUdpPort(),
+            ListenAddress = "not-an-ip",
+        });
+
+        await using var brokenAgent = new SnmpAgent(
+            options, new EmptyOidTree(), NullLogger<SnmpAgent>.Instance);
+
+        var act = () => brokenAgent.StartAsync(CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*ListenAddress*");
+    }
+
+    private static int GetFreeUdpPort()
+    {
+        using var probe = new System.Net.Sockets.UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        return ((IPEndPoint)probe.Client.LocalEndPoint!).Port;
+    }
+}


### PR DESCRIPTION
First piece of the v0.64 SNMP-agent epic. Establishes the end-to-end UDP path so a real SNMP v2c client can send GET / GETNEXT / GETBULK to RSGO and receive a well-formed response. The OID tree is an empty stub (\`EmptyOidTree\`) so every request comes back as \`noSuchObject\` / \`endOfMibView\` — concrete OIDs follow in Feature 2.

Part of #377.

## What this adds

- **Lextm.SharpSnmpLib 12.5.7** in Infrastructure for SNMP message encoding/decoding.
- **Infrastructure/Snmp**:
  - \`SnmpAgentOptions\` (\`Snmp:Enabled\`/\`Port\`/\`ListenAddress\`/\`RootOid\`). Default disabled; default port \`1161\` (non-privileged) so the container can run rootless. Default root OID is the placeholder \`1.3.6.1.4.1.99999.1\` — swapped for the assigned IANA PEN once issued (application submitted 2026-05-19).
  - \`IOidTree\` + \`EmptyOidTree\` (stub) — abstraction the agent reads from.
  - \`SnmpAgent\` — UDP listener that parses incoming PDUs via \`MessageFactory\`, dispatches per-variable to the OID tree, and emits proper \`noSuchObject\`/\`endOfMibView\` results for unknown OIDs. v1 and v2c only; v3 ships in Feature 4.
- **Api/BackgroundServices/SnmpAgentBackgroundService** — hosts Start/Stop alongside application lifetime, no-ops when disabled.
- **Program.cs DI wiring** (options bind, singleton agent + OID tree, hosted service).
- **docker-compose.yml** maps \`"1161:1161/udp"\`. Comment documents the rootless-ready default and how operators flip to host \`161\` via override.
- **appsettings.json** defaults (\`Snmp\` section).

## Tests (8 new, full suite 2894/2894)

- \`EmptyOidTreeTests\` — \`Get\` / \`GetNext\` return null for any OID.
- \`SnmpAgentTests\` — end-to-end UDP round-trip with SharpSnmpLib client:
  - Start binds the configured endpoint, Stop releases it.
  - Disabled agent does not bind a socket.
  - GET against unknown OID returns \`NoSuchObject\`.
  - Walk on empty tree terminates immediately (0 entries).
  - Repeated Start is idempotent.
  - Invalid \`ListenAddress\` throws.

## Verification
- \`dotnet build\` — 0 errors, no new warnings (5 pre-existing warnings unchanged).
- \`dotnet test tests/ReadyStackGo.UnitTests/\` — 2894/2894 pass.

## AMS UI impact
Not affected — pure backend feature, no \`@rsgo/core\` exports or shared types touched.

## What's next (separate PRs into \`integration/snmp-agent\`)
- Feature 2: Snapshot provider + OID tree builder (replaces \`EmptyOidTree\`)
- Feature 3: v2c community-string auth
- Feature 4: v3 user storage + auth/priv
- Feature 5: REST endpoints for settings/users
- Feature 6: WebUI Settings section
- Feature 7: OID Reference browser page
- Feature 8: MIB-file generation/download