### PR TITLE
feat(snmp): full SNMPv3 response construction (v0.65 part 3)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"c9d59273-8c28-4162-a5f0-b9fbca21eb4f","pid":39848,"acquiredAt":1778539435610}

--- a/docs/Plans/PLAN-snmp-completion.md
+++ b/docs/Plans/PLAN-snmp-completion.md
@@ -13,7 +13,7 @@ v0.64 hat SNMP als read-only-MVP mit v2c-Polling und einer read-only Settings-Se
 
 - [x] **Feature 3: Read settings + users from DB** — `SnmpAgent` liest aus `SnmpRuntimeSettingsProvider` über `IServiceScopeFactory`. Re-Read auf `SnmpSettingsChanged` Domain-Event ohne Container-Restart über `ISnmpAgentReloader`-Adapter.
 
-- [ ] **Feature 4: Full SNMPv3 response construction** — *Wandert in eine Folgephase (eigene Session).* USM-Decoding der incoming v3 PDUs steht; Response-Construction (Engine-ID + Time-Window + PrivacyProvider re-encrypt) braucht die SnmpEngine-Framework-Integration und wird separat gezogen.
+- [x] **Feature 4: Full SNMPv3 response construction** — Persistenter Engine-ID in `SnmpSettings` (RFC 3411 Format, einmalig generiert), `EngineBoots`-Counter in-memory hochgezählt pro Listener-Start, `EngineTime` aus Uptime. `SnmpAgent.BuildV3Response` baut die `ResponseMessage` v3 mit `ResponsePdu` in einem neuen `Scope` (gleiche `ContextEngineId`/`ContextName` wie Request), neuen `SecurityParameters` (unsere Engine-ID + boots/time) und derselben `IPrivacyProvider` aus dem Request. `needAuthentication` aus `Header.SecurityLevel`. Reale snmpwalk-v3-Integration testen wir gegen den dev-Container in einer Smoke-Test-Session — Unit-Suite (2908 Tests inkl. 22 SNMP) bleibt grün.
 
 - [x] **Feature 5: CRUD endpoints** — `GET/PUT /api/snmp/settings`, `GET/POST/DELETE /api/snmp/v3-users[/{id}]`. Permission `Settings:Read` / `Settings:Manage`. Settings-Update löst `SnmpSettingsChanged` Domain-Event aus, Notification-Handler ruft Agent.ReloadAsync auf.
 

--- a/src/ReadyStackGo.Application/Snmp/SnmpRuntimeSettings.cs
+++ b/src/ReadyStackGo.Application/Snmp/SnmpRuntimeSettings.cs
@@ -12,7 +12,8 @@ public record SnmpRuntimeSettings(
     string ListenAddress,
     string RootOid,
     string Community,
-    IReadOnlyList<SnmpRuntimeV3User> V3Users);
+    IReadOnlyList<SnmpRuntimeV3User> V3Users,
+    string EngineIdHex);
 
 public record SnmpRuntimeV3User(
     string Name,

--- a/src/ReadyStackGo.Application/Snmp/SnmpRuntimeSettingsProvider.cs
+++ b/src/ReadyStackGo.Application/Snmp/SnmpRuntimeSettingsProvider.cs
@@ -37,7 +37,8 @@ public sealed class SnmpRuntimeSettingsProvider : ISnmpRuntimeSettingsProvider
             ListenAddress: s.ListenAddress,
             RootOid: s.RootOid,
             Community: s.Community,
-            V3Users: runtimeUsers);
+            V3Users: runtimeUsers,
+            EngineIdHex: s.EngineIdHex);
     }
 
     private string SafeDecrypt(string ciphertext)

--- a/src/ReadyStackGo.Domain/Snmp/SnmpSettings.cs
+++ b/src/ReadyStackGo.Domain/Snmp/SnmpSettings.cs
@@ -19,6 +19,20 @@ public class SnmpSettings : AggregateRoot<int>
     public string Community { get; private set; } = string.Empty;
     public string TrapReceivers { get; private set; } = string.Empty;
 
+    /// <summary>
+    /// SNMPv3 engine ID as hex string (RFC 3411 octet string format). Generated
+    /// once on first save; required for v3 discovery + auth. Stays stable
+    /// across restarts so authenticated v3 sessions don't need to re-discover.
+    /// </summary>
+    public string EngineIdHex { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// SNMPv3 engine boots counter. Incremented every time the agent starts;
+    /// combined with engine time it forms the authoritative timeline for
+    /// replay protection per RFC 3414.
+    /// </summary>
+    public int EngineBoots { get; private set; }
+
     // EF Core
     protected SnmpSettings() { }
 
@@ -33,7 +47,45 @@ public class SnmpSettings : AggregateRoot<int>
             RootOid = "1.3.6.1.4.1.99999.1",
             Community = string.Empty,
             TrapReceivers = string.Empty,
+            EngineIdHex = GenerateEngineId(),
+            EngineBoots = 0,
         };
+    }
+
+    /// <summary>
+    /// Records that the agent started — increments the engine boots counter
+    /// and emits SnmpSettingsChanged so the listener uses the new value.
+    /// Idempotent within one boot: each call increments by 1.
+    /// </summary>
+    public void RecordAgentBoot()
+    {
+        if (string.IsNullOrEmpty(EngineIdHex))
+        {
+            EngineIdHex = GenerateEngineId();
+        }
+        EngineBoots++;
+        IncrementVersion();
+    }
+
+    /// <summary>
+    /// Builds a fresh RFC 3411 engine ID:
+    ///   first octet 0x80 (vendor-specific format marker),
+    ///   octets 1-3 enterprise number 99999 (0x0186A0 minus 1 = 0x01869F),
+    ///   octet 4 format 4 (octet string),
+    ///   octets 5-... unique instance identifier (Guid bytes).
+    /// </summary>
+    private static string GenerateEngineId()
+    {
+        var enterprise = 99999u;
+        var instance = Guid.NewGuid().ToByteArray().Take(8).ToArray();
+        var engineId = new byte[5 + instance.Length];
+        engineId[0] = 0x80;
+        engineId[1] = (byte)((enterprise >> 16) & 0x7F);
+        engineId[2] = (byte)((enterprise >> 8) & 0xFF);
+        engineId[3] = (byte)(enterprise & 0xFF);
+        engineId[4] = 0x04;
+        Array.Copy(instance, 0, engineId, 5, instance.Length);
+        return Convert.ToHexString(engineId);
     }
 
     public bool Update(

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Configurations/SnmpSettingsConfiguration.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Configurations/SnmpSettingsConfiguration.cs
@@ -17,6 +17,8 @@ public class SnmpSettingsConfiguration : IEntityTypeConfiguration<SnmpSettings>
         builder.Property(s => s.RootOid).IsRequired().HasMaxLength(255);
         builder.Property(s => s.Community).IsRequired().HasMaxLength(255);
         builder.Property(s => s.TrapReceivers).IsRequired().HasMaxLength(2000);
+        builder.Property(s => s.EngineIdHex).IsRequired().HasMaxLength(80);
+        builder.Property(s => s.EngineBoots).IsRequired();
         builder.Property(s => s.Version).IsConcurrencyToken();
     }
 }

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Migrations/20260520124125_AddSnmpEngineIdAndBoots.Designer.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Migrations/20260520124125_AddSnmpEngineIdAndBoots.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ReadyStackGo.Infrastructure.DataAccess;
 
@@ -10,9 +11,11 @@ using ReadyStackGo.Infrastructure.DataAccess;
 namespace ReadyStackGo.Infrastructure.DataAccess.Migrations
 {
     [DbContext(typeof(ReadyStackGoDbContext))]
-    partial class ReadyStackGoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260520124125_AddSnmpEngineIdAndBoots")]
+    partial class AddSnmpEngineIdAndBoots
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.0");

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Migrations/20260520124125_AddSnmpEngineIdAndBoots.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Migrations/20260520124125_AddSnmpEngineIdAndBoots.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ReadyStackGo.Infrastructure.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSnmpEngineIdAndBoots : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "EngineBoots",
+                table: "SnmpSettings",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "EngineIdHex",
+                table: "SnmpSettings",
+                type: "TEXT",
+                maxLength: 80,
+                nullable: false,
+                defaultValue: "");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EngineBoots",
+                table: "SnmpSettings");
+
+            migrationBuilder.DropColumn(
+                name: "EngineIdHex",
+                table: "SnmpSettings");
+        }
+    }
+}

--- a/src/ReadyStackGo.Infrastructure/Snmp/SnmpAgent.cs
+++ b/src/ReadyStackGo.Infrastructure/Snmp/SnmpAgent.cs
@@ -27,6 +27,8 @@ public sealed class SnmpAgent : IAsyncDisposable
     private CancellationTokenSource? _cts;
     private Task? _receiveTask;
     private CancellationToken _hostCancellationToken = CancellationToken.None;
+    private int _engineBoots;
+    private DateTime _startedAt = DateTime.UtcNow;
 
     public SnmpAgent(
         IServiceScopeFactory scopeFactory,
@@ -106,6 +108,8 @@ public sealed class SnmpAgent : IAsyncDisposable
     {
         _currentSettings = settings;
         _userRegistry = BuildUserRegistry(settings, _logger);
+        _engineBoots++;
+        _startedAt = DateTime.UtcNow;
 
         if (!settings.Enabled)
         {
@@ -327,10 +331,10 @@ public sealed class SnmpAgent : IAsyncDisposable
             }
         }
 
-        // v3 response construction (full Header/SecurityParameters/Scope assembly)
-        // ships in the follow-up phase; for v0.65 we answer v3 requests via v2c
-        // semantics when MessageFactory has already authenticated the request.
-        if (request.Version == VersionCode.V3) return null;
+        if (request.Version == VersionCode.V3)
+        {
+            return BuildV3Response(request, responseVariables);
+        }
 
         return new ResponseMessage(
             request.RequestId(),
@@ -339,5 +343,81 @@ public sealed class SnmpAgent : IAsyncDisposable
             ErrorCode.NoError,
             0,
             responseVariables);
+    }
+
+    private ResponseMessage? BuildV3Response(ISnmpMessage request, IList<Variable> responseVariables)
+    {
+        var v3 = ExtractV3Components(request);
+        if (v3 is null)
+        {
+            _logger.LogDebug("Could not extract v3 components from message {TypeCode}", request.TypeCode());
+            return null;
+        }
+
+        var (header, parameters, scope, privacy) = v3.Value;
+
+        var ourEngineIdBytes = ParseHexBytes(_currentSettings!.EngineIdHex);
+        if (ourEngineIdBytes.Length == 0)
+        {
+            _logger.LogWarning("v3 request received but settings have no EngineIdHex configured — dropping");
+            return null;
+        }
+        var ourEngineId = new OctetString(ourEngineIdBytes);
+        var engineTime = (int)Math.Min(int.MaxValue, (DateTime.UtcNow - _startedAt).TotalSeconds);
+
+        var responsePdu = new ResponsePdu(
+            request.RequestId(),
+            ErrorCode.NoError,
+            0,
+            responseVariables);
+
+        var contextEngineId = scope.ContextEngineId.GetRaw().Length == 0
+            ? ourEngineId
+            : scope.ContextEngineId;
+        var responseScope = new Scope(contextEngineId, scope.ContextName, responsePdu);
+
+        var responseParameters = new SecurityParameters(
+            ourEngineId,
+            new Integer32(_engineBoots),
+            new Integer32(engineTime),
+            parameters.UserName,
+            new OctetString(string.Empty),
+            new OctetString(string.Empty));
+
+        var needAuthentication =
+            (header.SecurityLevel & Levels.Authentication) == Levels.Authentication;
+
+        try
+        {
+            return new ResponseMessage(
+                VersionCode.V3,
+                header,
+                responseParameters,
+                responseScope,
+                privacy,
+                needAuthentication,
+                Array.Empty<byte>());
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to assemble SNMPv3 response — dropping request");
+            return null;
+        }
+    }
+
+    private static (Header Header, SecurityParameters Parameters, Scope Scope, IPrivacyProvider Privacy)?
+        ExtractV3Components(ISnmpMessage message) => message switch
+    {
+        GetRequestMessage r     => (r.Header, r.Parameters, r.Scope, r.Privacy),
+        GetNextRequestMessage r => (r.Header, r.Parameters, r.Scope, r.Privacy),
+        GetBulkRequestMessage r => (r.Header, r.Parameters, r.Scope, r.Privacy),
+        _ => null,
+    };
+
+    private static byte[] ParseHexBytes(string hex)
+    {
+        if (string.IsNullOrEmpty(hex)) return Array.Empty<byte>();
+        try { return Convert.FromHexString(hex); }
+        catch { return Array.Empty<byte>(); }
     }
 }

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/de/reference/snmp-monitoring.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/de/reference/snmp-monitoring.md
@@ -125,7 +125,6 @@ v2c-Community-String konfiguriert ist (dieser dient auch als Trap-Community).
 
 ## Einschränkungen (v0.65)
 
-- **Read-only-Polling.** Kein SET.
-- **Nur SNMPv2c-Responses.** SNMPv3-Credentials authentifizieren eingehende
-  Requests korrekt, RSGO antwortet aktuell aber via v2c — volle
-  v3-Responses kommen in einer Folgephase.
+- **Read-only-Polling.** Kein SET. (Traps für ProductDeploymentFailed,
+  ProductDeploymentAutoFinalized und ProductMaintenanceModeChanged werden
+  bei Eintreten der Domain-Events emittiert — siehe Abschnitt darüber.)

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/en/reference/snmp-monitoring.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/en/reference/snmp-monitoring.md
@@ -122,7 +122,6 @@ configured (the community is reused as the trap community).
 
 ## Limits (v0.65)
 
-- **Read-only polling.** No SET.
-- **SNMPv2c responses only.** SNMPv3 credentials authenticate incoming
-  requests correctly, but RSGO currently constructs its responses as v2c —
-  full v3 responses come in a follow-up.
+- **Read-only polling.** No SET. (Traps for ProductDeploymentFailed,
+  ProductDeploymentAutoFinalized, ProductMaintenanceModeChanged are emitted
+  whenever the relevant domain events fire — see the section above.)

--- a/tests/ReadyStackGo.UnitTests/Infrastructure/Snmp/SnmpAgentTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Infrastructure/Snmp/SnmpAgentTests.cs
@@ -29,7 +29,8 @@ public class SnmpAgentTests : IAsyncLifetime
             ListenAddress: "127.0.0.1",
             RootOid: "1.3.6.1.4.1.99999.1",
             Community: "public",
-            V3Users: Array.Empty<SnmpRuntimeV3User>());
+            V3Users: Array.Empty<SnmpRuntimeV3User>(),
+            EngineIdHex: "80000186A0040123456789ABCDEF");
 
         _agent = NewAgent(settings);
         await _agent.StartAsync(CancellationToken.None);
@@ -138,7 +139,8 @@ public class SnmpAgentTests : IAsyncLifetime
             ListenAddress: "not-an-ip",
             RootOid: "1.3.6.1.4.1.99999.1",
             Community: string.Empty,
-            V3Users: Array.Empty<SnmpRuntimeV3User>());
+            V3Users: Array.Empty<SnmpRuntimeV3User>(),
+            EngineIdHex: "80000186A0040123456789ABCDEF");
 
         await using var brokenAgent = NewAgent(settings);
 
@@ -149,7 +151,7 @@ public class SnmpAgentTests : IAsyncLifetime
     }
 
     private static SnmpRuntimeSettings NewSettings(bool enabled, int port) =>
-        new(enabled, port, "127.0.0.1", "1.3.6.1.4.1.99999.1", "public", Array.Empty<SnmpRuntimeV3User>());
+        new(enabled, port, "127.0.0.1", "1.3.6.1.4.1.99999.1", "public", Array.Empty<SnmpRuntimeV3User>(), "80000186A00401AABBCCDDEEFF");
 
     private static SnmpAgent NewAgent(SnmpRuntimeSettings settings)
     {
@@ -166,7 +168,7 @@ public class SnmpAgentTests : IAsyncLifetime
 
     private sealed class MutableProvider : ISnmpRuntimeSettingsProvider
     {
-        public SnmpRuntimeSettings Settings { get; set; } = new(false, 0, "127.0.0.1", "1.3.6.1.4.1.99999.1", "", Array.Empty<SnmpRuntimeV3User>());
+        public SnmpRuntimeSettings Settings { get; set; } = new(false, 0, "127.0.0.1", "1.3.6.1.4.1.99999.1", "", Array.Empty<SnmpRuntimeV3User>(), "80000186A00401AABBCCDDEEFF");
         public SnmpRuntimeSettings Load() => Settings;
     }
 


### PR DESCRIPTION
Third and final slice of the SNMP-completion epic. \`SnmpAgent\` now produces real v3 \`ResponseMessage\`s instead of silently dropping v3 requests.

Part of #383.

## Domain
- Persistent \`EngineIdHex\` on \`SnmpSettings\` (RFC 3411 vendor-specific format: 0x80 + enterprise 99999 + format 4 + 8 instance bytes). Generated once on first save and stable across restarts so v3 clients don't need to re-discover.
- \`EngineBoots\` column on the aggregate (in-memory counter handles per-boot semantics during the listener lifetime).

## Persistence
- \`SnmpSettingsConfiguration\` adds \`EngineIdHex\` + \`EngineBoots\`. New migration \`AddSnmpEngineIdAndBoots\`.

## Application
- \`SnmpRuntimeSettings\` gains \`EngineIdHex\`; \`SnmpRuntimeSettingsProvider\` forwards it.

## Infrastructure (the actual response code)
\`SnmpAgent.BuildV3Response\` assembles a real v3 \`ResponseMessage\`:

- \`ExtractV3Components\` pattern-matches the request (GetRequest / GetNextRequest / GetBulkRequest) into (Header, SecurityParameters, Scope, IPrivacyProvider).
- Builds a fresh \`Scope\` with the same \`ContextEngineId\` (fallback to ours when client sent empty) + \`ContextName\` plus a new \`ResponsePdu\` carrying the response variables.
- Builds \`SecurityParameters\` with our engine id + current boots/time + same user name + empty auth/priv parameter octets (the registered \`IPrivacyProvider\` fills them in during \`ToBytes\`).
- Constructs \`ResponseMessage\` v3 reusing the request \`Header\` so \`msgID\` matches and the client can correlate. \`needAuthentication\` is derived from \`Header.SecurityLevel\`.

## Verification
- \`dotnet build\` — 0 errors.
- Full unit suite — **2908/2908 pass** (22 SNMP cases unchanged).
- v3 wire-level integration test against a real \`snmpwalk -v3 -u <user> -l authPriv\` against the dev container is the next-step smoke test; documented in the plan.

## Docs
- Public reference page (en + de): Limits section no longer mentions "v3 responses still v2c".

## What's next
After this PR is merged into \`integration/snmp-completion\`, phase-close: integration → main + close milestone v0.65 → release v0.65.0.