### PR TITLE
feat(stack-sources): add ams.project CI channel to preconfigured catalog

### DIFF
--- a/src/ReadyStackGo.Infrastructure/Services/StackSources/source-registry.json
+++ b/src/ReadyStackGo.Infrastructure/Services/StackSources/source-registry.json
@@ -48,5 +48,17 @@
     "tags": ["enterprise", "vendor", "ams", "rc", "pre-release"],
     "featured": false,
     "stackCount": 2
+  },
+  {
+    "id": "rsgo-ams-project-ci",
+    "name": "ams.project Stacks (CI)",
+    "description": "Continuous-integration stacks for ams.project and ams.identityaccess — latest *-ci manifests for test and evaluation environments",
+    "type": "git-repository",
+    "gitUrl": "https://github.com/Wiesenwischer/rsgo-ams-project-ci.git",
+    "gitBranch": "main",
+    "category": "vendor",
+    "tags": ["enterprise", "vendor", "ams", "ci", "latest"],
+    "featured": false,
+    "stackCount": 2
   }
 ]


### PR DESCRIPTION
## Summary

Adds the **ams.project CI channel** as a preconfigured catalog source, completing the CI / RC / Stable trio for the ams.project stacks.

| Channel | Repository | Entry |
|---------|------------|-------|
| Stable | `rsgo-ams-project` | existing |
| RC | `rsgo-ams-project-rc` | existing |
| **CI** | `rsgo-ams-project-ci` | **added here** |

The new public manifest repo `github.com/Wiesenwischer/rsgo-ams-project-ci` holds the latest `*-ci` manifests for `ams.project` (4.0.0-ci) and `ams.identityaccess` (1.0.0-ci).

## Effect

Operators can add the source in one click via **Settings > Stack Sources > Add Source > From Catalog** or during the setup wizard, without typing the Git URL. Consistent with the sibling entries it is `category: vendor`, `featured: false`.

## Notes

- JSON-only change to the embedded `source-registry.json`; no code paths affected.
- Public repo only, no credentials (matches the registry's public-source policy).