### PR TITLE
fix(notifications): warn admin when maintenance observer drops on unresolved variables

### DIFF
--- a/src/ReadyStackGo.Application/Notifications/Notification.cs
+++ b/src/ReadyStackGo.Application/Notifications/Notification.cs
@@ -25,7 +25,8 @@ public enum NotificationType
     ProductDeploymentResult,
     HealthChange,
     ApiKeyFirstUse,
-    CertificateExpiry
+    CertificateExpiry,
+    MaintenanceObserverDisabled,
 }
 
 public enum NotificationSeverity

--- a/src/ReadyStackGo.Application/Notifications/NotificationFactory.cs
+++ b/src/ReadyStackGo.Application/Notifications/NotificationFactory.cs
@@ -197,6 +197,29 @@ public static class NotificationFactory
         };
     }
 
+    public static Notification CreateMaintenanceObserverDisabledNotification(
+        string productName,
+        string productDeploymentId,
+        string reason)
+    {
+        return new Notification
+        {
+            Type = NotificationType.MaintenanceObserverDisabled,
+            Title = "Maintenance observer disabled",
+            Message = $"Product '{productName}' declares a maintenance observer in its manifest, but RSGO could not activate it: {reason}. The deployment will run without maintenance polling until this is resolved.",
+            Severity = NotificationSeverity.Warning,
+            ActionUrl = $"/product-deployments/{productDeploymentId}",
+            ActionLabel = "Open deployment",
+            Metadata = new Dictionary<string, string>
+            {
+                ["productName"] = productName,
+                ["productDeploymentId"] = productDeploymentId,
+                ["reason"] = reason,
+                ["threshold"] = $"{productDeploymentId}:observer-disabled",
+            },
+        };
+    }
+
     private static NotificationSeverity ResolveHealthSeverity(string currentStatus) =>
         currentStatus.ToLowerInvariant() switch
         {

--- a/src/ReadyStackGo.Application/UseCases/Deployments/DeployProduct/DeployProductHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/DeployProduct/DeployProductHandler.cs
@@ -149,6 +149,15 @@ public class DeployProductHandler : IRequestHandler<DeployProductCommand, Deploy
             _logger.LogWarning(
                 "Product {ProductName} defines maintenanceObserver but it could not be mapped (unresolved variables?) — observer disabled",
                 product.Name);
+            if (_inAppNotificationService is not null)
+            {
+                await _inAppNotificationService.AddAsync(
+                    ReadyStackGo.Application.Notifications.NotificationFactory.CreateMaintenanceObserverDisabledNotification(
+                        productName: product.Name,
+                        productDeploymentId: productDeploymentId.Value.ToString(),
+                        reason: "the manifest references variables that are not defined as shared variables for this product"),
+                    cancellationToken);
+            }
         }
 
         _repository.Add(productDeployment);

--- a/src/ReadyStackGo.Application/UseCases/Deployments/RedeployProduct/RedeployProductHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/RedeployProduct/RedeployProductHandler.cs
@@ -99,6 +99,15 @@ public class RedeployProductHandler : IRequestHandler<RedeployProductCommand, De
                     _logger.LogWarning(
                         "Product {ProductName} defines maintenanceObserver but it could not be mapped on redeploy (unresolved variables?) — observer disabled",
                         productDeployment.ProductName);
+                    if (_inAppNotificationService is not null)
+                    {
+                        await _inAppNotificationService.AddAsync(
+                            ReadyStackGo.Application.Notifications.NotificationFactory.CreateMaintenanceObserverDisabledNotification(
+                                productName: productDeployment.ProductName,
+                                productDeploymentId: productDeployment.Id.Value.ToString(),
+                                reason: "the manifest references variables that are not defined as shared variables for this product"),
+                            cancellationToken);
+                    }
                 }
             }
         }

--- a/tests/ReadyStackGo.UnitTests/Application/Deployments/DeployProductHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Deployments/DeployProductHandlerTests.cs
@@ -939,6 +939,39 @@ public class DeployProductHandlerTests
     }
 
     [Fact]
+    public async Task Handle_ObserverConnectionStringUnresolvable_EmitsInAppNotification()
+    {
+        var product = CreateProductWithObserver(
+            new global::ReadyStackGo.Domain.StackManagement.Manifests.RsgoMaintenanceObserver
+            {
+                Type = "sqlExtendedProperty",
+                PropertyName = "ams-MaintenanceMode",
+                ConnectionString = "Server=${DB_SERVER};Database=${DB_NAME};",
+                MaintenanceValue = "1"
+            });
+
+        SetupProductFound(product);
+        SetupNoExistingDeployment();
+        SetupAllStacksSucceed();
+
+        // DB_NAME intentionally missing — observer drops and an admin notification fires.
+        var cmd = CreateCommand(product, new Dictionary<string, string>
+        {
+            ["DB_SERVER"] = "sqldev2017"
+        });
+
+        await _handler.Handle(cmd, CancellationToken.None);
+
+        _inAppNotificationMock.Verify(n => n.AddAsync(
+            It.Is<global::ReadyStackGo.Application.Notifications.Notification>(notif =>
+                notif.Type == global::ReadyStackGo.Application.Notifications.NotificationType.MaintenanceObserverDisabled &&
+                notif.Severity == global::ReadyStackGo.Application.Notifications.NotificationSeverity.Warning &&
+                notif.Metadata.ContainsKey("productName") &&
+                notif.Metadata["productName"] == product.Name),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task Handle_ProductHasNoObserver_LeavesConfigNull()
     {
         var product = CreateTestProduct(1);


### PR DESCRIPTION
Fixes #389.

## Bug
A product manifest can declare a \`maintenance.observer\` block whose connection string references variables that aren't actually defined as shared variables. The mapper refuses to produce a config containing leftover \`\${...}\` placeholders, so \`Map\` returns null and the observer is silently disabled. Until now the only signal was a single \`LogWarning\` at deploy time — easy to miss in production.

**Real case** (test-ux-dokker): ams.project declared \`\${DB_NAME}\` while only \`\${DB_NAME_PERSISTENCE}\`, \`\${DB_NAME_TRANSPORT}\`, \`\${DB_NAME_ERP}\` are defined. The maintenance flag in the database never triggered RSGO maintenance mode because the observer was never wired.

## Fix
- New \`NotificationType.MaintenanceObserverDisabled\`.
- \`NotificationFactory.CreateMaintenanceObserverDisabledNotification(productName, productDeploymentId, reason)\` — Severity Warning, ActionUrl back to the deployment detail page, metadata with \`productName\`, \`productDeploymentId\`, \`reason\`, plus a stable \`threshold\` key for dedup.
- \`DeployProductHandler\` + \`RedeployProductHandler\` now call \`_inAppNotificationService.AddAsync(...)\` right next to the existing \`LogWarning\`.

\`UpgradeProductHandler\` doesn't touch observer config; the existing config from the prior deployment carries over and remains in the same drop-silent path it was before. Not in scope here.

## Verification
- New unit test \`Handle_ObserverConnectionStringUnresolvable_EmitsInAppNotification\` verifies the notification is raised with the expected Type / Severity / metadata when the connection string has an unresolved variable.
- Full unit suite: **2909/2909 pass**.
- \`dotnet build\` — 0 errors.

## Note for affected customers
The actual manifest at \`SPE-Project/stacks/ams.project/stack.yaml\` was also corrected to use \`\${DB_NAME_PERSISTENCE}\` (the right database). After the next ams.project redeploy on test-ux-dokker, the maintenance observer will wire up correctly.