### PR TITLE
fix(deployments): mark old ProductDeployment as Superseded on upgrade

### DIFF
--- a/src/ReadyStackGo.Application/UseCases/Deployments/UpgradeProduct/UpgradeProductHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/UpgradeProduct/UpgradeProductHandler.cs
@@ -191,11 +191,19 @@ public class UpgradeProductHandler : IRequestHandler<UpgradeProductCommand, Upgr
             request.ContinueOnError);
 
         _repository.Add(productDeployment);
+
+        // Mark the old aggregate as superseded so it no longer appears as an active
+        // product deployment. Docker resources stay live under the same stack names
+        // — they belong to the new aggregate now. Without this the old row would
+        // linger in the dashboard with stale DeploymentId references and surface as
+        // a "0 containers" zombie after the new deployment is removed.
+        existing.MarkSuperseded(newDeploymentId);
+        _repository.Update(existing);
         _repository.SaveChanges();
 
         _logger.LogInformation(
-            "Product upgrade {ProductDeploymentId} initiated for {ProductName} from v{PreviousVersion} to v{TargetVersion} with {StackCount} stacks",
-            newDeploymentId, targetProduct.Name, previousVersion, targetVersion, stackConfigs.Count);
+            "Product upgrade {ProductDeploymentId} initiated for {ProductName} from v{PreviousVersion} to v{TargetVersion} with {StackCount} stacks (superseded {OldId})",
+            newDeploymentId, targetProduct.Name, previousVersion, targetVersion, stackConfigs.Count, existing.Id);
 
         // 8. Generate session ID
         var sessionId = !string.IsNullOrEmpty(request.SessionId)

--- a/src/ReadyStackGo.Domain/Deployment/ProductDeployments/ProductDeployment.cs
+++ b/src/ReadyStackGo.Domain/Deployment/ProductDeployments/ProductDeployment.cs
@@ -13,13 +13,14 @@ using ReadyStackGo.Domain.SharedKernel;
 ///
 /// State machine:
 ///   Deploying        → Running | PartiallyRunning | Failed
-///   Running          → Upgrading | Removing | Stopped | Redeploying
-///   PartiallyRunning → Deploying (retry) | Upgrading | Removing | Stopped
+///   Running          → Upgrading | Removing | Stopped | Redeploying | Superseded
+///   PartiallyRunning → Deploying (retry) | Upgrading | Removing | Stopped | Superseded
 ///   Upgrading        → Running | PartiallyRunning | Failed
-///   Failed           → Deploying (retry) | Upgrading | Removing
-///   Stopped          → Running | PartiallyRunning | Upgrading | Removing
+///   Failed           → Deploying (retry) | Upgrading | Removing | Superseded
+///   Stopped          → Running | PartiallyRunning | Upgrading | Removing | Superseded
 ///   Removing         → Removed (terminal)
 ///   Redeploying      → Running | PartiallyRunning | Failed
+///   Superseded       → (terminal)
 /// </summary>
 public class ProductDeployment : AggregateRoot<ProductDeploymentId>
 {
@@ -40,7 +41,8 @@ public class ProductDeployment : AggregateRoot<ProductDeploymentId>
     public string? ErrorMessage { get; private set; }
     public bool ContinueOnError { get; private set; }
 
-    public bool IsTerminal => Status == ProductDeploymentStatus.Removed;
+    public bool IsTerminal => Status is ProductDeploymentStatus.Removed
+                                     or ProductDeploymentStatus.Superseded;
     public bool IsInProgress => Status is ProductDeploymentStatus.Deploying
                                        or ProductDeploymentStatus.Upgrading
                                        or ProductDeploymentStatus.Removing
@@ -79,14 +81,15 @@ public class ProductDeployment : AggregateRoot<ProductDeploymentId>
     private static readonly Dictionary<ProductDeploymentStatus, ProductDeploymentStatus[]> ValidTransitions = new()
     {
         { ProductDeploymentStatus.Deploying, new[] { ProductDeploymentStatus.Running, ProductDeploymentStatus.PartiallyRunning, ProductDeploymentStatus.Failed } },
-        { ProductDeploymentStatus.Running, new[] { ProductDeploymentStatus.Upgrading, ProductDeploymentStatus.Removing, ProductDeploymentStatus.Stopped, ProductDeploymentStatus.Redeploying } },
-        { ProductDeploymentStatus.PartiallyRunning, new[] { ProductDeploymentStatus.Deploying, ProductDeploymentStatus.Upgrading, ProductDeploymentStatus.Removing, ProductDeploymentStatus.Stopped } },
+        { ProductDeploymentStatus.Running, new[] { ProductDeploymentStatus.Upgrading, ProductDeploymentStatus.Removing, ProductDeploymentStatus.Stopped, ProductDeploymentStatus.Redeploying, ProductDeploymentStatus.Superseded } },
+        { ProductDeploymentStatus.PartiallyRunning, new[] { ProductDeploymentStatus.Deploying, ProductDeploymentStatus.Upgrading, ProductDeploymentStatus.Removing, ProductDeploymentStatus.Stopped, ProductDeploymentStatus.Superseded } },
         { ProductDeploymentStatus.Upgrading, new[] { ProductDeploymentStatus.Running, ProductDeploymentStatus.PartiallyRunning, ProductDeploymentStatus.Failed } },
-        { ProductDeploymentStatus.Failed, new[] { ProductDeploymentStatus.Deploying, ProductDeploymentStatus.Upgrading, ProductDeploymentStatus.Removing } },
-        { ProductDeploymentStatus.Stopped, new[] { ProductDeploymentStatus.Running, ProductDeploymentStatus.PartiallyRunning, ProductDeploymentStatus.Upgrading, ProductDeploymentStatus.Removing } },
+        { ProductDeploymentStatus.Failed, new[] { ProductDeploymentStatus.Deploying, ProductDeploymentStatus.Upgrading, ProductDeploymentStatus.Removing, ProductDeploymentStatus.Superseded } },
+        { ProductDeploymentStatus.Stopped, new[] { ProductDeploymentStatus.Running, ProductDeploymentStatus.PartiallyRunning, ProductDeploymentStatus.Upgrading, ProductDeploymentStatus.Removing, ProductDeploymentStatus.Superseded } },
         { ProductDeploymentStatus.Removing, new[] { ProductDeploymentStatus.Removed } },
         { ProductDeploymentStatus.Removed, Array.Empty<ProductDeploymentStatus>() },
-        { ProductDeploymentStatus.Redeploying, new[] { ProductDeploymentStatus.Running, ProductDeploymentStatus.PartiallyRunning, ProductDeploymentStatus.Failed } }
+        { ProductDeploymentStatus.Redeploying, new[] { ProductDeploymentStatus.Running, ProductDeploymentStatus.PartiallyRunning, ProductDeploymentStatus.Failed } },
+        { ProductDeploymentStatus.Superseded, Array.Empty<ProductDeploymentStatus>() }
     };
 
     // For EF Core
@@ -556,6 +559,28 @@ public class ProductDeployment : AggregateRoot<ProductDeploymentId>
             ErrorMessage = null;
             RecordPhase($"Restarted: {restartedStacks} stacks restarted");
         }
+    }
+
+    /// <summary>
+    /// Marks this product deployment as superseded by a newer one (terminal).
+    /// Used when an upgrade transfers Docker resources (same stack names) into a
+    /// successor row — the old row no longer reflects live state and must be
+    /// excluded from active dashboards/queries, but is kept for history.
+    /// No <see cref="ProductDeploymentRemoved"/> event is raised because nothing
+    /// was Docker-removed.
+    /// </summary>
+    public void MarkSuperseded(ProductDeploymentId successorId)
+    {
+        AssertArgumentNotNull(successorId, "Successor product deployment id is required.");
+        SelfAssertStateTrue(!IsTerminal,
+            $"Cannot supersede a product deployment in terminal status {Status}.");
+
+        var previousStatus = Status;
+        Status = ProductDeploymentStatus.Superseded;
+        CompletedAt ??= SystemClock.UtcNow;
+
+        RecordPhase($"Superseded by {successorId.Value} (was {previousStatus})");
+        AddDomainEvent(new ProductDeploymentSuperseded(Id, ProductName, ProductVersion, successorId));
     }
 
     /// <summary>

--- a/src/ReadyStackGo.Domain/Deployment/ProductDeployments/ProductDeploymentEvents.cs
+++ b/src/ReadyStackGo.Domain/Deployment/ProductDeployments/ProductDeploymentEvents.cs
@@ -255,6 +255,31 @@ public sealed class ProductDeploymentRemoved : DomainEvent
 }
 
 /// <summary>
+/// Raised when a product deployment is superseded by a successor (e.g. via upgrade).
+/// Docker resources were not removed — they were transferred to the successor — so this
+/// is distinct from <see cref="ProductDeploymentRemoved"/>.
+/// </summary>
+public sealed class ProductDeploymentSuperseded : DomainEvent
+{
+    public ProductDeploymentId ProductDeploymentId { get; }
+    public string ProductName { get; }
+    public string ProductVersion { get; }
+    public ProductDeploymentId SuccessorId { get; }
+
+    public ProductDeploymentSuperseded(
+        ProductDeploymentId productDeploymentId,
+        string productName,
+        string productVersion,
+        ProductDeploymentId successorId)
+    {
+        ProductDeploymentId = productDeploymentId;
+        ProductName = productName;
+        ProductVersion = productVersion;
+        SuccessorId = successorId;
+    }
+}
+
+/// <summary>
 /// Raised when the operation mode of a product deployment changes (Normal ↔ Maintenance).
 /// </summary>
 public sealed class ProductMaintenanceModeChanged : DomainEvent

--- a/src/ReadyStackGo.Domain/Deployment/ProductDeployments/ProductDeploymentStatus.cs
+++ b/src/ReadyStackGo.Domain/Deployment/ProductDeployments/ProductDeploymentStatus.cs
@@ -5,13 +5,14 @@ namespace ReadyStackGo.Domain.Deployment.ProductDeployments;
 ///
 /// State machine:
 ///   Deploying        → Running | PartiallyRunning | Failed
-///   Running          → Upgrading | Removing | Stopped | Redeploying
-///   PartiallyRunning → Deploying (retry) | Upgrading | Removing | Stopped
+///   Running          → Upgrading | Removing | Stopped | Redeploying | Superseded
+///   PartiallyRunning → Deploying (retry) | Upgrading | Removing | Stopped | Superseded
 ///   Upgrading        → Running | PartiallyRunning | Failed
-///   Failed           → Deploying (retry) | Upgrading | Removing
-///   Stopped          → Running | PartiallyRunning | Upgrading | Removing
+///   Failed           → Deploying (retry) | Upgrading | Removing | Superseded
+///   Stopped          → Running | PartiallyRunning | Upgrading | Removing | Superseded
 ///   Removing         → Removed (terminal)
 ///   Redeploying      → Running | PartiallyRunning | Failed
+///   Superseded       → (terminal — Docker resources transferred to successor)
 /// </summary>
 public enum ProductDeploymentStatus
 {
@@ -58,5 +59,12 @@ public enum ProductDeploymentStatus
     /// <summary>
     /// Redeployment of all or selected stacks is in progress (same version, fresh pull).
     /// </summary>
-    Redeploying = 8
+    Redeploying = 8,
+
+    /// <summary>
+    /// Replaced by a newer ProductDeployment (e.g. via upgrade) — terminal.
+    /// Docker resources were transferred to the successor row (same stack names),
+    /// so this row no longer reflects live state and must be hidden from active lists.
+    /// </summary>
+    Superseded = 9
 }

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Repositories/ProductDeploymentRepository.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Repositories/ProductDeploymentRepository.cs
@@ -43,7 +43,8 @@ public class ProductDeploymentRepository : IProductDeploymentRepository
     {
         return _context.ProductDeployments
             .Where(d => d.EnvironmentId == environmentId && d.ProductGroupId == productGroupId)
-            .Where(d => d.Status != ProductDeploymentStatus.Removed)
+            .Where(d => d.Status != ProductDeploymentStatus.Removed
+                     && d.Status != ProductDeploymentStatus.Superseded)
             .OrderByDescending(d => d.CreatedAt)
             .FirstOrDefault();
     }
@@ -51,7 +52,8 @@ public class ProductDeploymentRepository : IProductDeploymentRepository
     public ProductDeployment? GetByStackDeploymentId(DeploymentId deploymentId)
     {
         return _context.ProductDeployments
-            .Where(d => d.Status != ProductDeploymentStatus.Removed)
+            .Where(d => d.Status != ProductDeploymentStatus.Removed
+                     && d.Status != ProductDeploymentStatus.Superseded)
             .AsEnumerable()
             .FirstOrDefault(d => d.Stacks.Any(s => s.DeploymentId == deploymentId));
     }

--- a/tests/ReadyStackGo.UnitTests/Application/Deployments/UpgradeProductHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Deployments/UpgradeProductHandlerTests.cs
@@ -317,6 +317,32 @@ public class UpgradeProductHandlerTests
     }
 
     [Fact]
+    public async Task Handle_MarksExistingProductDeploymentAsSuperseded()
+    {
+        var currentProduct = CreateTestProduct(2, version: "1.0.0");
+        var targetProduct = CreateTestProduct(2, version: "2.0.0");
+        var existing = CreateExistingDeployment(currentProduct);
+        var existingId = existing.Id;
+
+        SetupExistingDeployment(existing);
+        SetupTargetProductFound(targetProduct);
+        SetupAllStacksSucceed();
+
+        var updatedAggregates = new List<ProductDeployment>();
+        _repositoryMock
+            .Setup(r => r.Update(It.IsAny<ProductDeployment>()))
+            .Callback<ProductDeployment>(pd => updatedAggregates.Add(pd));
+
+        await _handler.Handle(
+            CreateUpgradeCommand(existing, targetProduct), CancellationToken.None);
+
+        existing.Status.Should().Be(ProductDeploymentStatus.Superseded);
+        existing.IsTerminal.Should().BeTrue();
+        updatedAggregates.Should().Contain(pd => pd.Id == existingId
+            && pd.Status == ProductDeploymentStatus.Superseded);
+    }
+
+    [Fact]
     public async Task Handle_NewAggregateHasUpgradeStatus()
     {
         var currentProduct = CreateTestProduct(1, version: "1.0.0");

--- a/tests/ReadyStackGo.UnitTests/Domain/Deployment/ProductDeploymentTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Domain/Deployment/ProductDeploymentTests.cs
@@ -726,6 +726,78 @@ public class ProductDeploymentTests
 
     #endregion
 
+    #region MarkSuperseded
+
+    [Fact]
+    public void MarkSuperseded_FromRunning_TransitionsToSupersededAndIsTerminal()
+    {
+        var pd = CreateRunningDeployment(2);
+        var successorId = ProductDeploymentId.NewId();
+
+        pd.MarkSuperseded(successorId);
+
+        pd.Status.Should().Be(ProductDeploymentStatus.Superseded);
+        pd.IsTerminal.Should().BeTrue();
+        pd.CompletedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void MarkSuperseded_RaisesProductDeploymentSupersededEventNotRemovedEvent()
+    {
+        var pd = CreateRunningDeployment(1);
+        var successorId = ProductDeploymentId.NewId();
+
+        pd.MarkSuperseded(successorId);
+
+        var evt = pd.DomainEvents.OfType<ProductDeploymentSuperseded>().Should().ContainSingle().Subject;
+        evt.SuccessorId.Should().Be(successorId);
+        evt.ProductDeploymentId.Should().Be(pd.Id);
+        pd.DomainEvents.OfType<ProductDeploymentRemoved>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void MarkSuperseded_FromPartiallyRunning_AllowedSoUpgradeCanReplaceUnhealthyPrevious()
+    {
+        var pd = CreatePartiallyRunningDeployment();
+
+        pd.MarkSuperseded(ProductDeploymentId.NewId());
+
+        pd.Status.Should().Be(ProductDeploymentStatus.Superseded);
+    }
+
+    [Fact]
+    public void MarkSuperseded_WhenAlreadyRemoved_ThrowsInvalidOperationException()
+    {
+        var pd = CreateRemovedDeployment();
+
+        var act = () => pd.MarkSuperseded(ProductDeploymentId.NewId());
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void MarkSuperseded_WhenAlreadySuperseded_ThrowsInvalidOperationException()
+    {
+        var pd = CreateRunningDeployment(1);
+        pd.MarkSuperseded(ProductDeploymentId.NewId());
+
+        var act = () => pd.MarkSuperseded(ProductDeploymentId.NewId());
+
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void MarkSuperseded_NullSuccessor_ThrowsArgumentException()
+    {
+        var pd = CreateRunningDeployment(1);
+
+        var act = () => pd.MarkSuperseded(null!);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    #endregion
+
     #region State Machine Transitions
 
     [Theory]
@@ -769,6 +841,17 @@ public class ProductDeploymentTests
     [InlineData(ProductDeploymentStatus.Removed, ProductDeploymentStatus.Deploying, false)]
     [InlineData(ProductDeploymentStatus.Removed, ProductDeploymentStatus.Running, false)]
     [InlineData(ProductDeploymentStatus.Removed, ProductDeploymentStatus.Removing, false)]
+    [InlineData(ProductDeploymentStatus.Running, ProductDeploymentStatus.Superseded, true)]
+    [InlineData(ProductDeploymentStatus.PartiallyRunning, ProductDeploymentStatus.Superseded, true)]
+    [InlineData(ProductDeploymentStatus.Failed, ProductDeploymentStatus.Superseded, true)]
+    [InlineData(ProductDeploymentStatus.Stopped, ProductDeploymentStatus.Superseded, true)]
+    [InlineData(ProductDeploymentStatus.Deploying, ProductDeploymentStatus.Superseded, false)]
+    [InlineData(ProductDeploymentStatus.Upgrading, ProductDeploymentStatus.Superseded, false)]
+    [InlineData(ProductDeploymentStatus.Removing, ProductDeploymentStatus.Superseded, false)]
+    [InlineData(ProductDeploymentStatus.Redeploying, ProductDeploymentStatus.Superseded, false)]
+    [InlineData(ProductDeploymentStatus.Superseded, ProductDeploymentStatus.Deploying, false)]
+    [InlineData(ProductDeploymentStatus.Superseded, ProductDeploymentStatus.Running, false)]
+    [InlineData(ProductDeploymentStatus.Superseded, ProductDeploymentStatus.Removing, false)]
     public void CanTransitionTo_ReturnsExpectedResult(
         ProductDeploymentStatus from, ProductDeploymentStatus to, bool expected)
     {
@@ -1752,8 +1835,16 @@ public class ProductDeploymentTests
             ProductDeploymentStatus.Removing => CreateRemovingDeployment(),
             ProductDeploymentStatus.Removed => CreateRemovedDeployment(),
             ProductDeploymentStatus.Redeploying => CreateRedeployingDeployment(),
+            ProductDeploymentStatus.Superseded => CreateSupersededDeployment(),
             _ => throw new ArgumentOutOfRangeException(nameof(status))
         };
+    }
+
+    private static ProductDeployment CreateSupersededDeployment()
+    {
+        var pd = CreateRunningDeployment(1);
+        pd.MarkSuperseded(ProductDeploymentId.NewId());
+        return pd;
     }
 
     private static ProductDeployment CreateUpgradingDeployment()


### PR DESCRIPTION
## Summary

After an upgrade the old `ProductDeployment` row was left in its previous status (Running) while a new row was added for the target version. Both rows referenced the same underlying `DeploymentId`s because the upgrade reuses stack names in-place at the Docker level. As a result:

- The dashboard listed two product deployments after every upgrade.
- After removing the new deployment, the old row remained visible with **0 containers** (its `DeploymentId` references were dangling).

## Fix

- Introduce a new terminal `ProductDeploymentStatus.Superseded` and a `ProductDeployment.MarkSuperseded(successorId)` method.
- `UpgradeProductHandler` now marks the previous aggregate as `Superseded` immediately after creating the new aggregate.
- `IsTerminal` now covers both `Removed` and `Superseded`, so `ListProductDeploymentsHandler`, `GetEnvironmentHealthSummaryHandler`, `GetStackHealthHandler`, and `HealthCollectorService` filter the old row out automatically.
- Repository queries that hardcoded `Status != Removed` (`GetActiveByProductGroupId`, `GetByStackDeploymentId`) now also exclude `Superseded`.
- New `ProductDeploymentSuperseded` domain event makes the transition observable without misrepresenting it as a Docker removal (no `ProductDeploymentRemoved` is raised).

## Test plan
- [x] `dotnet build` — 0 errors, only pre-existing warnings
- [x] Unit tests — 2927 passing (incl. 6 new `MarkSuperseded` tests + transition-table InlineData + handler test)
- [x] Integration tests for `ProductDeploymentRepository` — 28 passing
- [ ] Manual: run an upgrade on test-amsproject, confirm only the new product deployment appears in the dashboard, then remove it and confirm no zombie row remains