### PR TITLE
fix(api): stop serializing CancellationToken as response body on no-body endpoints

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/PrtgConnections/LinkPrtgConnectionEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/PrtgConnections/LinkPrtgConnectionEndpoint.cs
@@ -28,7 +28,10 @@ public class LinkPrtgConnectionEndpoint : Endpoint<LinkPrtgConnectionRequest>
             ThrowError(result.Error ?? "Failed to link PRTG connection.", StatusCodes.Status400BadRequest);
             return;
         }
-        await Send.OkAsync(ct);
+        // NoContent — Send.OkAsync(ct) binds `ct` positionally as TResponse and
+        // tries to serialize the CancellationToken (throws on WaitHandle.Handle
+        // IntPtr). This endpoint has no response body, so 204 is the right code.
+        await Send.NoContentAsync(ct);
     }
 }
 

--- a/src/ReadyStackGo.Api/Endpoints/PrtgConnections/PrtgConnectionEndpoints.cs
+++ b/src/ReadyStackGo.Api/Endpoints/PrtgConnections/PrtgConnectionEndpoints.cs
@@ -116,7 +116,7 @@ public class DeletePrtgConnectionEndpoint : Endpoint<DeletePrtgConnectionRequest
             ThrowError(result.Error ?? "Failed to delete PRTG connection.", StatusCodes.Status404NotFound);
             return;
         }
-        await Send.OkAsync(ct);
+        await Send.NoContentAsync(ct);
     }
 }
 

--- a/src/ReadyStackGo.Api/Endpoints/PrtgConnections/SetInlinePrtgRegistrationEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/PrtgConnections/SetInlinePrtgRegistrationEndpoint.cs
@@ -30,7 +30,7 @@ public class SetInlinePrtgRegistrationEndpoint : Endpoint<SetInlinePrtgRegistrat
             ThrowError(result.Error ?? "Failed to set inline PRTG registration.", StatusCodes.Status400BadRequest);
             return;
         }
-        await Send.OkAsync(ct);
+        await Send.NoContentAsync(ct);
     }
 }
 

--- a/src/ReadyStackGo.Api/Endpoints/Snmp/V3UsersEndpoints.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Snmp/V3UsersEndpoints.cs
@@ -75,7 +75,7 @@ public class UpdateV3UserEndpoint : Endpoint<UpdateV3UserRequest>
             ThrowError(result.ErrorMessage ?? "Failed", StatusCodes.Status400BadRequest);
             return;
         }
-        await Send.OkAsync(ct);
+        await Send.NoContentAsync(ct);
     }
 }
 
@@ -104,7 +104,7 @@ public class DeleteV3UserEndpoint : Endpoint<DeleteV3UserRequest>
             ThrowError(result.ErrorMessage ?? "Failed", StatusCodes.Status404NotFound);
             return;
         }
-        await Send.OkAsync(ct);
+        await Send.NoContentAsync(ct);
     }
 }
 

--- a/tests/ReadyStackGo.IntegrationTests/PrtgConnectionLinkIntegrationTests.cs
+++ b/tests/ReadyStackGo.IntegrationTests/PrtgConnectionLinkIntegrationTests.cs
@@ -1,0 +1,87 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using ReadyStackGo.Domain.Deployment;
+using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.Deployment.ProductDeployments;
+using ReadyStackGo.Infrastructure.DataAccess;
+using ReadyStackGo.IntegrationTests.Infrastructure;
+
+namespace ReadyStackGo.IntegrationTests;
+
+/// <summary>
+/// Reproduces the "Save link" 500 — clicking the saved-PRTG-connection picker
+/// on the deployment detail page returned Internal Server Error.
+/// </summary>
+public class PrtgConnectionLinkIntegrationTests : AuthenticatedTestBase
+{
+    [Fact]
+    public async Task LinkPrtgConnection_OnExistingDeployment_DoesNotReturn500()
+    {
+        var connectionId = await CreatePrtgConnectionAsync("repro-prtg");
+        var productDeploymentId = SeedProductDeployment();
+
+        var response = await Client.PutAsJsonAsync(
+            $"/api/deployments/{productDeploymentId}/prtg-connection",
+            new { id = productDeploymentId, prtgConnectionId = connectionId });
+
+        var body = await response.Content.ReadAsStringAsync();
+        // Print whatever we got so a failing test surfaces the real reason.
+        response.StatusCode.Should().NotBe(HttpStatusCode.InternalServerError,
+            $"server returned 500 — body: {body}");
+        response.IsSuccessStatusCode.Should().BeTrue($"unexpected status {response.StatusCode} — body: {body}");
+    }
+
+    private async Task<Guid> CreatePrtgConnectionAsync(string name)
+    {
+        var req = new
+        {
+            name,
+            url = "https://prtg.example.local",
+            apiToken = "fake-api-token-for-test",
+            templateDeviceId = (int?)null,
+            verifyTls = true,
+        };
+        var response = await Client.PostAsJsonAsync("/api/prtg-connections", req);
+        var body = await response.Content.ReadAsStringAsync();
+        response.IsSuccessStatusCode.Should().BeTrue($"connection create failed: {response.StatusCode} {body}");
+        var dto = System.Text.Json.JsonDocument.Parse(body);
+        var connectionElement = dto.RootElement.GetProperty("connection");
+        return connectionElement.GetProperty("id").GetGuid();
+    }
+
+    private Guid SeedProductDeployment()
+    {
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ReadyStackGoDbContext>();
+
+        var id = ProductDeploymentId.Create();
+        var deployment = ProductDeployment.InitiateDeployment(
+            id,
+            new EnvironmentId(Guid.Parse(EnvironmentId)),
+            productGroupId: "repro:product",
+            productId: "repro:product:1.0.0",
+            productName: "Repro Product",
+            productDisplayName: "Repro Product",
+            productVersion: "1.0.0",
+            deployedBy: new UserId(Guid.NewGuid()),
+            deploymentName: "repro-deployment",
+            stackConfigs: new[]
+            {
+                new StackDeploymentConfig(
+                    StackName: "repro-stack",
+                    StackDisplayName: "Repro Stack",
+                    StackId: "repro:stack:1.0.0",
+                    ServiceCount: 1,
+                    Variables: new Dictionary<string, string>()),
+            },
+            sharedVariables: new Dictionary<string, string>(),
+            continueOnError: true);
+
+        db.ProductDeployments.Add(deployment);
+        db.SaveChanges();
+
+        return id.Value;
+    }
+}


### PR DESCRIPTION
## Bug

Five endpoints returned **500 Internal Server Error** on every success path:

- `PUT /api/deployments/{id}/prtg-connection` (link reusable PRTG connection) — user-visible: "Save link" on deployment detail page
- `PUT /api/deployments/{id}/prtg-inline` (set inline PRTG registration)
- `DELETE /api/prtg-connections/{id}` (delete saved PRTG connection)
- `PUT /api/snmp/v3-users/{id}` (update SNMP v3 user)
- `DELETE /api/snmp/v3-users/{id}` (delete SNMP v3 user)

The frontend showed "API request failed: Internal Server Error" with no detail.

## Root cause

`Send.OkAsync(ct)` on `Endpoint<TRequest>` (no TResponse) is resolved by the compiler positionally to:

```csharp
SendOkAsync<TResponse>(TResponse response, CancellationToken ct = default)
```

— so the `CancellationToken` gets bound as the **response object**. System.Text.Json then walks into `CancellationToken.WaitHandle.Handle` (IntPtr), refuses to serialize it, and throws `NotSupportedException`:

```
System.NotSupportedException: Serialization and deserialization of 'System.IntPtr' instances is not supported. Path: $.WaitHandle.Handle.
   at FastEndpoints.HttpResponseExtensions.SendOkAsync[TResponse](HttpResponse rsp, TResponse response, ...)
   at ReadyStackGo.Api.Endpoints.PrtgConnections.LinkPrtgConnectionEndpoint.HandleAsync(...)
```

## Fix

Replace `Send.OkAsync(ct)` with `Send.NoContentAsync(ct)` on all five endpoints. These actions have no response body anyway, so 204 is the semantically correct status, and there is nothing to serialize.

The `apiPut` / `apiDelete` clients already handle 204 (early-return `undefined`).

## Test plan

- [x] New `PrtgConnectionLinkIntegrationTests.LinkPrtgConnection_OnExistingDeployment_DoesNotReturn500` reproduces the exact failing PUT — fails on old code with the IntPtr exception, passes after the fix.
- [x] `dotnet build` — 0 errors
- [x] `dotnet test --filter PrtgConnection` — green
- [ ] Manual: rebuild container, click Save link in deployment detail PRTG card, verify it persists without 500