### PR TITLE
fix(stack-sources): offer only ams.project Preview channel (remove stable + RC)

### DIFF
--- a/src/ReadyStackGo.Infrastructure/Services/StackSources/source-registry.json
+++ b/src/ReadyStackGo.Infrastructure/Services/StackSources/source-registry.json
@@ -26,18 +26,6 @@
     "stackCount": 1
   },
   {
-    "id": "rsgo-ams-project-stacks",
-    "name": "ams.project Stacks",
-    "description": "Stable release stacks for ams.project and ams.identityaccess by ams.Solution AG",
-    "type": "git-repository",
-    "gitUrl": "https://github.com/Wiesenwischer/rsgo-ams-project.git",
-    "gitBranch": "main",
-    "category": "vendor",
-    "tags": ["enterprise", "vendor", "ams", "stable"],
-    "featured": false,
-    "stackCount": 2
-  },
-  {
     "id": "rsgo-ams-project-rc",
     "name": "ams.project Stacks (RC)",
     "description": "Release candidate stacks for ams.project and ams.identityaccess — pre-release testing",

--- a/src/ReadyStackGo.Infrastructure/Services/StackSources/source-registry.json
+++ b/src/ReadyStackGo.Infrastructure/Services/StackSources/source-registry.json
@@ -26,18 +26,6 @@
     "stackCount": 1
   },
   {
-    "id": "rsgo-ams-project-rc",
-    "name": "ams.project Stacks (RC)",
-    "description": "Release candidate stacks for ams.project and ams.identityaccess — pre-release testing",
-    "type": "git-repository",
-    "gitUrl": "https://github.com/Wiesenwischer/rsgo-ams-project-rc.git",
-    "gitBranch": "main",
-    "category": "vendor",
-    "tags": ["enterprise", "vendor", "ams", "rc", "pre-release"],
-    "featured": false,
-    "stackCount": 2
-  },
-  {
     "id": "rsgo-ams-project-preview",
     "name": "ams.project Stacks (Preview)",
     "description": "Preview-version stacks for ams.project and ams.identityaccess — early preview builds for evaluation and pre-release testing",

--- a/tests/ReadyStackGo.UnitTests/Services/SourceRegistryServiceTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Services/SourceRegistryServiceTests.cs
@@ -88,24 +88,37 @@ public class SourceRegistryServiceTests
     }
 
     [Fact]
-    public void GetAll_ContainsAmsProjectStacksEntry()
+    public void GetAll_DoesNotContainStableAmsProjectStacksEntry()
+    {
+        // The stable "ams.project Stacks" channel was removed from the registry
+        // because there is currently no production-ready ams.project version.
+        var service = CreateService();
+
+        var entries = service.GetAll();
+
+        entries.Should().NotContain(e => e.Id == "rsgo-ams-project-stacks");
+    }
+
+    [Fact]
+    public void GetAll_ContainsAmsProjectPreReleaseEntries()
     {
         var service = CreateService();
 
         var entries = service.GetAll();
 
-        entries.Should().Contain(e => e.Id == "rsgo-ams-project-stacks");
+        entries.Should().Contain(e => e.Id == "rsgo-ams-project-rc");
+        entries.Should().Contain(e => e.Id == "rsgo-ams-project-preview");
     }
 
     [Fact]
-    public void GetAll_AmsProjectStacksHasCorrectData()
+    public void GetAll_AmsProjectPreviewHasCorrectData()
     {
         var service = CreateService();
 
-        var entry = service.GetAll().First(e => e.Id == "rsgo-ams-project-stacks");
+        var entry = service.GetAll().First(e => e.Id == "rsgo-ams-project-preview");
 
-        entry.Name.Should().Be("ams.project Stacks");
-        entry.GitUrl.Should().Contain("github.com/Wiesenwischer/rsgo-ams-project");
+        entry.Name.Should().Be("ams.project Stacks (Preview)");
+        entry.GitUrl.Should().Contain("github.com/Wiesenwischer/rsgo-ams-project-preview");
         entry.GitBranch.Should().Be("main");
         entry.Category.Should().Be("vendor");
         entry.Featured.Should().BeFalse();

--- a/tests/ReadyStackGo.UnitTests/Services/SourceRegistryServiceTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Services/SourceRegistryServiceTests.cs
@@ -88,25 +88,26 @@ public class SourceRegistryServiceTests
     }
 
     [Fact]
-    public void GetAll_DoesNotContainStableAmsProjectStacksEntry()
+    public void GetAll_DoesNotContainStableOrRcAmsProjectChannels()
     {
-        // The stable "ams.project Stacks" channel was removed from the registry
-        // because there is currently no production-ready ams.project version.
+        // Only the Preview channel is currently offered: there is no
+        // production-ready ams.project version (stable removed) and the RC
+        // channel has been retired as well.
         var service = CreateService();
 
         var entries = service.GetAll();
 
         entries.Should().NotContain(e => e.Id == "rsgo-ams-project-stacks");
+        entries.Should().NotContain(e => e.Id == "rsgo-ams-project-rc");
     }
 
     [Fact]
-    public void GetAll_ContainsAmsProjectPreReleaseEntries()
+    public void GetAll_ContainsAmsProjectPreviewEntry()
     {
         var service = CreateService();
 
         var entries = service.GetAll();
 
-        entries.Should().Contain(e => e.Id == "rsgo-ams-project-rc");
         entries.Should().Contain(e => e.Id == "rsgo-ams-project-preview");
     }
 


### PR DESCRIPTION
## Summary

There is currently no production-ready ams.project version, and the RC channel is no longer needed. Among the AMS vendor channels, only **Preview** should be offerable when adding stack sources.

## Changes

- Remove the stable `rsgo-ams-project-stacks` entry from the source registry.
- Remove the `rsgo-ams-project-rc` entry from the source registry.
- Keep `rsgo-ams-project-preview` (the only AMS channel currently needed).
- Update `SourceRegistryServiceTests` to assert the stable and RC entries are gone and the Preview entry remains.

## Notes

- This only affects the *available-to-add* registry list. Already-active stack sources on running instances are unaffected, so existing deployments and the RC→Preview identityaccess upgrade path (driven by the active Preview source) keep working.
- Remaining sources after this change: `rsgo-embedded-stacks`, `rsgo-community-stacks`, `rsgo-ams-project-preview`.