### PR TITLE
feat(snmp): emit SNMP v2c traps on domain events (v0.65 part 2)

### DIFF
--- a/docs/Plans/PLAN-snmp-completion.md
+++ b/docs/Plans/PLAN-snmp-completion.md
@@ -19,7 +19,7 @@ v0.64 hat SNMP als read-only-MVP mit v2c-Polling und einer read-only Settings-Se
 
 - [x] **Feature 6: Editable WebUI** — `/settings/snmp` wird read/write: Enable-Toggle, Port, Community, TrapReceivers Inputs; v3-User-Liste mit Add-Dialog (Name + Auth-Protokoll + Passphrase + Priv-Protokoll + Passphrase) und Delete-Action. OID-Reference-Tree und MIB-Download bleiben.
 
-- [ ] **Feature 7: SNMP Traps** — *Wandert in eine Folgephase (eigene Session).* `TrapReceivers`-Feld ist im UI und in der DB vorbereitet; Trap-Emission über `ISnmpTrapEmitter` Application-Service kommt separat.
+- [x] **Feature 7: SNMP Traps** — `ISnmpTrapEmitter` + `SnmpTrapEmitter` (SharpSnmp `Messenger.SendTrapV2Async`) sendet an alle Empfänger aus `SnmpSettings.TrapReceivers`. Drei MediatR-Handler hängen auf `ProductDeploymentFailed`, `ProductDeploymentAutoFinalized`, `ProductMaintenanceModeChanged`. MIB um `rsgoNotifications` + `rsgoTrapVarBinds` erweitert.
 
 - [x] **Feature 8: smilint CI** — `.github/workflows/mib-lint.yml` installiert `smitools` und validiert `READYSTACKGO-MIB.txt` auf PRs + Pushes.
 

--- a/src/ReadyStackGo.Api/Program.cs
+++ b/src/ReadyStackGo.Api/Program.cs
@@ -144,6 +144,7 @@ public class Program
         builder.Services.AddSingleton<SnmpAgent>();
         builder.Services.AddSingleton<ReadyStackGo.Application.Snmp.ISnmpAgentReloader>(sp =>
             new SnmpAgentReloader(sp.GetRequiredService<SnmpAgent>()));
+        builder.Services.AddSingleton<ReadyStackGo.Application.Snmp.ISnmpTrapEmitter, SnmpTrapEmitter>();
         builder.Services.AddHostedService<SnmpAgentBackgroundService>();
 
         // Add CORS for development

--- a/src/ReadyStackGo.Api/Resources/READYSTACKGO-MIB.txt
+++ b/src/ReadyStackGo.Api/Resources/READYSTACKGO-MIB.txt
@@ -16,7 +16,7 @@ READYSTACKGO-MIB DEFINITIONS ::= BEGIN
 --
 
 IMPORTS
-    MODULE-IDENTITY, OBJECT-TYPE,
+    MODULE-IDENTITY, OBJECT-TYPE, NOTIFICATION-TYPE,
     Integer32, Counter32, TimeTicks
         FROM SNMPv2-SMI
     DateAndTime
@@ -43,6 +43,8 @@ rsgoEnvironmentTable  OBJECT IDENTIFIER ::= { readyStackGoMIB 2 }
 rsgoProductTable      OBJECT IDENTIFIER ::= { readyStackGoMIB 3 }
 rsgoStackTable        OBJECT IDENTIFIER ::= { readyStackGoMIB 4 }
 rsgoServiceTable      OBJECT IDENTIFIER ::= { readyStackGoMIB 5 }
+rsgoNotifications     OBJECT IDENTIFIER ::= { readyStackGoMIB 6 }
+rsgoTrapVarBinds      OBJECT IDENTIFIER ::= { readyStackGoMIB 7 }
 
 --
 -- rsgoSystem — scalars
@@ -316,5 +318,42 @@ rsgoServiceHealthStatus    OBJECT-TYPE
     MAX-ACCESS read-only STATUS current ::= { rsgoServiceEntry 8 }
 rsgoServiceRestartCount    OBJECT-TYPE SYNTAX Counter32 MAX-ACCESS read-only STATUS current ::= { rsgoServiceEntry 9 }
 rsgoServiceLastHealthCheck OBJECT-TYPE SYNTAX DateAndTime MAX-ACCESS read-only STATUS current ::= { rsgoServiceEntry 10 }
+
+--
+-- Trap VarBinds — the payload objects RSGO attaches to its notifications.
+--
+rsgoTrapProductId      OBJECT-TYPE SYNTAX OCTET STRING MAX-ACCESS accessible-for-notify STATUS current ::= { rsgoTrapVarBinds 1 }
+rsgoTrapProductName    OBJECT-TYPE SYNTAX OCTET STRING MAX-ACCESS accessible-for-notify STATUS current ::= { rsgoTrapVarBinds 2 }
+rsgoTrapProductVersion OBJECT-TYPE SYNTAX OCTET STRING MAX-ACCESS accessible-for-notify STATUS current ::= { rsgoTrapVarBinds 3 }
+rsgoTrapStatus         OBJECT-TYPE SYNTAX Integer32   MAX-ACCESS accessible-for-notify STATUS current ::= { rsgoTrapVarBinds 4 }
+rsgoTrapStatusText     OBJECT-TYPE SYNTAX OCTET STRING MAX-ACCESS accessible-for-notify STATUS current ::= { rsgoTrapVarBinds 5 }
+rsgoTrapMessage        OBJECT-TYPE SYNTAX OCTET STRING MAX-ACCESS accessible-for-notify STATUS current ::= { rsgoTrapVarBinds 6 }
+rsgoTrapOperationMode  OBJECT-TYPE SYNTAX Integer32   MAX-ACCESS accessible-for-notify STATUS current ::= { rsgoTrapVarBinds 7 }
+
+--
+-- Notifications (SNMP v2c traps)
+--
+rsgoProductDeploymentFailedTrap NOTIFICATION-TYPE
+    OBJECTS { rsgoTrapProductName, rsgoTrapMessage }
+    STATUS  current
+    DESCRIPTION "A product deployment transitioned into Failed state."
+    ::= { rsgoNotifications 1 }
+
+rsgoProductDeploymentAutoFinalizedTrap NOTIFICATION-TYPE
+    OBJECTS { rsgoTrapProductName, rsgoTrapStatus, rsgoTrapStatusText, rsgoTrapMessage }
+    STATUS  current
+    DESCRIPTION
+        "A stuck product deployment was automatically finalized by RSGO
+         after the orchestrator went away. rsgoTrapStatus carries the
+         resulting product status (Running, PartiallyRunning or Failed)."
+    ::= { rsgoNotifications 2 }
+
+rsgoProductMaintenanceModeChangedTrap NOTIFICATION-TYPE
+    OBJECTS { rsgoTrapOperationMode, rsgoTrapMessage }
+    STATUS  current
+    DESCRIPTION
+        "A product deployment's operation mode switched between Normal and
+         Maintenance. rsgoTrapOperationMode carries the new mode."
+    ::= { rsgoNotifications 3 }
 
 END

--- a/src/ReadyStackGo.Application/Snmp/ISnmpTrapEmitter.cs
+++ b/src/ReadyStackGo.Application/Snmp/ISnmpTrapEmitter.cs
@@ -1,0 +1,25 @@
+namespace ReadyStackGo.Application.Snmp;
+
+/// <summary>
+/// Sends SNMP v2c traps to the receivers configured in SnmpSettings.
+/// Implementation lives in Infrastructure/Snmp because it speaks UDP.
+/// </summary>
+public interface ISnmpTrapEmitter
+{
+    Task EmitAsync(SnmpTrap trap, CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// A trap that's about to be emitted. <see cref="TrapOid"/> identifies the
+/// trap class (rsgoProductDeploymentFailedTrap etc.); <see cref="Variables"/>
+/// carry the payload bindings.
+/// </summary>
+public record SnmpTrap(string TrapOid, IReadOnlyList<SnmpTrapVariable> Variables);
+
+public record SnmpTrapVariable(string Oid, SnmpTrapValueType Type, string Value);
+
+public enum SnmpTrapValueType
+{
+    OctetString = 0,
+    Integer32 = 1,
+}

--- a/src/ReadyStackGo.Application/Snmp/ProductDeploymentTrapHandlers.cs
+++ b/src/ReadyStackGo.Application/Snmp/ProductDeploymentTrapHandlers.cs
@@ -1,0 +1,113 @@
+using MediatR;
+using Microsoft.Extensions.Logging;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Domain.Deployment.ProductDeployments;
+
+namespace ReadyStackGo.Application.Snmp;
+
+/// <summary>
+/// Sends an SNMP trap whenever a product deployment fails.
+/// </summary>
+public sealed class ProductDeploymentFailedTrapHandler
+    : INotificationHandler<DomainEventNotification<ProductDeploymentFailed>>
+{
+    private readonly ISnmpTrapEmitter _emitter;
+    private readonly ILogger<ProductDeploymentFailedTrapHandler> _logger;
+
+    public ProductDeploymentFailedTrapHandler(
+        ISnmpTrapEmitter emitter,
+        ILogger<ProductDeploymentFailedTrapHandler> logger)
+    {
+        _emitter = emitter;
+        _logger = logger;
+    }
+
+    public async Task Handle(DomainEventNotification<ProductDeploymentFailed> notification, CancellationToken cancellationToken)
+    {
+        var evt = notification.DomainEvent;
+        try
+        {
+            await _emitter.EmitAsync(new SnmpTrap(
+                TrapOid: SnmpTrapOids.TrapProductDeploymentFailed,
+                Variables: new[]
+                {
+                    new SnmpTrapVariable(SnmpTrapOids.VarProductName, SnmpTrapValueType.OctetString, evt.ProductName),
+                    new SnmpTrapVariable(SnmpTrapOids.VarMessage, SnmpTrapValueType.OctetString, evt.ErrorMessage ?? string.Empty),
+                }), cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to emit ProductDeploymentFailed trap");
+        }
+    }
+}
+
+public sealed class ProductDeploymentAutoFinalizedTrapHandler
+    : INotificationHandler<DomainEventNotification<ProductDeploymentAutoFinalized>>
+{
+    private readonly ISnmpTrapEmitter _emitter;
+    private readonly ILogger<ProductDeploymentAutoFinalizedTrapHandler> _logger;
+
+    public ProductDeploymentAutoFinalizedTrapHandler(
+        ISnmpTrapEmitter emitter,
+        ILogger<ProductDeploymentAutoFinalizedTrapHandler> logger)
+    {
+        _emitter = emitter;
+        _logger = logger;
+    }
+
+    public async Task Handle(DomainEventNotification<ProductDeploymentAutoFinalized> notification, CancellationToken cancellationToken)
+    {
+        var evt = notification.DomainEvent;
+        try
+        {
+            await _emitter.EmitAsync(new SnmpTrap(
+                TrapOid: SnmpTrapOids.TrapProductDeploymentAutoFinalized,
+                Variables: new[]
+                {
+                    new SnmpTrapVariable(SnmpTrapOids.VarProductName, SnmpTrapValueType.OctetString, evt.ProductName),
+                    new SnmpTrapVariable(SnmpTrapOids.VarStatus, SnmpTrapValueType.Integer32, ((int)evt.NewStatus).ToString()),
+                    new SnmpTrapVariable(SnmpTrapOids.VarStatusText, SnmpTrapValueType.OctetString, evt.NewStatus.ToString()),
+                    new SnmpTrapVariable(SnmpTrapOids.VarMessage, SnmpTrapValueType.OctetString, evt.Reason ?? string.Empty),
+                }), cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to emit ProductDeploymentAutoFinalized trap");
+        }
+    }
+}
+
+public sealed class ProductMaintenanceModeChangedTrapHandler
+    : INotificationHandler<DomainEventNotification<ProductMaintenanceModeChanged>>
+{
+    private readonly ISnmpTrapEmitter _emitter;
+    private readonly ILogger<ProductMaintenanceModeChangedTrapHandler> _logger;
+
+    public ProductMaintenanceModeChangedTrapHandler(
+        ISnmpTrapEmitter emitter,
+        ILogger<ProductMaintenanceModeChangedTrapHandler> logger)
+    {
+        _emitter = emitter;
+        _logger = logger;
+    }
+
+    public async Task Handle(DomainEventNotification<ProductMaintenanceModeChanged> notification, CancellationToken cancellationToken)
+    {
+        var evt = notification.DomainEvent;
+        try
+        {
+            await _emitter.EmitAsync(new SnmpTrap(
+                TrapOid: SnmpTrapOids.TrapProductMaintenanceModeChanged,
+                Variables: new[]
+                {
+                    new SnmpTrapVariable(SnmpTrapOids.VarOperationMode, SnmpTrapValueType.Integer32, ((int)evt.NewMode).ToString()),
+                    new SnmpTrapVariable(SnmpTrapOids.VarMessage, SnmpTrapValueType.OctetString, evt.Trigger?.Reason ?? string.Empty),
+                }), cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to emit ProductMaintenanceModeChanged trap");
+        }
+    }
+}

--- a/src/ReadyStackGo.Application/Snmp/SnmpTrapOids.cs
+++ b/src/ReadyStackGo.Application/Snmp/SnmpTrapOids.cs
@@ -1,0 +1,37 @@
+namespace ReadyStackGo.Application.Snmp;
+
+/// <summary>
+/// Stable OID suffixes (relative to <c>SnmpAgentOptions.RootOid</c>) for the
+/// trap classes RSGO emits. Kept in Application so the trap emitter, the
+/// notification handlers, and any documentation generators share one source.
+///
+/// Layout under <c>rsgoRoot</c>:
+///   .6  rsgoNotifications
+///       .1  rsgoProductDeploymentFailedTrap
+///       .2  rsgoProductDeploymentAutoFinalizedTrap
+///       .3  rsgoProductMaintenanceModeChangedTrap
+///   .7  rsgoTrapVarBinds
+///       .1  rsgoTrapProductId       (STRING)
+///       .2  rsgoTrapProductName     (STRING)
+///       .3  rsgoTrapProductVersion  (STRING)
+///       .4  rsgoTrapStatus          (Integer32)
+///       .5  rsgoTrapStatusText      (STRING)
+///       .6  rsgoTrapMessage         (STRING)
+///       .7  rsgoTrapOperationMode   (Integer32)
+/// </summary>
+public static class SnmpTrapOids
+{
+    public const string NotificationsSuffix = "6";
+    public const string TrapProductDeploymentFailed = "6.1";
+    public const string TrapProductDeploymentAutoFinalized = "6.2";
+    public const string TrapProductMaintenanceModeChanged = "6.3";
+
+    public const string VarBindBase = "7";
+    public const string VarProductId = "7.1.0";
+    public const string VarProductName = "7.2.0";
+    public const string VarProductVersion = "7.3.0";
+    public const string VarStatus = "7.4.0";
+    public const string VarStatusText = "7.5.0";
+    public const string VarMessage = "7.6.0";
+    public const string VarOperationMode = "7.7.0";
+}

--- a/src/ReadyStackGo.Infrastructure/Snmp/SnmpTrapEmitter.cs
+++ b/src/ReadyStackGo.Infrastructure/Snmp/SnmpTrapEmitter.cs
@@ -1,0 +1,132 @@
+using System.Net;
+using Lextm.SharpSnmpLib;
+using Lextm.SharpSnmpLib.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using ReadyStackGo.Application.Snmp;
+using ReadyStackGo.Domain.Snmp;
+
+namespace ReadyStackGo.Infrastructure.Snmp;
+
+/// <summary>
+/// Emits SNMP v2c traps via UDP to every receiver listed in
+/// <see cref="SnmpSettings.TrapReceivers"/>. Resolves the live settings
+/// through a DI scope each time so admin edits in the WebUI take effect
+/// immediately, without re-instantiating this singleton.
+/// </summary>
+public sealed class SnmpTrapEmitter : ISnmpTrapEmitter
+{
+    private static readonly DateTime ProcessStartedAt = DateTime.UtcNow;
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<SnmpTrapEmitter> _logger;
+    private int _requestIdCounter;
+
+    public SnmpTrapEmitter(
+        IServiceScopeFactory scopeFactory,
+        ILogger<SnmpTrapEmitter> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    public async Task EmitAsync(SnmpTrap trap, CancellationToken cancellationToken = default)
+    {
+        SnmpSettings settings;
+        try
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var repo = scope.ServiceProvider.GetRequiredService<ISnmpSettingsRepository>();
+            settings = repo.GetOrCreate();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load SNMP settings while emitting trap");
+            return;
+        }
+
+        if (!settings.Enabled)
+        {
+            _logger.LogDebug("Skipping trap emission — SNMP agent is disabled");
+            return;
+        }
+        if (string.IsNullOrWhiteSpace(settings.Community))
+        {
+            _logger.LogDebug("Skipping trap emission — no v2c community configured");
+            return;
+        }
+
+        var receivers = settings.ParseTrapReceivers().ToList();
+        if (receivers.Count == 0)
+        {
+            _logger.LogDebug("Skipping trap emission — no receivers configured");
+            return;
+        }
+
+        var trapOid = new ObjectIdentifier(CombineOid(settings.RootOid, trap.TrapOid));
+        var variables = trap.Variables
+            .Select(v => new Variable(
+                new ObjectIdentifier(CombineOid(settings.RootOid, v.Oid)),
+                v.Type switch
+                {
+                    SnmpTrapValueType.Integer32 => (ISnmpData)new Integer32(int.TryParse(v.Value, out var i) ? i : 0),
+                    _ => new OctetString(v.Value ?? string.Empty),
+                }))
+            .ToList();
+
+        var uptime = (uint)Math.Min(
+            uint.MaxValue,
+            (long)((DateTime.UtcNow - ProcessStartedAt).TotalMilliseconds * 10));
+
+        var community = new OctetString(settings.Community);
+        var requestId = Interlocked.Increment(ref _requestIdCounter);
+
+        foreach (var receiver in receivers)
+        {
+            if (cancellationToken.IsCancellationRequested) break;
+            if (!IPAddress.TryParse(receiver.Host, out var ip))
+            {
+                try
+                {
+                    var hostEntry = await Dns.GetHostEntryAsync(receiver.Host, cancellationToken).ConfigureAwait(false);
+                    ip = hostEntry.AddressList.FirstOrDefault();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Trap receiver '{Host}' could not be resolved", receiver.Host);
+                    continue;
+                }
+            }
+            if (ip is null) continue;
+
+            var endpoint = new IPEndPoint(ip, receiver.Port);
+
+            try
+            {
+                await Messenger.SendTrapV2Async(
+                    requestId: requestId,
+                    version: VersionCode.V2,
+                    receiver: endpoint,
+                    community: community,
+                    enterprise: trapOid,
+                    timestamp: uptime,
+                    variables: variables).ConfigureAwait(false);
+
+                _logger.LogInformation(
+                    "Sent SNMP v2c trap {TrapOid} to {Receiver}",
+                    trap.TrapOid, endpoint);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to send SNMP trap to {Receiver}", endpoint);
+            }
+        }
+    }
+
+    private static string CombineOid(string root, string suffix)
+    {
+        var rootTrim = root.TrimEnd('.');
+        var suffixTrim = suffix.TrimStart('.');
+        return string.IsNullOrEmpty(suffixTrim) ? rootTrim : $"{rootTrim}.{suffixTrim}";
+    }
+}

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/de/reference/snmp-monitoring.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/de/reference/snmp-monitoring.md
@@ -108,10 +108,24 @@ Add/Delete-Operationen auf anderen Entitäten stabil — wenn du eine OID
 einmal in deiner Monitoring-Config speicherst, zeigt sie auch danach noch
 auf dasselbe logische Objekt.
 
+## SNMP Traps (Push-Benachrichtigungen)
+
+RSGO sendet v2c-Traps an alle Empfänger aus dem Feld **Trap receivers**
+auf der Settings-Seite (Komma- oder Zeilenumbruch-getrennt, `host[:port]`,
+Default-Port `162`), sobald ein relevantes Domain-Event eintritt:
+
+| Trap | Domain-Event | Inhalt |
+| --- | --- | --- |
+| `rsgoProductDeploymentFailedTrap` | Ein ProductDeployment ist final auf `Failed`. | Produktname, Fehlermeldung |
+| `rsgoProductDeploymentAutoFinalizedTrap` | Eine stuck-Deployment wurde von RSGO automatisch finalisiert. | Produktname, Folge-Status, Begründung |
+| `rsgoProductMaintenanceModeChangedTrap` | Maintenance-Modus an/aus für ein Produkt. | Neuer Operation-Mode, Begründung |
+
+Traps werden nur gesendet, wenn der SNMP-Agent aktiviert ist und ein
+v2c-Community-String konfiguriert ist (dieser dient auch als Trap-Community).
+
 ## Einschränkungen (v0.65)
 
-- **Read-only.** Kein SET. Traps sind scaffolded (Receiver editierbar), die
-  Emission kommt in einer Folgephase.
-- **Nur SNMPv2c-Responses.** v3-Credentials authentifizieren eingehende
-  Requests korrekt, Antworten gehen aktuell aber via v2c — volle
+- **Read-only-Polling.** Kein SET.
+- **Nur SNMPv2c-Responses.** SNMPv3-Credentials authentifizieren eingehende
+  Requests korrekt, RSGO antwortet aktuell aber via v2c — volle
   v3-Responses kommen in einer Folgephase.

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/en/reference/snmp-monitoring.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/en/reference/snmp-monitoring.md
@@ -105,10 +105,24 @@ the same across container restarts and across add/delete operations on other
 entities — so once you store an OID in your monitoring config, it keeps
 pointing at the same logical object.
 
+## SNMP Traps (push notifications)
+
+RSGO sends v2c traps to every receiver listed in **Trap receivers** on the
+Settings page (comma- or newline-separated `host[:port]`, default port `162`)
+whenever a notable domain event occurs:
+
+| Trap | Domain event | Carries |
+| --- | --- | --- |
+| `rsgoProductDeploymentFailedTrap` | A product deployment ended in `Failed`. | Product name, error message |
+| `rsgoProductDeploymentAutoFinalizedTrap` | A stuck deployment was auto-finalized by RSGO. | Product name, resulting status, reason |
+| `rsgoProductMaintenanceModeChangedTrap` | A product entered or left maintenance mode. | New operation mode, reason |
+
+Traps are only sent when the SNMP agent is enabled and a v2c community is
+configured (the community is reused as the trap community).
+
 ## Limits (v0.65)
 
-- **Read-only.** No SET. Traps are scaffolded (receivers editable) but
-  emission ships in a follow-up.
-- **SNMPv2c responses only.** v3 credentials authenticate incoming requests
-  correctly, but the response is currently constructed as v2c — full v3
-  responses come in a follow-up.
+- **Read-only polling.** No SET.
+- **SNMPv2c responses only.** SNMPv3 credentials authenticate incoming
+  requests correctly, but RSGO currently constructs its responses as v2c —
+  full v3 responses come in a follow-up.

--- a/tests/ReadyStackGo.UnitTests/Infrastructure/Snmp/SnmpTrapEmitterTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Infrastructure/Snmp/SnmpTrapEmitterTests.cs
@@ -1,0 +1,150 @@
+using System.Net;
+using System.Net.Sockets;
+using FluentAssertions;
+using Lextm.SharpSnmpLib;
+using Lextm.SharpSnmpLib.Messaging;
+using Lextm.SharpSnmpLib.Security;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using ReadyStackGo.Application.Snmp;
+using ReadyStackGo.Domain.Snmp;
+using ReadyStackGo.Infrastructure.Snmp;
+
+namespace ReadyStackGo.UnitTests.Infrastructure.Snmp;
+
+public class SnmpTrapEmitterTests : IAsyncLifetime
+{
+    private UdpClient _receiver = null!;
+    private int _receiverPort;
+    private FakeSettingsRepository _settingsRepo = null!;
+    private SnmpTrapEmitter _emitter = null!;
+
+    public Task InitializeAsync()
+    {
+        _receiver = new UdpClient(new IPEndPoint(IPAddress.Loopback, 0));
+        _receiverPort = ((IPEndPoint)_receiver.Client.LocalEndPoint!).Port;
+        _settingsRepo = new FakeSettingsRepository(BuildSettings(enabled: true, community: "public", receivers: $"127.0.0.1:{_receiverPort}"));
+
+        var scopeFactory = new FakeScopeFactory(_settingsRepo);
+        _emitter = new SnmpTrapEmitter(scopeFactory, NullLogger<SnmpTrapEmitter>.Instance);
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _receiver.Dispose();
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Emit_WhenAgentDisabled_DoesNothing()
+    {
+        _settingsRepo.Settings = BuildSettings(enabled: false, community: "public", receivers: $"127.0.0.1:{_receiverPort}");
+
+        var trap = new SnmpTrap(SnmpTrapOids.TrapProductDeploymentFailed,
+            new[] { new SnmpTrapVariable(SnmpTrapOids.VarProductName, SnmpTrapValueType.OctetString, "ams.project") });
+
+        await _emitter.EmitAsync(trap);
+        var arrived = await TryReceiveAsync(TimeSpan.FromMilliseconds(300));
+        arrived.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Emit_WhenCommunityEmpty_DoesNothing()
+    {
+        _settingsRepo.Settings = BuildSettings(enabled: true, community: string.Empty, receivers: $"127.0.0.1:{_receiverPort}");
+
+        var trap = new SnmpTrap(SnmpTrapOids.TrapProductDeploymentFailed,
+            new[] { new SnmpTrapVariable(SnmpTrapOids.VarProductName, SnmpTrapValueType.OctetString, "ams.project") });
+
+        await _emitter.EmitAsync(trap);
+        var arrived = await TryReceiveAsync(TimeSpan.FromMilliseconds(300));
+        arrived.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Emit_WhenReceiversEmpty_DoesNothing()
+    {
+        _settingsRepo.Settings = BuildSettings(enabled: true, community: "public", receivers: string.Empty);
+
+        var trap = new SnmpTrap(SnmpTrapOids.TrapProductDeploymentFailed,
+            new[] { new SnmpTrapVariable(SnmpTrapOids.VarProductName, SnmpTrapValueType.OctetString, "ams.project") });
+
+        await _emitter.EmitAsync(trap);
+        var arrived = await TryReceiveAsync(TimeSpan.FromMilliseconds(300));
+        arrived.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Emit_ProductDeploymentFailedTrap_ArrivesAtReceiver()
+    {
+        var trap = new SnmpTrap(SnmpTrapOids.TrapProductDeploymentFailed,
+            new[]
+            {
+                new SnmpTrapVariable(SnmpTrapOids.VarProductName, SnmpTrapValueType.OctetString, "ams.project"),
+                new SnmpTrapVariable(SnmpTrapOids.VarMessage, SnmpTrapValueType.OctetString, "stack X failed"),
+            });
+
+        await _emitter.EmitAsync(trap);
+
+        var arrived = await TryReceiveAsync(TimeSpan.FromSeconds(2));
+        arrived.Should().NotBeNull();
+
+        var messages = MessageFactory.ParseMessages(arrived!, new UserRegistry());
+        messages.Should().ContainSingle();
+        var trapV2 = messages[0] as TrapV2Message;
+        trapV2.Should().NotBeNull();
+
+        trapV2.Enterprise.ToString().Should().Contain("99999.1.6.1");
+
+        var variables = trapV2.Pdu().Variables;
+        var productNameVb = variables.FirstOrDefault(v => v.Id.ToString().Contains("99999.1.7.2.0"));
+        productNameVb.Should().NotBeNull("the productName varbind should be present");
+        productNameVb!.Data.ToString().Should().Be("ams.project");
+    }
+
+    private async Task<byte[]?> TryReceiveAsync(TimeSpan timeout)
+    {
+        try
+        {
+            using var cts = new CancellationTokenSource(timeout);
+            var result = await _receiver.ReceiveAsync(cts.Token);
+            return result.Buffer;
+        }
+        catch (OperationCanceledException) { return null; }
+    }
+
+    private static SnmpSettings BuildSettings(bool enabled, string community, string receivers)
+    {
+        var s = SnmpSettings.CreateDefault();
+        s.Update(enabled, port: 1161, listenAddress: "0.0.0.0",
+            rootOid: "1.3.6.1.4.1.99999.1", community: community, trapReceivers: receivers);
+        return s;
+    }
+
+    private sealed class FakeSettingsRepository : ISnmpSettingsRepository
+    {
+        public SnmpSettings Settings { get; set; }
+        public FakeSettingsRepository(SnmpSettings settings) => Settings = settings;
+        public SnmpSettings GetOrCreate() => Settings;
+        public void Update(SnmpSettings settings) => Settings = settings;
+        public void SaveChanges() { }
+    }
+
+    private sealed class FakeScopeFactory : IServiceScopeFactory
+    {
+        private readonly ISnmpSettingsRepository _repo;
+        public FakeScopeFactory(ISnmpSettingsRepository repo) => _repo = repo;
+        public IServiceScope CreateScope() => new FakeScope(_repo);
+    }
+
+    private sealed class FakeScope : IServiceScope, IServiceProvider
+    {
+        private readonly ISnmpSettingsRepository _repo;
+        public FakeScope(ISnmpSettingsRepository repo) => _repo = repo;
+        public IServiceProvider ServiceProvider => this;
+        public object? GetService(Type serviceType) =>
+            serviceType == typeof(ISnmpSettingsRepository) ? _repo : null;
+        public void Dispose() { }
+    }
+}


### PR DESCRIPTION
Second slice of the SNMP-completion epic (#383). Wires the trap receivers list introduced in PR #384 to actual outbound v2c traps for the three most operationally-relevant domain events.

## Application/Snmp
- \`ISnmpTrapEmitter\` contract + \`SnmpTrap\` / \`SnmpTrapVariable\` record types.
- \`SnmpTrapOids\` constants (relative to \`SnmpAgentOptions.RootOid\`):
  - \`.6\` \`rsgoNotifications\`: \`.1\` ProductDeploymentFailed, \`.2\` AutoFinalized, \`.3\` MaintenanceModeChanged.
  - \`.7\` \`rsgoTrapVarBinds\`: ProductId, ProductName, ProductVersion, Status, StatusText, Message, OperationMode.
- Three \`INotificationHandler<DomainEventNotification<...>>\` for \`ProductDeploymentFailed\`, \`ProductDeploymentAutoFinalized\`, \`ProductMaintenanceModeChanged\`.

## Infrastructure/Snmp
- \`SnmpTrapEmitter\` uses SharpSnmpLib's \`Messenger.SendTrapV2Async\`. Loads the live \`SnmpSettings\` each call through a fresh DI scope so admin edits in the WebUI take effect immediately. Silently no-ops when agent is disabled, community is empty, or receivers list is empty. DNS resolution for non-IP hostnames, default port 162.

## MIB
- \`READYSTACKGO-MIB.txt\` extended with \`NOTIFICATION-TYPE\` imports plus the three \`rsgoNotifications\` and the seven accessible-for-notify \`rsgoTrapVarBinds\` objects.

## DI
- \`ISnmpTrapEmitter\` registered as singleton in Program.cs.

## Docs (en + de)
- New "SNMP Traps" section in the public reference page documenting trap receivers config and the three trap classes.
- Limits section updated — only "v3 responses still v2c" remains.

## Verification
- 4 new tests in \`SnmpTrapEmitterTests\`, including a real UDP round-trip that asserts the trap class \`Enterprise\` OID + \`productName\` varbind on the decoded \`TrapV2Message\`.
- Full unit suite: **2908/2908** pass.
- \`dotnet build\` — 0 errors.

## What's next for v0.65
- Session 3: full SNMPv3 response construction.
- Then phase close + release.