### PR TITLE
Server-side logout via token revocation

### DIFF
--- a/src/ReadyStackGo.Api/Endpoints/Auth/LogoutEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Auth/LogoutEndpoint.cs
@@ -1,21 +1,35 @@
 using FastEndpoints;
-using Microsoft.AspNetCore.Http;
+using ReadyStackGo.Application.Services;
 
 namespace ReadyStackGo.API.Endpoints.Auth;
 
 public class LogoutEndpoint : EndpointWithoutRequest
 {
+    private readonly ITokenRevocationService _revocation;
+
+    public LogoutEndpoint(ITokenRevocationService revocation)
+    {
+        _revocation = revocation;
+    }
+
     public override void Configure()
     {
         Post("/api/auth/logout");
-        AllowAnonymous(); // Logout doesn't require authentication
+        AllowAnonymous(); // A present bearer token is still authenticated by the middleware.
     }
 
     public override Task HandleAsync(CancellationToken ct)
     {
-        // For JWT, logout is handled client-side by removing the token
-        // In the future, we could add token blacklisting if needed
-        // FastEndpoints will automatically return 200 OK for successful completion
+        // Revoke the current token server-side so it can no longer be used before its expiry.
+        // The client also clears it locally. If no valid token was sent, this is a no-op.
+        var jti = HttpContext.User.FindFirst("jti")?.Value;
+        var expClaim = HttpContext.User.FindFirst("exp")?.Value;
+
+        if (!string.IsNullOrEmpty(jti) && long.TryParse(expClaim, out var expUnix))
+        {
+            _revocation.Revoke(jti, DateTimeOffset.FromUnixTimeSeconds(expUnix));
+        }
+
         return Task.CompletedTask;
     }
 }

--- a/src/ReadyStackGo.Api/Program.cs
+++ b/src/ReadyStackGo.Api/Program.cs
@@ -73,6 +73,22 @@ public class Program
                         }
 
                         return Task.CompletedTask;
+                    },
+                    // Reject tokens that have been revoked (server-side logout).
+                    OnTokenValidated = context =>
+                    {
+                        var jti = context.Principal?.FindFirst("jti")?.Value;
+                        if (!string.IsNullOrEmpty(jti))
+                        {
+                            var revocation = context.HttpContext.RequestServices
+                                .GetRequiredService<ReadyStackGo.Application.Services.ITokenRevocationService>();
+                            if (revocation.IsRevoked(jti))
+                            {
+                                context.Fail("Token has been revoked.");
+                            }
+                        }
+
+                        return Task.CompletedTask;
                     }
                 };
             })

--- a/src/ReadyStackGo.Application/Services/ITokenRevocationService.cs
+++ b/src/ReadyStackGo.Application/Services/ITokenRevocationService.cs
@@ -1,0 +1,15 @@
+namespace ReadyStackGo.Application.Services;
+
+/// <summary>
+/// Tracks revoked session tokens by their JWT id (jti) so that a logout takes effect
+/// server-side before the token would naturally expire. In-memory and best-effort
+/// (single-instance deployments); entries auto-expire at the token's own expiry.
+/// </summary>
+public interface ITokenRevocationService
+{
+    /// <summary>Marks a token (by jti) as revoked until its expiry.</summary>
+    void Revoke(string jti, DateTimeOffset expiresAt);
+
+    /// <summary>True if the token id has been revoked and has not yet expired.</summary>
+    bool IsRevoked(string jti);
+}

--- a/src/ReadyStackGo.Infrastructure.Security/Authentication/TokenRevocationService.cs
+++ b/src/ReadyStackGo.Infrastructure.Security/Authentication/TokenRevocationService.cs
@@ -1,0 +1,51 @@
+using System.Collections.Concurrent;
+using ReadyStackGo.Application.Services;
+
+namespace ReadyStackGo.Infrastructure.Security.Authentication;
+
+/// <summary>
+/// In-memory token revocation store keyed by jti, with each entry holding the token's
+/// expiry (unix seconds). Expired entries are pruned lazily, so the set stays bounded by
+/// the number of unexpired revoked tokens.
+/// </summary>
+public class TokenRevocationService : ITokenRevocationService
+{
+    private readonly ConcurrentDictionary<string, long> _revoked = new();
+
+    public void Revoke(string jti, DateTimeOffset expiresAt)
+    {
+        if (string.IsNullOrEmpty(jti))
+            return;
+
+        Prune();
+        _revoked[jti] = expiresAt.ToUnixTimeSeconds();
+    }
+
+    public bool IsRevoked(string jti)
+    {
+        if (string.IsNullOrEmpty(jti))
+            return false;
+
+        if (!_revoked.TryGetValue(jti, out var expiresAtUnix))
+            return false;
+
+        if (expiresAtUnix <= DateTimeOffset.UtcNow.ToUnixTimeSeconds())
+        {
+            // Token would be rejected by lifetime validation anyway; drop the entry.
+            _revoked.TryRemove(jti, out _);
+            return false;
+        }
+
+        return true;
+    }
+
+    private void Prune()
+    {
+        var nowUnix = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        foreach (var entry in _revoked)
+        {
+            if (entry.Value <= nowUnix)
+                _revoked.TryRemove(entry.Key, out _);
+        }
+    }
+}

--- a/src/ReadyStackGo.Infrastructure.Security/DependencyInjection.cs
+++ b/src/ReadyStackGo.Infrastructure.Security/DependencyInjection.cs
@@ -15,6 +15,7 @@ public static class DependencyInjection
         services.AddSingleton<ITokenService, TokenService>();
         services.AddSingleton<IEmailVerificationTokenService, EmailVerificationTokenService>();
         services.AddSingleton<IPasswordResetTokenService, PasswordResetTokenService>();
+        services.AddSingleton<ITokenRevocationService, TokenRevocationService>();
         services.AddSingleton<Application.Services.Oidc.IOidcService, OidcService>();
         services.AddSingleton<IRbacService, RbacService>();
 

--- a/tests/ReadyStackGo.UnitTests/Infrastructure/Security/TokenRevocationServiceTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Infrastructure/Security/TokenRevocationServiceTests.cs
@@ -1,0 +1,58 @@
+using FluentAssertions;
+using ReadyStackGo.Infrastructure.Security.Authentication;
+
+namespace ReadyStackGo.UnitTests.Infrastructure.Security;
+
+public class TokenRevocationServiceTests
+{
+    [Fact]
+    public void Revoke_then_IsRevoked_ReturnsTrue()
+    {
+        var sut = new TokenRevocationService();
+
+        sut.Revoke("jti-1", DateTimeOffset.UtcNow.AddHours(1));
+
+        sut.IsRevoked("jti-1").Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRevoked_UnknownToken_ReturnsFalse()
+    {
+        var sut = new TokenRevocationService();
+
+        sut.IsRevoked("never-seen").Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsRevoked_ExpiredRevocation_ReturnsFalse()
+    {
+        var sut = new TokenRevocationService();
+
+        // Already past expiry — the lifetime check would reject it anyway.
+        sut.Revoke("jti-old", DateTimeOffset.UtcNow.AddMinutes(-5));
+
+        sut.IsRevoked("jti-old").Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Revoke_BlankJti_IsNoOp(string? jti)
+    {
+        var sut = new TokenRevocationService();
+
+        sut.Revoke(jti!, DateTimeOffset.UtcNow.AddHours(1));
+
+        sut.IsRevoked(jti!).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Revoke_DoesNotAffectOtherTokens()
+    {
+        var sut = new TokenRevocationService();
+
+        sut.Revoke("jti-1", DateTimeOffset.UtcNow.AddHours(1));
+
+        sut.IsRevoked("jti-2").Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
Makes logout effective **server-side**: until now logout only cleared the token client-side, so a leaked JWT stayed valid until expiry. This adds a revocation list so a logged-out token is rejected immediately. Follows up on #422.

## What's included
- `ITokenRevocationService` + in-memory implementation keyed by `jti`; entries auto-expire at the token's own expiry and are pruned lazily (bounded by the number of unexpired revoked tokens)
- `POST /api/auth/logout` revokes the current token's `jti`
- JWT bearer `OnTokenValidated` rejects revoked tokens (401)
- Unit tests for the revocation store (revoke/expire/unknown/blank/isolation)

## Notes
- In-memory and best-effort, sufficient for single-instance deployments. A multi-instance setup would need a shared store (e.g. the existing config/DB) — out of scope here.
- Backend-only; the frontend already calls `/api/auth/logout`.

## Testing
- `dotnet build`: 0 errors, no new warnings
- Unit tests: **3022 passing** (5 new)