### PR TITLE
feat(stack-sources): replace ams.project CI channel with Preview channel

### DIFF
--- a/src/ReadyStackGo.Infrastructure/Services/StackSources/source-registry.json
+++ b/src/ReadyStackGo.Infrastructure/Services/StackSources/source-registry.json
@@ -50,14 +50,14 @@
     "stackCount": 2
   },
   {
-    "id": "rsgo-ams-project-ci",
-    "name": "ams.project Stacks (CI)",
-    "description": "Continuous-integration stacks for ams.project and ams.identityaccess — latest *-ci manifests for test and evaluation environments",
+    "id": "rsgo-ams-project-preview",
+    "name": "ams.project Stacks (Preview)",
+    "description": "Preview-version stacks for ams.project and ams.identityaccess — early preview builds for evaluation and pre-release testing",
     "type": "git-repository",
-    "gitUrl": "https://github.com/Wiesenwischer/rsgo-ams-project-ci.git",
+    "gitUrl": "https://github.com/Wiesenwischer/rsgo-ams-project-preview.git",
     "gitBranch": "main",
     "category": "vendor",
-    "tags": ["enterprise", "vendor", "ams", "ci", "latest"],
+    "tags": ["enterprise", "vendor", "ams", "preview", "pre-release"],
     "featured": false,
     "stackCount": 2
   }


### PR DESCRIPTION
## Summary

Replaces the ams.project **CI** catalog channel with a new **Preview** channel.

## Changes
- **Add** `rsgo-ams-project-preview` — preview builds of ams.project (4.0) and ams.identityaccess (3.2), public repo `rsgo-ams-project-preview`, same per-minor manifest layout as the stable/RC sources.
- **Remove** `rsgo-ams-project-ci` — customers must not install CI builds.

## Notes
- Catalog is defined solely in `source-registry.json` (embedded resource); no other references to the CI channel exist in the repo or docs.
- Preview repo verified public + reachable on `main`.
- `SourceRegistryServiceTests` (13) pass; `dotnet build` 0 errors.