### PR TITLE
fix(snmp): make container start and v3 user form work

### DIFF
--- a/src/ReadyStackGo.Api/Program.cs
+++ b/src/ReadyStackGo.Api/Program.cs
@@ -233,7 +233,16 @@ public class Program
 
         app.UseAuthentication();
         app.UseAuthorization();
-        app.UseFastEndpoints();
+        app.UseFastEndpoints(c =>
+        {
+            // Serialize enums as strings (PascalCase) for both request and response —
+            // the TypeScript clients (e.g. SnmpAuthProtocol = 'Sha256' | 'Md5' | ...)
+            // exchange enum values as strings. Without this, FastEndpoints would
+            // expect integers and POSTing the SNMPv3 user form would fail with
+            // "could not be converted to ReadyStackGo.Domain.Snmp.SnmpAuthProtocol".
+            c.Serializer.Options.Converters.Add(
+                new System.Text.Json.Serialization.JsonStringEnumConverter());
+        });
 
         // Map SignalR hubs
         app.MapHub<HealthHub>("/hubs/health");

--- a/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
+++ b/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
@@ -141,7 +141,13 @@ public static class DependencyInjection
         services.AddSingleton<IHealthCheckStrategy, DockerHealthCheckStrategy>();
         services.AddScoped<IHealthCheckStrategy, HttpHealthCheckStrategy>();
         services.AddSingleton<IHealthCheckStrategy, TcpHealthCheckStrategy>();
-        services.AddSingleton<IHealthCheckStrategyFactory, HealthCheckStrategyFactory>();
+        // Factory is Scoped because it consumes IEnumerable<IHealthCheckStrategy>,
+        // and HttpHealthCheckStrategy is Scoped (it wraps the typed HttpClient
+        // IHttpHealthChecker, which AddHttpClient registers as Transient and which
+        // therefore must not be captured by a Singleton). All current consumers of
+        // IHealthCheckStrategyFactory (HealthMonitoringService, HealthCollectorService)
+        // are themselves Scoped, so no behavior changes.
+        services.AddScoped<IHealthCheckStrategyFactory, HealthCheckStrategyFactory>();
 
         // SSH Tunnel services (v0.49)
         services.AddSingleton<ICredentialEncryptionService, CredentialEncryptionService>();


### PR DESCRIPTION
## Summary

Two latent bugs prevented the SNMP feature (v0.64/v0.65) from being usable on a clean `docker compose up` deployment. Both are surfaced as soon as you actually try to set up the agent.

### 1. Container fails to start (DI scope validation)

`HttpHealthCheckStrategy` is registered as **Scoped** (because it wraps `IHttpHealthChecker`, which `AddHttpClient<>` registers as Transient — capturing a typed HttpClient in a singleton is the wrong lifetime). But the `IHealthCheckStrategyFactory` was **Singleton** and resolved `IEnumerable<IHealthCheckStrategy>` — `WebApplication.CreateBuilder` runs scope validation in Development and refuses to build the container.

Repro: any clean clone, `docker compose up -d --build`, the container exits during startup with:
> Cannot consume scoped service 'IHealthCheckStrategy' from singleton 'IHealthCheckStrategyFactory'.

Fix: demote the factory to **Scoped**. All current consumers (`HealthMonitoringService`, `HealthCollectorService`) are already Scoped, so behaviour is unchanged at runtime.

### 2. Adding an SNMPv3 user fails with a JSON conversion error

FastEndpoints serialises enums as **integers** by default. The TypeScript clients in `@rsgo/core` and `ui-generic` send `SnmpAuthProtocol`/`SnmpPrivProtocol` as **strings** (`'Sha256'`, `'Aes128'`, …). Posting the user form returns:
> The JSON value could not be converted to ReadyStackGo.Domain.Snmp.SnmpAuthProtocol. Path: \$.authProtocol

Fix: register a global `JsonStringEnumConverter` in `app.UseFastEndpoints(c => …)` so request and response round-trip by name.

## Test plan
- [x] `docker compose down -v && docker compose up -d --build` — container reaches Healthy state (was: crash loop on scope validation)
- [x] Settings → SNMP Monitoring → Add user → Sha256/Aes128 → user appears in the list (was: 400 with JSON conversion error)
- [x] Existing E2E suite still passes