### PR TITLE
fix(notifications): suppress per-service health alerts while product is in maintenance

### DIFF
--- a/src/ReadyStackGo.Infrastructure/Services/Health/HealthCollectorService.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Health/HealthCollectorService.cs
@@ -107,15 +107,19 @@ public class HealthCollectorService : IHealthCollectorService
 
                 // Track health changes and create in-app notifications.
                 // Suppress during install/upgrade so the per-product result is the
-                // sole signal the user sees for the deploy.
+                // sole signal the user sees for the deploy. Also suppress while
+                // the parent product is in Maintenance — every service goes down
+                // by design and we don't want 40+ Service-Health-Changed
+                // notifications for one planned event (issue #391).
                 var serviceStatuses = dto.Self.Services
                     .Select(s => new ServiceHealthUpdate(s.Name, s.Status))
                     .ToList();
+                var suppress = deployment.IsInProgress || IsParentInMaintenance(deployment.Id);
                 await _healthChangeTracker.ProcessHealthUpdateAsync(
                     deployment.Id.Value.ToString(),
                     deployment.StackName,
                     serviceStatuses,
-                    deployment.IsInProgress,
+                    suppress,
                     cancellationToken);
 
                 // Notify about individual deployment health change (SignalR real-time)
@@ -312,5 +316,16 @@ public class HealthCollectorService : IHealthCollectorService
             dto.ProductDeploymentId = productDeployment.Id.Value.ToString();
             dto.ProductDisplayName = productDeployment.ProductDisplayName;
         }
+    }
+
+    /// <summary>
+    /// Returns true if the stack deployment belongs to a ProductDeployment that
+    /// is currently in Maintenance mode. Used to suppress per-service health
+    /// notifications during planned maintenance (issue #391).
+    /// </summary>
+    private bool IsParentInMaintenance(DeploymentId deploymentId)
+    {
+        var parent = _productDeploymentRepository.GetByStackDeploymentId(deploymentId);
+        return parent is not null && parent.OperationMode == ReadyStackGo.Domain.Deployment.Health.OperationMode.Maintenance;
     }
 }


### PR DESCRIPTION
Fixes #391.

## Bug
test-ux-dokker, ams.project (v0.65.1): when the product enters maintenance via the SQL extended-property observer, all 47 services across 15 stacks go from Healthy to Stopped at once. Each transition fires a "Service Health Changed" notification → ~45 unactionable entries in the notification center for a single planned event.

## Fix
\`HealthChangeTracker\` already has a \`suppressNotifications\` parameter; \`HealthCollectorService\` set it only when the underlying Deployment was \`IsInProgress\` (Installing/Upgrading). Extended the gate with \`IsParentInMaintenance(deploymentId)\`: look up the owning ProductDeployment via the existing \`_productDeploymentRepository\` and check \`OperationMode == Maintenance\`.

While maintenance is on, per-service health notifications are skipped but baselines keep advancing — once maintenance ends, real deviations from the post-maintenance baseline fire normally.

## Verification
- \`dotnet build\` — 0 errors.
- Unit suite: 2909/2909 pass.
- Existing \`HealthChangeTrackerTests.SuppressNotifications_SkipsNotification_*\` covers the receiving end of the suppression flag.

## Related follow-ups (separate issues, separate PRs)
- #392 — Health Dashboard product header shows "Unhealthy" when product is in Maintenance.
- #393 — ProductDeployment detail page does not live-update on OperationMode / health changes.