### PR TITLE
Active maintenance setter (mirror of the observer)

### DIFF
--- a/src/ReadyStackGo.Application/Services/IMaintenanceSetterService.cs
+++ b/src/ReadyStackGo.Application/Services/IMaintenanceSetterService.cs
@@ -1,0 +1,16 @@
+using ReadyStackGo.Domain.Deployment.Observers;
+
+namespace ReadyStackGo.Application.Services;
+
+/// <summary>
+/// Applies a maintenance setter (writes the SQL flag / calls the webhook) for an RSGO-initiated
+/// maintenance transition. Best-effort: never throws; returns the outcome so the caller can
+/// surface it without aborting the transition.
+/// </summary>
+public interface IMaintenanceSetterService
+{
+    Task<SetterResult> ApplyAsync(
+        MaintenanceSetterConfig? config,
+        MaintenanceState state,
+        CancellationToken cancellationToken = default);
+}

--- a/src/ReadyStackGo.Application/Services/Impl/MaintenanceSetterService.cs
+++ b/src/ReadyStackGo.Application/Services/Impl/MaintenanceSetterService.cs
@@ -1,0 +1,60 @@
+using Microsoft.Extensions.Logging;
+using ReadyStackGo.Domain.Deployment.Observers;
+
+namespace ReadyStackGo.Application.Services.Impl;
+
+/// <summary>
+/// Creates the configured setter via the factory and invokes it, turning any exception into a
+/// non-fatal failure result. No-ops (skips) when no setter is configured.
+/// </summary>
+public class MaintenanceSetterService : IMaintenanceSetterService
+{
+    private readonly IMaintenanceSetterFactory _factory;
+    private readonly ILogger<MaintenanceSetterService> _logger;
+
+    public MaintenanceSetterService(
+        IMaintenanceSetterFactory factory,
+        ILogger<MaintenanceSetterService> logger)
+    {
+        _factory = factory;
+        _logger = logger;
+    }
+
+    public async Task<SetterResult> ApplyAsync(
+        MaintenanceSetterConfig? config,
+        MaintenanceState state,
+        CancellationToken cancellationToken = default)
+    {
+        if (config == null)
+        {
+            return SetterResult.WasSkipped("No maintenance setter configured");
+        }
+
+        if (!_factory.IsSupported(config.Type))
+        {
+            _logger.LogWarning("Maintenance setter type {Type} is not supported", config.Type);
+            return SetterResult.Failed($"Unsupported setter type: {config.Type}");
+        }
+
+        try
+        {
+            var setter = _factory.Create(config);
+            var result = await setter.SetAsync(state, cancellationToken);
+
+            if (!result.Success)
+            {
+                // The setter itself logs details (without secrets); keep this terse.
+                _logger.LogWarning("Maintenance setter ({Type}) failed for state {State}: {Error}",
+                    config.Type, state, result.Error);
+            }
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Maintenance setter ({Type}) threw while applying state {State}",
+                config.Type, state);
+            return SetterResult.Failed(ex.Message);
+        }
+    }
+}

--- a/src/ReadyStackGo.Application/Services/MaintenanceSetterConfigMapper.cs
+++ b/src/ReadyStackGo.Application/Services/MaintenanceSetterConfigMapper.cs
@@ -1,0 +1,107 @@
+using ReadyStackGo.Domain.Deployment.Observers;
+using ReadyStackGo.Domain.StackManagement.Manifests;
+
+namespace ReadyStackGo.Application.Services;
+
+/// <summary>
+/// Maps a <see cref="RsgoMaintenanceSetter"/> (manifest) to a <see cref="MaintenanceSetterConfig"/>
+/// (deployment domain), resolving ${VAR} placeholders against a variable dictionary.
+/// Mirror of <see cref="MaintenanceObserverConfigMapper"/>.
+/// </summary>
+public static class MaintenanceSetterConfigMapper
+{
+    public static MaintenanceSetterConfig? Map(
+        RsgoMaintenanceSetter? source,
+        IReadOnlyDictionary<string, string> variables)
+    {
+        if (source == null)
+            return null;
+
+        var type = source.Type?.Trim().ToLowerInvariant();
+        var gracePeriod = ParseTimeSpan(source.GracePeriod) ?? TimeSpan.Zero;
+
+        if (type == "sqlextendedproperty")
+        {
+            var connectionString = ResolveConnectionString(source, variables);
+            if (string.IsNullOrEmpty(connectionString) || string.IsNullOrWhiteSpace(source.PropertyName))
+                return null;
+
+            var settings = new SqlSetterSettings(connectionString, source.PropertyName);
+
+            return MaintenanceSetterConfig.Create(
+                SetterType.SqlExtendedProperty,
+                gracePeriod,
+                source.MaintenanceValue ?? "1",
+                source.NormalValue ?? "0",
+                settings);
+        }
+
+        if (type == "webhook")
+        {
+            var url = ResolveVariables(source.Url ?? string.Empty, variables);
+            if (string.IsNullOrEmpty(url))
+                return null;
+
+            var secret = string.IsNullOrEmpty(source.Secret) ? null : ResolveVariables(source.Secret, variables);
+            var timeout = ParseTimeSpan(source.Timeout) ?? TimeSpan.FromSeconds(10);
+
+            var settings = new WebhookSetterSettings(url, secret, timeout, source.Retries ?? 2);
+
+            return MaintenanceSetterConfig.Create(
+                SetterType.Webhook,
+                gracePeriod,
+                source.MaintenanceValue ?? "maintenance",
+                source.NormalValue ?? "normal",
+                settings);
+        }
+
+        return null;
+    }
+
+    private static string? ResolveConnectionString(
+        RsgoMaintenanceSetter source,
+        IReadOnlyDictionary<string, string> variables)
+    {
+        if (!string.IsNullOrEmpty(source.ConnectionString))
+            return ResolveVariables(source.ConnectionString, variables);
+
+        if (!string.IsNullOrEmpty(source.ConnectionName) &&
+            variables.TryGetValue(source.ConnectionName, out var connectionString))
+        {
+            return connectionString;
+        }
+
+        return null;
+    }
+
+    private static string? ResolveVariables(string template, IReadOnlyDictionary<string, string> variables)
+    {
+        if (string.IsNullOrEmpty(template))
+            return template;
+
+        var result = template;
+        foreach (var kvp in variables)
+        {
+            result = result.Replace($"${{{kvp.Key}}}", kvp.Value);
+        }
+
+        return result.Contains("${") ? null : result;
+    }
+
+    private static TimeSpan? ParseTimeSpan(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return null;
+
+        value = value.Trim().ToLowerInvariant();
+
+        if (value.EndsWith('s') && int.TryParse(value[..^1], out var seconds))
+            return TimeSpan.FromSeconds(seconds);
+        if (value.EndsWith('m') && int.TryParse(value[..^1], out var minutes))
+            return TimeSpan.FromMinutes(minutes);
+        if (value.EndsWith('h') && int.TryParse(value[..^1], out var hours))
+            return TimeSpan.FromHours(hours);
+
+        return null;
+    }
+}

--- a/src/ReadyStackGo.Application/UseCases/Deployments/ChangeProductOperationMode/ChangeProductOperationModeCommand.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/ChangeProductOperationMode/ChangeProductOperationModeCommand.cs
@@ -25,8 +25,15 @@ public record ChangeProductOperationModeResponse
     public string? NewMode { get; init; }
     public string? TriggerSource { get; init; }
 
+    /// <summary>
+    /// Non-fatal error from propagating the state to the product via the maintenance setter
+    /// (SQL write / webhook). Null when no setter is configured or it succeeded.
+    /// </summary>
+    public string? SetterError { get; init; }
+
     public static ChangeProductOperationModeResponse Ok(
-        string productDeploymentId, string previousMode, string newMode, string? triggerSource = null) =>
+        string productDeploymentId, string previousMode, string newMode,
+        string? triggerSource = null, string? setterError = null) =>
         new()
         {
             Success = true,
@@ -34,6 +41,7 @@ public record ChangeProductOperationModeResponse
             PreviousMode = previousMode,
             NewMode = newMode,
             TriggerSource = triggerSource,
+            SetterError = setterError,
             Message = $"Operation mode changed from {previousMode} to {newMode}"
         };
 

--- a/src/ReadyStackGo.Application/UseCases/Deployments/ChangeProductOperationMode/ChangeProductOperationModeHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/ChangeProductOperationMode/ChangeProductOperationModeHandler.cs
@@ -22,6 +22,7 @@ public class ChangeProductOperationModeHandler
     private readonly IDeploymentRepository _deploymentRepository;
     private readonly IDockerService _dockerService;
     private readonly IHealthNotificationService _healthNotificationService;
+    private readonly IMaintenanceSetterService _maintenanceSetterService;
     private readonly ILogger<ChangeProductOperationModeHandler> _logger;
 
     public ChangeProductOperationModeHandler(
@@ -29,12 +30,14 @@ public class ChangeProductOperationModeHandler
         IDeploymentRepository deploymentRepository,
         IDockerService dockerService,
         IHealthNotificationService healthNotificationService,
+        IMaintenanceSetterService maintenanceSetterService,
         ILogger<ChangeProductOperationModeHandler> logger)
     {
         _productDeploymentRepository = productDeploymentRepository;
         _deploymentRepository = deploymentRepository;
         _dockerService = dockerService;
         _healthNotificationService = healthNotificationService;
+        _maintenanceSetterService = maintenanceSetterService;
         _logger = logger;
     }
 
@@ -113,12 +116,44 @@ public class ChangeProductOperationModeHandler
             "Changed operation mode for product deployment {ProductDeploymentId} ({ProductName}) from {PreviousMode} to {NewMode}",
             request.ProductDeploymentId, productDeployment.ProductName, previousMode.Name, targetMode.Name);
 
+        // Propagate the state to the product via the maintenance setter (best-effort).
+        // Loop protection: only fire for Manual transitions. Observer-initiated transitions
+        // mean the product already set the flag itself — re-writing would be redundant and
+        // could drive a feedback loop.
+        var fireSetter = source == MaintenanceTriggerSource.Manual;
+        var setterConfig = productDeployment.MaintenanceSetterConfig;
+        SetterResult? setterResult = null;
+
+        if (targetMode == OperationMode.Maintenance && fireSetter)
+        {
+            setterResult = await _maintenanceSetterService.ApplyAsync(
+                setterConfig, MaintenanceState.Maintenance, cancellationToken);
+
+            // Optional grace window: let the product drain clients before containers stop.
+            if (setterConfig is { GracePeriod.Ticks: > 0 })
+            {
+                _logger.LogInformation(
+                    "Waiting {GraceSeconds}s grace period before stopping containers for {ProductDeploymentId}",
+                    setterConfig.GracePeriod.TotalSeconds, request.ProductDeploymentId);
+                await Task.Delay(setterConfig.GracePeriod, cancellationToken);
+            }
+        }
+
         // Handle container lifecycle and propagate operation mode to ALL child stacks
         await HandleContainerLifecycleAsync(
             productDeployment, previousMode, targetMode, trigger, source, cancellationToken);
 
+        if (targetMode == OperationMode.Normal && fireSetter)
+        {
+            // Fire after containers have been started again (health verification is the caller's concern).
+            setterResult = await _maintenanceSetterService.ApplyAsync(
+                setterConfig, MaintenanceState.Normal, cancellationToken);
+        }
+
+        var setterError = setterResult is { Success: false } ? setterResult.Error : null;
+
         return ChangeProductOperationModeResponse.Ok(
-            request.ProductDeploymentId, previousMode.Name, targetMode.Name, source.ToString());
+            request.ProductDeploymentId, previousMode.Name, targetMode.Name, source.ToString(), setterError);
     }
 
     private async Task HandleContainerLifecycleAsync(

--- a/src/ReadyStackGo.Application/UseCases/Deployments/DeployProduct/DeployProductHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/DeployProduct/DeployProductHandler.cs
@@ -160,6 +160,17 @@ public class DeployProductHandler : IRequestHandler<DeployProductCommand, Deploy
             }
         }
 
+        // Resolve and attach the product-level maintenance setter config (mirror of observer).
+        var setterConfig = MaintenanceSetterConfigMapper.Map(
+            product.MaintenanceSetter, request.SharedVariables);
+        if (setterConfig != null)
+        {
+            productDeployment.SetMaintenanceSetterConfig(setterConfig);
+            _logger.LogInformation(
+                "Product deployment {ProductDeploymentId} wired maintenance setter type={SetterType}",
+                productDeploymentId, setterConfig.Type);
+        }
+
         _repository.Add(productDeployment);
         _repository.SaveChanges();
 

--- a/src/ReadyStackGo.Application/UseCases/Deployments/RedeployProduct/RedeployProductHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/RedeployProduct/RedeployProductHandler.cs
@@ -88,6 +88,10 @@ public class RedeployProductHandler : IRequestHandler<RedeployProductCommand, De
                     product.MaintenanceObserver, observerVariables);
                 productDeployment.SetMaintenanceObserverConfig(observerConfig);
 
+                // Refresh the maintenance setter config too (mirror of the observer).
+                productDeployment.SetMaintenanceSetterConfig(
+                    MaintenanceSetterConfigMapper.Map(product.MaintenanceSetter, observerVariables));
+
                 if (observerConfig != null)
                 {
                     _logger.LogInformation(

--- a/src/ReadyStackGo.Domain/Deployment/Observers/IMaintenanceSetter.cs
+++ b/src/ReadyStackGo.Domain/Deployment/Observers/IMaintenanceSetter.cs
@@ -1,0 +1,22 @@
+namespace ReadyStackGo.Domain.Deployment.Observers;
+
+/// <summary>
+/// Propagates an RSGO-initiated maintenance state to the product (the write-side mirror of
+/// <see cref="IMaintenanceObserver"/>). Implementations are best-effort: a failure is returned
+/// as a non-successful <see cref="SetterResult"/>, never thrown, so it cannot break the
+/// maintenance transition.
+/// </summary>
+public interface IMaintenanceSetter
+{
+    SetterType Type { get; }
+
+    Task<SetterResult> SetAsync(MaintenanceState state, CancellationToken cancellationToken = default);
+}
+
+/// <summary>Factory for creating maintenance setter instances from configuration.</summary>
+public interface IMaintenanceSetterFactory
+{
+    IMaintenanceSetter Create(MaintenanceSetterConfig config);
+
+    bool IsSupported(SetterType type);
+}

--- a/src/ReadyStackGo.Domain/Deployment/Observers/MaintenanceSetterConfig.cs
+++ b/src/ReadyStackGo.Domain/Deployment/Observers/MaintenanceSetterConfig.cs
@@ -1,0 +1,151 @@
+namespace ReadyStackGo.Domain.Deployment.Observers;
+
+using ReadyStackGo.Domain.SharedKernel;
+
+/// <summary>Type of maintenance setter (mirror of <see cref="ObserverType"/> for writing).</summary>
+public enum SetterType
+{
+    SqlExtendedProperty,
+    Webhook
+}
+
+/// <summary>The maintenance state RSGO propagates to the product.</summary>
+public enum MaintenanceState
+{
+    Maintenance,
+    Normal
+}
+
+/// <summary>
+/// Configuration for a maintenance setter — the write-side mirror of
+/// <see cref="MaintenanceObserverConfig"/>.
+/// </summary>
+public sealed class MaintenanceSetterConfig : ValueObject
+{
+    public SetterType Type { get; }
+
+    /// <summary>Delay between firing the setter and stopping containers (0 = none).</summary>
+    public TimeSpan GracePeriod { get; }
+
+    /// <summary>Value written for the maintenance state (sqlExtendedProperty).</summary>
+    public string MaintenanceValue { get; }
+
+    /// <summary>Value written for the normal state (sqlExtendedProperty).</summary>
+    public string NormalValue { get; }
+
+    public ISetterSettings Settings { get; }
+
+    private MaintenanceSetterConfig(
+        SetterType type, TimeSpan gracePeriod, string maintenanceValue, string normalValue, ISetterSettings settings)
+    {
+        Type = type;
+        GracePeriod = gracePeriod;
+        MaintenanceValue = maintenanceValue;
+        NormalValue = normalValue;
+        Settings = settings;
+    }
+
+    public static MaintenanceSetterConfig Create(
+        SetterType type, TimeSpan gracePeriod, string maintenanceValue, string normalValue, ISetterSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        if (gracePeriod < TimeSpan.Zero)
+            throw new ArgumentException("Grace period cannot be negative", nameof(gracePeriod));
+
+        return new MaintenanceSetterConfig(type, gracePeriod, maintenanceValue ?? string.Empty, normalValue ?? string.Empty, settings);
+    }
+
+    /// <summary>The value to write for the given state (used by the SQL setter).</summary>
+    public string ValueForState(MaintenanceState state) =>
+        state == MaintenanceState.Maintenance ? MaintenanceValue : NormalValue;
+
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return Type;
+        yield return GracePeriod;
+        yield return MaintenanceValue;
+        yield return NormalValue;
+        yield return Settings;
+    }
+}
+
+/// <summary>Marker interface for type-specific setter settings.</summary>
+public interface ISetterSettings
+{
+    IEnumerable<string> Validate();
+}
+
+/// <summary>Settings for the SQL extended-property setter.</summary>
+public sealed class SqlSetterSettings : ValueObject, ISetterSettings
+{
+    public string ConnectionString { get; }
+    public string PropertyName { get; }
+
+    public SqlSetterSettings(string connectionString, string propertyName)
+    {
+        ConnectionString = connectionString;
+        PropertyName = propertyName;
+    }
+
+    public IEnumerable<string> Validate()
+    {
+        if (string.IsNullOrWhiteSpace(ConnectionString))
+            yield return "connectionString must be specified";
+        if (string.IsNullOrWhiteSpace(PropertyName))
+            yield return "propertyName must be specified";
+    }
+
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return ConnectionString;
+        yield return PropertyName;
+    }
+}
+
+/// <summary>Settings for the signed webhook setter.</summary>
+public sealed class WebhookSetterSettings : ValueObject, ISetterSettings
+{
+    public string Url { get; }
+
+    /// <summary>HMAC-SHA256 secret used to sign the request body. Never logged.</summary>
+    public string? Secret { get; }
+
+    public TimeSpan Timeout { get; }
+    public int MaxRetries { get; }
+
+    public WebhookSetterSettings(string url, string? secret, TimeSpan timeout, int maxRetries)
+    {
+        Url = url;
+        Secret = secret;
+        Timeout = timeout;
+        MaxRetries = maxRetries < 0 ? 0 : maxRetries;
+    }
+
+    public IEnumerable<string> Validate()
+    {
+        if (string.IsNullOrWhiteSpace(Url))
+            yield return "url must be specified";
+        else if (!Uri.TryCreate(Url, UriKind.Absolute, out var uri) || (uri.Scheme != "http" && uri.Scheme != "https"))
+            yield return "url must be a valid HTTP or HTTPS URL";
+
+        if (Timeout <= TimeSpan.Zero)
+            yield return "timeout must be positive";
+    }
+
+    protected override IEnumerable<object?> GetEqualityComponents()
+    {
+        yield return Url;
+        yield return Secret;
+        yield return Timeout;
+        yield return MaxRetries;
+    }
+}
+
+/// <summary>Outcome of a setter invocation (best-effort; failures are non-fatal).</summary>
+public sealed record SetterResult(bool Success, bool Skipped, string? Error)
+{
+    public static SetterResult Ok() => new(true, false, null);
+    public static SetterResult WasSkipped(string reason) => new(true, true, reason);
+    public static SetterResult Failed(string error) => new(false, false, error);
+}

--- a/src/ReadyStackGo.Domain/Deployment/ProductDeployments/ProductDeployment.cs
+++ b/src/ReadyStackGo.Domain/Deployment/ProductDeployments/ProductDeployment.cs
@@ -72,6 +72,7 @@ public class ProductDeployment : AggregateRoot<ProductDeploymentId>
     public OperationMode OperationMode { get; private set; } = OperationMode.Normal;
     public MaintenanceTrigger? MaintenanceTrigger { get; private set; }
     public MaintenanceObserverConfig? MaintenanceObserverConfig { get; private set; }
+    public MaintenanceSetterConfig? MaintenanceSetterConfig { get; private set; }
 
     // ── PRTG Integration (Variant 3 — PrtgConnection-Resource) ─────
     /// <summary>
@@ -873,6 +874,15 @@ public class ProductDeployment : AggregateRoot<ProductDeploymentId>
     public void SetMaintenanceObserverConfig(MaintenanceObserverConfig? config)
     {
         MaintenanceObserverConfig = config;
+    }
+
+    /// <summary>
+    /// Sets the maintenance setter configuration for this product deployment.
+    /// Called during deployment when setter config is available from the product definition.
+    /// </summary>
+    public void SetMaintenanceSetterConfig(MaintenanceSetterConfig? config)
+    {
+        MaintenanceSetterConfig = config;
     }
 
     /// <summary>

--- a/src/ReadyStackGo.Domain/StackManagement/Manifests/RsgoMaintenance.cs
+++ b/src/ReadyStackGo.Domain/StackManagement/Manifests/RsgoMaintenance.cs
@@ -7,7 +7,13 @@ namespace ReadyStackGo.Domain.StackManagement.Manifests;
 public class RsgoMaintenance
 {
     /// <summary>
-    /// Observer configuration for automatic maintenance mode detection.
+    /// Observer configuration for automatic maintenance mode detection (RSGO reads state).
     /// </summary>
     public RsgoMaintenanceObserver? Observer { get; set; }
+
+    /// <summary>
+    /// Setter configuration for propagating RSGO-initiated maintenance transitions to the
+    /// product (RSGO writes state). Mirror image of the observer.
+    /// </summary>
+    public RsgoMaintenanceSetter? Setter { get; set; }
 }

--- a/src/ReadyStackGo.Domain/StackManagement/Manifests/RsgoMaintenanceSetter.cs
+++ b/src/ReadyStackGo.Domain/StackManagement/Manifests/RsgoMaintenanceSetter.cs
@@ -1,0 +1,61 @@
+namespace ReadyStackGo.Domain.StackManagement.Manifests;
+
+/// <summary>
+/// Maintenance setter configuration — the mirror image of the observer.
+/// When RSGO transitions a product into/out of maintenance manually (not via the observer),
+/// the setter actively propagates that state to the product:
+/// - sqlExtendedProperty: writes the same SQL Server extended property the observer reads.
+/// - webhook: POSTs a signed { "state": "maintenance" | "normal" } to a product endpoint.
+/// </summary>
+public class RsgoMaintenanceSetter
+{
+    /// <summary>Setter type: "sqlExtendedProperty" or "webhook".</summary>
+    public required string Type { get; set; }
+
+    /// <summary>
+    /// Value written to indicate maintenance is active (sqlExtendedProperty). Should match the
+    /// observer's maintenanceValue so both paths stay consistent.
+    /// </summary>
+    public string? MaintenanceValue { get; set; }
+
+    /// <summary>Value written to indicate normal operation (sqlExtendedProperty).</summary>
+    public string? NormalValue { get; set; }
+
+    /// <summary>
+    /// Optional delay between firing the setter and stopping the containers, so the product can
+    /// drain its clients (e.g. "10s"). Default 0 (no behavior change).
+    /// </summary>
+    public string? GracePeriod { get; set; }
+
+    #region SQL setter (sqlExtendedProperty)
+
+    /// <summary>Direct connection string. Supports variable substitution: ${VAR_NAME}.</summary>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>Name of a manifest variable containing the connection string.</summary>
+    public string? ConnectionName { get; set; }
+
+    /// <summary>Name of the SQL Server extended property to write (class = 0, database-level).</summary>
+    public string? PropertyName { get; set; }
+
+    #endregion
+
+    #region Webhook setter
+
+    /// <summary>URL the product exposes to receive the maintenance state. Supports ${VAR_NAME}.</summary>
+    public string? Url { get; set; }
+
+    /// <summary>
+    /// HMAC secret used to sign the request body (SHA-256). Supports ${VAR_NAME}.
+    /// Never logged.
+    /// </summary>
+    public string? Secret { get; set; }
+
+    /// <summary>Request timeout (e.g. "10s"). Defaults to 10s.</summary>
+    public string? Timeout { get; set; }
+
+    /// <summary>Number of retries on failure. Defaults to 2.</summary>
+    public int? Retries { get; set; }
+
+    #endregion
+}

--- a/src/ReadyStackGo.Domain/StackManagement/Stacks/ProductDefinition.cs
+++ b/src/ReadyStackGo.Domain/StackManagement/Stacks/ProductDefinition.cs
@@ -93,6 +93,12 @@ public class ProductDefinition
     public RsgoMaintenanceObserver? MaintenanceObserver { get; }
 
     /// <summary>
+    /// Maintenance setter configuration for this product.
+    /// Used to propagate RSGO-initiated maintenance transitions back to the product.
+    /// </summary>
+    public RsgoMaintenanceSetter? MaintenanceSetter { get; }
+
+    /// <summary>
     /// Whether this product contains multiple stacks.
     /// </summary>
     public bool IsMultiStack => Stacks.Count > 1;
@@ -144,7 +150,8 @@ public class ProductDefinition
         string? relativePath = null,
         string? productId = null,
         string? releaseNotesUrl = null,
-        string? changelogMarkdown = null)
+        string? changelogMarkdown = null,
+        RsgoMaintenanceSetter? maintenanceSetter = null)
     {
         if (string.IsNullOrWhiteSpace(sourceId))
             throw new ArgumentException("SourceId cannot be empty.", nameof(sourceId));
@@ -168,6 +175,7 @@ public class ProductDefinition
         ReleaseNotesUrl = releaseNotesUrl;
         ChangelogMarkdown = changelogMarkdown;
         MaintenanceObserver = maintenanceObserver;
+        MaintenanceSetter = maintenanceSetter;
         FilePath = filePath;
         RelativePath = relativePath;
 

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Configurations/MaintenanceSetterConfigJsonConverter.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Configurations/MaintenanceSetterConfigJsonConverter.cs
@@ -1,0 +1,86 @@
+namespace ReadyStackGo.Infrastructure.DataAccess.Configurations;
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using ReadyStackGo.Domain.Deployment.Observers;
+
+/// <summary>
+/// JSON converter for MaintenanceSetterConfig that handles polymorphic ISetterSettings.
+/// Mirror of <see cref="MaintenanceObserverConfigJsonConverter"/>.
+/// </summary>
+public class MaintenanceSetterConfigJsonConverter : JsonConverter<MaintenanceSetterConfig>
+{
+    public override MaintenanceSetterConfig? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        using var doc = JsonDocument.ParseValue(ref reader);
+        var root = doc.RootElement;
+
+        var typeValue = root.GetProperty("type").GetString();
+        if (string.IsNullOrEmpty(typeValue) || !Enum.TryParse<SetterType>(typeValue, ignoreCase: true, out var setterType))
+            return null;
+
+        var gracePeriod = TimeSpan.FromTicks(
+            root.TryGetProperty("gracePeriodTicks", out var gp) ? gp.GetInt64() : 0);
+        var maintenanceValue = root.TryGetProperty("maintenanceValue", out var mv) ? mv.GetString() ?? "" : "";
+        var normalValue = root.TryGetProperty("normalValue", out var nv) ? nv.GetString() ?? "" : "";
+
+        var settingsElement = root.GetProperty("settings");
+        var settingsType = settingsElement.GetProperty("settingsType").GetString();
+
+        ISetterSettings settings = settingsType switch
+        {
+            "sql" => DeserializeSqlSettings(settingsElement),
+            "webhook" => DeserializeWebhookSettings(settingsElement),
+            _ => throw new JsonException($"Unknown setter settings type: {settingsType}")
+        };
+
+        return MaintenanceSetterConfig.Create(setterType, gracePeriod, maintenanceValue, normalValue, settings);
+    }
+
+    public override void Write(Utf8JsonWriter writer, MaintenanceSetterConfig value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+
+        writer.WriteString("type", value.Type.ToString());
+        writer.WriteNumber("gracePeriodTicks", value.GracePeriod.Ticks);
+        writer.WriteString("maintenanceValue", value.MaintenanceValue);
+        writer.WriteString("normalValue", value.NormalValue);
+
+        writer.WriteStartObject("settings");
+        switch (value.Settings)
+        {
+            case SqlSetterSettings sql:
+                writer.WriteString("settingsType", "sql");
+                writer.WriteString("connectionString", sql.ConnectionString);
+                writer.WriteString("propertyName", sql.PropertyName);
+                break;
+
+            case WebhookSetterSettings webhook:
+                writer.WriteString("settingsType", "webhook");
+                writer.WriteString("url", webhook.Url);
+                if (webhook.Secret != null) writer.WriteString("secret", webhook.Secret);
+                writer.WriteNumber("timeoutTicks", webhook.Timeout.Ticks);
+                writer.WriteNumber("maxRetries", webhook.MaxRetries);
+                break;
+        }
+        writer.WriteEndObject();
+
+        writer.WriteEndObject();
+    }
+
+    private static SqlSetterSettings DeserializeSqlSettings(JsonElement element)
+    {
+        var connectionString = element.TryGetProperty("connectionString", out var cs) ? cs.GetString() ?? "" : "";
+        var propertyName = element.TryGetProperty("propertyName", out var pn) ? pn.GetString() ?? "" : "";
+        return new SqlSetterSettings(connectionString, propertyName);
+    }
+
+    private static WebhookSetterSettings DeserializeWebhookSettings(JsonElement element)
+    {
+        var url = element.GetProperty("url").GetString() ?? throw new JsonException("URL is required");
+        var secret = element.TryGetProperty("secret", out var s) ? s.GetString() : null;
+        var timeoutTicks = element.TryGetProperty("timeoutTicks", out var t) ? t.GetInt64() : TimeSpan.FromSeconds(10).Ticks;
+        var maxRetries = element.TryGetProperty("maxRetries", out var r) ? r.GetInt32() : 2;
+        return new WebhookSetterSettings(url, secret, TimeSpan.FromTicks(timeoutTicks), maxRetries);
+    }
+}

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Configurations/ProductDeploymentConfiguration.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Configurations/ProductDeploymentConfiguration.cs
@@ -136,6 +136,18 @@ public class ProductDeploymentConfiguration : IEntityTypeConfiguration<ProductDe
                 v => string.IsNullOrEmpty(v) ? null : JsonSerializer.Deserialize<MaintenanceObserverConfig>(v, observerConfigOptions))
             .HasColumnName("MaintenanceObserverConfigJson");
 
+        // Configure MaintenanceSetterConfig as JSON column (mirror of the observer config)
+        var setterConfigOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters = { new MaintenanceSetterConfigJsonConverter() }
+        };
+        builder.Property(d => d.MaintenanceSetterConfig)
+            .HasConversion(
+                v => v == null ? null : JsonSerializer.Serialize(v, setterConfigOptions),
+                v => string.IsNullOrEmpty(v) ? null : JsonSerializer.Deserialize<MaintenanceSetterConfig>(v, setterConfigOptions))
+            .HasColumnName("MaintenanceSetterConfigJson");
+
         // Configure SharedVariables as JSON column
         builder.Property(d => d.SharedVariables)
             .HasConversion(

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Migrations/20260618103851_AddMaintenanceSetterConfig.Designer.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Migrations/20260618103851_AddMaintenanceSetterConfig.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ReadyStackGo.Infrastructure.DataAccess;
 
@@ -10,9 +11,11 @@ using ReadyStackGo.Infrastructure.DataAccess;
 namespace ReadyStackGo.Infrastructure.DataAccess.Migrations
 {
     [DbContext(typeof(ReadyStackGoDbContext))]
-    partial class ReadyStackGoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260618103851_AddMaintenanceSetterConfig")]
+    partial class AddMaintenanceSetterConfig
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.0");

--- a/src/ReadyStackGo.Infrastructure.DataAccess/Migrations/20260618103851_AddMaintenanceSetterConfig.cs
+++ b/src/ReadyStackGo.Infrastructure.DataAccess/Migrations/20260618103851_AddMaintenanceSetterConfig.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ReadyStackGo.Infrastructure.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMaintenanceSetterConfig : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "MaintenanceSetterConfigJson",
+                table: "ProductDeployments",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MaintenanceSetterConfigJson",
+                table: "ProductDeployments");
+        }
+    }
+}

--- a/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
+++ b/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
@@ -126,6 +126,20 @@ public static class DependencyInjection
             ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
         });
 
+        // Maintenance Setter (mirror of the observer — propagates RSGO-initiated transitions)
+        services.AddSingleton<IMaintenanceSetterFactory, MaintenanceSetterFactory>();
+        services.AddScoped<IMaintenanceSetterService, Application.Services.Impl.MaintenanceSetterService>();
+
+        // HTTP client for the webhook setter
+        services.AddHttpClient("MaintenanceSetter", client =>
+        {
+            client.DefaultRequestHeaders.Add("User-Agent", "ReadyStackGo-MaintenanceSetter");
+        })
+        .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+        {
+            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+        });
+
         // Health check infrastructure services
         services.AddHttpClient<IHttpHealthChecker, HttpHealthChecker>(client =>
         {

--- a/src/ReadyStackGo.Infrastructure/Services/Health/MaintenanceSetterFactory.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Health/MaintenanceSetterFactory.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.DependencyInjection;
+using ReadyStackGo.Domain.Deployment.Observers;
+
+namespace ReadyStackGo.Infrastructure.Services.Health;
+
+/// <summary>
+/// Factory for creating maintenance setter instances. Mirror of
+/// <see cref="MaintenanceObserverFactory"/>.
+/// </summary>
+public sealed class MaintenanceSetterFactory : IMaintenanceSetterFactory
+{
+    private readonly IServiceProvider _serviceProvider;
+    private readonly Dictionary<SetterType, Type> _setterTypes = new();
+
+    public MaintenanceSetterFactory(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+
+        _setterTypes[SetterType.SqlExtendedProperty] = typeof(SqlExtendedPropertySetter);
+        _setterTypes[SetterType.Webhook] = typeof(WebhookSetter);
+    }
+
+    public IMaintenanceSetter Create(MaintenanceSetterConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        if (!_setterTypes.TryGetValue(config.Type, out var setterType))
+        {
+            throw new NotSupportedException($"Setter type '{config.Type}' is not supported");
+        }
+
+        return (IMaintenanceSetter)ActivatorUtilities.CreateInstance(
+            _serviceProvider, setterType, config);
+    }
+
+    public bool IsSupported(SetterType type) => _setterTypes.ContainsKey(type);
+}

--- a/src/ReadyStackGo.Infrastructure/Services/Health/SqlExtendedPropertySetter.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Health/SqlExtendedPropertySetter.cs
@@ -1,0 +1,67 @@
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+using ReadyStackGo.Domain.Deployment.Observers;
+
+namespace ReadyStackGo.Infrastructure.Services.Health;
+
+/// <summary>
+/// Writes a SQL Server database-level extended property — the write-side mirror of
+/// <see cref="SqlExtendedPropertyObserver"/>. Idempotent: it upserts the desired value, so
+/// repeating the same transition is a no-op effect and cannot drive a feedback loop with the
+/// observer (which only reads).
+/// </summary>
+public sealed class SqlExtendedPropertySetter : IMaintenanceSetter
+{
+    private readonly MaintenanceSetterConfig _config;
+    private readonly SqlSetterSettings _settings;
+    private readonly ILogger<SqlExtendedPropertySetter> _logger;
+
+    public SqlExtendedPropertySetter(
+        MaintenanceSetterConfig config,
+        ILogger<SqlExtendedPropertySetter> logger)
+    {
+        _config = config;
+        _logger = logger;
+        _settings = config.Settings as SqlSetterSettings
+            ?? throw new ArgumentException("Invalid settings type for SQL Extended Property setter");
+    }
+
+    public SetterType Type => SetterType.SqlExtendedProperty;
+
+    public async Task<SetterResult> SetAsync(MaintenanceState state, CancellationToken cancellationToken = default)
+    {
+        var desiredValue = _config.ValueForState(state);
+
+        try
+        {
+            await using var connection = new SqlConnection(_settings.ConnectionString);
+            await connection.OpenAsync(cancellationToken);
+
+            // Idempotent upsert of the database-level extended property.
+            const string sql = @"
+                IF EXISTS (SELECT 1 FROM sys.extended_properties WHERE class = 0 AND name = @name)
+                    EXEC sys.sp_updateextendedproperty @name = @name, @value = @value;
+                ELSE
+                    EXEC sys.sp_addextendedproperty @name = @name, @value = @value;";
+
+            await using var command = new SqlCommand(sql, connection);
+            command.Parameters.AddWithValue("@name", _settings.PropertyName);
+            command.Parameters.AddWithValue("@value", desiredValue);
+
+            await command.ExecuteNonQueryAsync(cancellationToken);
+
+            _logger.LogInformation(
+                "Maintenance setter wrote extended property '{PropertyName}' = '{Value}' (state {State})",
+                _settings.PropertyName, desiredValue, state);
+
+            return SetterResult.Ok();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Maintenance setter failed to write extended property '{PropertyName}' (state {State})",
+                _settings.PropertyName, state);
+            return SetterResult.Failed(ex.Message);
+        }
+    }
+}

--- a/src/ReadyStackGo.Infrastructure/Services/Health/WebhookSetter.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Health/WebhookSetter.cs
@@ -1,0 +1,90 @@
+using System.Net.Http.Headers;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using ReadyStackGo.Domain.Deployment.Observers;
+
+namespace ReadyStackGo.Infrastructure.Services.Health;
+
+/// <summary>
+/// Notifies the product of a maintenance transition via a signed webhook:
+/// POST { "state": "maintenance" | "normal" } with an HMAC-SHA256 signature header.
+/// Best-effort with a per-attempt timeout and bounded retries; the secret is never logged.
+/// </summary>
+public sealed class WebhookSetter : IMaintenanceSetter
+{
+    private readonly WebhookSetterSettings _settings;
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<WebhookSetter> _logger;
+
+    public WebhookSetter(
+        MaintenanceSetterConfig config,
+        IHttpClientFactory httpClientFactory,
+        ILogger<WebhookSetter> logger)
+    {
+        _settings = config.Settings as WebhookSetterSettings
+            ?? throw new ArgumentException("Invalid settings type for webhook setter");
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+    }
+
+    public SetterType Type => SetterType.Webhook;
+
+    public async Task<SetterResult> SetAsync(MaintenanceState state, CancellationToken cancellationToken = default)
+    {
+        var stateValue = state == MaintenanceState.Maintenance ? "maintenance" : "normal";
+        var body = $"{{\"state\":\"{stateValue}\"}}";
+
+        var attempts = _settings.MaxRetries + 1;
+        string? lastError = null;
+
+        for (var attempt = 1; attempt <= attempts; attempt++)
+        {
+            try
+            {
+                using var request = new HttpRequestMessage(HttpMethod.Post, _settings.Url)
+                {
+                    Content = new StringContent(body, Encoding.UTF8, "application/json")
+                };
+
+                if (!string.IsNullOrEmpty(_settings.Secret))
+                {
+                    request.Headers.TryAddWithoutValidation(
+                        WebhookSignature.HeaderName, WebhookSignature.Compute(_settings.Secret, body));
+                }
+
+                var client = _httpClientFactory.CreateClient("MaintenanceSetter");
+
+                using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                timeoutCts.CancelAfter(_settings.Timeout);
+
+                using var response = await client.SendAsync(request, timeoutCts.Token);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    _logger.LogInformation(
+                        "Maintenance webhook notified product of state '{State}' (attempt {Attempt}/{Attempts})",
+                        stateValue, attempt, attempts);
+                    return SetterResult.Ok();
+                }
+
+                lastError = $"HTTP {(int)response.StatusCode}";
+                _logger.LogWarning(
+                    "Maintenance webhook returned {Status} (attempt {Attempt}/{Attempts})",
+                    (int)response.StatusCode, attempt, attempts);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Caller cancelled — stop retrying.
+                return SetterResult.Failed("Cancelled");
+            }
+            catch (Exception ex)
+            {
+                lastError = ex.Message;
+                _logger.LogWarning(ex,
+                    "Maintenance webhook call failed (attempt {Attempt}/{Attempts})", attempt, attempts);
+            }
+        }
+
+        return SetterResult.Failed($"Webhook failed after {attempts} attempt(s): {lastError}");
+    }
+}

--- a/src/ReadyStackGo.Infrastructure/Services/Health/WebhookSignature.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Health/WebhookSignature.cs
@@ -1,0 +1,24 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace ReadyStackGo.Infrastructure.Services.Health;
+
+/// <summary>
+/// Computes the HMAC-SHA256 signature for maintenance webhook bodies.
+/// Format: "sha256=" + lowercase hex digest of HMAC-SHA256(secret, body).
+/// </summary>
+public static class WebhookSignature
+{
+    public const string HeaderName = "X-RSGO-Signature";
+
+    public static string Compute(string secret, string body)
+    {
+        var keyBytes = Encoding.UTF8.GetBytes(secret);
+        var bodyBytes = Encoding.UTF8.GetBytes(body);
+
+        using var hmac = new HMACSHA256(keyBytes);
+        var hash = hmac.ComputeHash(bodyBytes);
+
+        return "sha256=" + Convert.ToHexString(hash).ToLowerInvariant();
+    }
+}

--- a/src/ReadyStackGo.Infrastructure/Services/StackSources/LocalDirectoryProductSourceProvider.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/StackSources/LocalDirectoryProductSourceProvider.cs
@@ -252,6 +252,7 @@ public class LocalDirectoryProductSourceProvider : IProductSourceProvider
         var productCategory = manifest.Metadata?.Category;
         var productTags = manifest.Metadata?.Tags;
         var maintenanceObserver = manifest.Maintenance?.Observer;
+        var maintenanceSetter = manifest.Maintenance?.Setter;
         var version = ComputeHash(yamlContent);
         var stacks = new List<StackDefinition>();
 
@@ -303,7 +304,8 @@ public class LocalDirectoryProductSourceProvider : IProductSourceProvider
             relativePath: relativePath,
             productId: manifest.Metadata?.ProductId,
             releaseNotesUrl: releaseNotesUrl,
-            changelogMarkdown: changelogMarkdown);
+            changelogMarkdown: changelogMarkdown,
+            maintenanceSetter: maintenanceSetter);
     }
 
     /// <summary>

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/monitoring/maintenance-mode.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/monitoring/maintenance-mode.md
@@ -89,6 +89,44 @@ Wenn Maintenance durch den Observer aktiviert wurde, kann es **nicht** manuell �
 
 ---
 
+## Das Produkt benachrichtigen (Maintenance-Setter)
+
+Standardmäßig ist die Maintenance-Integration **read-only**: Der Observer pollt ein Flag, das
+das Produkt setzt. Daraus entsteht eine Lücke — startet ein Operator die Wartung **direkt in
+ReadyStackGo**, erfährt das Produkt selbst nichts davon. Der optionale **Maintenance-Setter**
+schließt diese Lücke: Er ist das Spiegelbild zum Observer und **propagiert** einen
+RSGO-initiierten Wartungszustand **aktiv** ans Produkt — so kann das Produkt seine Clients
+vorwarnen/geordnet beenden, und sein eigenes Maintenance-Flag bleibt mit RSGO konsistent.
+
+Der Setter wird pro Produkt im Manifest deklariert (`maintenance.setter`) und unterstützt zwei Typen:
+
+| Typ | Was er tut | Gut für |
+|-----|------------|---------|
+| `sqlExtendedProperty` | Schreibt **dieselbe** SQL-Server-Extended-Property, die der Observer liest | Konsistenz von RSGO & SQL-Flag; funktioniert auch wenn das Produkt down ist |
+| `webhook` | `POST { "state": "maintenance" \| "normal" }`, HMAC-SHA256-signiert | Synchrone Produkt-Reaktion (z. B. Clients vorwarnen), solange es noch läuft |
+
+**Wann er feuert:**
+
+- Eintritt in Maintenance: Setter schreibt `maintenance` **vor** dem Stoppen der Container.
+- Rückkehr in Normal: Setter schreibt `normal` **nach** dem Neustart der Container.
+- Ein optionales `gracePeriod` verzögert den Container-Stop, damit das Produkt seine Clients drainen kann.
+
+:::note[Kein Feedback-Loop]
+Der Setter feuert **nur bei manuellen/Operator-Übergängen** — nie bei observer-getriggerten
+(dort hat das Produkt das Flag bereits gesetzt). Der SQL-Write ist idempotent, sodass Observer
+(lesen) und Setter (schreiben) sich nicht gegenseitig aufschaukeln können.
+:::
+
+:::caution[Best-effort & sicher]
+Setter-Fehler (DB nicht erreichbar, Webhook-Timeout/5xx) sind **non-fatal**: Sie werden geloggt
+und in der API-Antwort ausgewiesen, verhindern den Wartungsübergang aber nie. Webhook-Secrets
+werden nie geloggt, externe Webhook-URLs nie serverseitig gelesen (kein SSRF).
+:::
+
+Die YAML-Felder sind in der [Manifest-Format-Referenz](/de/reference/manifest-format/#setter-konfiguration) dokumentiert.
+
+---
+
 ## API-Endpoint
 
 Der Maintenance Mode kann auch über die REST API gesteuert werden:

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/de/reference/manifest-format.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/de/reference/manifest-format.md
@@ -454,6 +454,70 @@ maintenance:
     normalValue: "false"
 ```
 
+### Setter-Konfiguration
+
+Der optionale `maintenance.setter` ist das Spiegelbild zum Observer: Wenn ein Operator das
+Produkt **direkt in ReadyStackGo** in den Wartungsmodus versetzt (nicht über den Observer),
+propagiert RSGO diesen Zustand aktiv ins Produkt. So bleiben RSGO-OperationMode und das
+Maintenance-Flag des Produkts konsistent, und das Produkt kann seine Clients vorwarnen.
+
+| Feld | Typ | Pflicht | Beschreibung |
+|------|-----|---------|--------------|
+| `type` | string | **Ja** | `sqlExtendedProperty` oder `webhook` |
+| `gracePeriod` | string | Nein | Verzögerung zwischen Setter-Aufruf und Container-Stop (z. B. `10s`). Default `0` |
+
+:::note[Kein Feedback-Loop]
+Der Setter feuert **nur bei manuellen/Operator-Übergängen**, nie bei Observer-getriggerten
+(dort hat das Produkt das Flag bereits gesetzt). Der SQL-Write ist idempotent. Setter-Fehler
+sind non-fatal: Sie werden geloggt und ausgewiesen, verhindern den Übergang aber nicht.
+:::
+
+#### SQL Extended Property (`sqlExtendedProperty`)
+
+Schreibt **dieselbe** Extended Property, die der Observer liest — beide Seiten bleiben synchron.
+Funktioniert auch, wenn das Produkt down ist.
+
+```yaml
+maintenance:
+  observer:
+    type: sqlExtendedProperty
+    connectionString: "${AMS_DB}"
+    propertyName: ams-MaintenanceMode
+    maintenanceValue: "1"
+    normalValue: "0"
+  setter:
+    type: sqlExtendedProperty
+    connectionString: "${AMS_DB}"
+    propertyName: ams-MaintenanceMode
+    maintenanceValue: "1"
+    normalValue: "0"
+    gracePeriod: "10s"
+```
+
+#### Webhook (`webhook`)
+
+Ruft einen Produkt-Endpoint mit `POST { "state": "maintenance" | "normal" }` auf, signiert per
+HMAC-SHA256 über den Body (Header `X-RSGO-Signature: sha256=<hex>`). Gut für eine synchrone
+Produkt-Reaktion, solange es noch läuft. Externe URLs werden nie serverseitig gelesen (kein SSRF).
+
+| Feld | Typ | Pflicht | Beschreibung |
+|------|-----|---------|--------------|
+| `url` | string | **Ja** | Vom Produkt bereitgestellter Endpoint (unterstützt `${VAR}`) |
+| `secret` | string | Nein | HMAC-Secret zum Signieren des Body (unterstützt `${VAR}`; wird nie geloggt) |
+| `timeout` | string | Nein | Request-Timeout (z. B. `10s`). Default `10s` |
+| `retries` | int | Nein | Wiederholungen bei Fehler. Default `2` |
+
+```yaml
+maintenance:
+  setter:
+    type: webhook
+    url: "${PRODUCT_BASE_URL}/internal/maintenance"
+    secret: "${MAINTENANCE_WEBHOOK_SECRET}"
+    timeout: "10s"
+    retries: 2
+    gracePeriod: "15s"
+```
+
 ---
 
 ## Multi-Stack Products

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/monitoring/maintenance-mode.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/monitoring/maintenance-mode.md
@@ -89,6 +89,44 @@ If maintenance was activated by the observer, it **cannot** be ended manually vi
 
 ---
 
+## Notifying the product (maintenance setter)
+
+By default the maintenance integration is **read-only**: the observer polls a flag the product
+sets. That leaves a gap — if an operator starts maintenance **inside ReadyStackGo**, the product
+itself never learns about it. The optional **maintenance setter** closes that gap: it is the
+mirror image of the observer and **actively propagates** an RSGO-initiated maintenance state to
+the product, so the product can warn/drain its clients and its own maintenance flag stays in
+sync with RSGO.
+
+The setter is declared per product in the manifest (`maintenance.setter`) and supports two types:
+
+| Type | What it does | Good for |
+|------|--------------|----------|
+| `sqlExtendedProperty` | Writes the **same** SQL Server extended property the observer reads | Keeping RSGO and the SQL flag consistent; works even while the product is down |
+| `webhook` | `POST { "state": "maintenance" \| "normal" }`, signed with HMAC-SHA256 | A synchronous product reaction (e.g. warning clients) while it is still running |
+
+**When it fires:**
+
+- Entering maintenance: the setter writes `maintenance` **before** containers are stopped.
+- Exiting maintenance: the setter writes `normal` **after** containers are started again.
+- An optional `gracePeriod` delays the container stop, giving the product time to drain clients.
+
+:::note[No feedback loop]
+The setter fires **only for manual/operator transitions** — never for observer-initiated ones
+(there the product already set the flag). The SQL write is idempotent, so the observer (read) and
+setter (write) can never drive each other in a loop.
+:::
+
+:::caution[Best-effort & secure]
+Setter failures (DB unreachable, webhook timeout/5xx) are **non-fatal**: they are logged and
+reported in the API response, but never block the maintenance transition. Webhook secrets are
+never logged, and external webhook URLs are never read back (no SSRF).
+:::
+
+The YAML fields are documented in the [manifest format reference](/en/reference/manifest-format/#setter-configuration).
+
+---
+
 ## API Endpoint
 
 Maintenance mode can also be controlled via the REST API:

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/en/reference/manifest-format.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/en/reference/manifest-format.md
@@ -513,6 +513,70 @@ maintenance:
     normalValue: "false"
 ```
 
+### Setter Configuration
+
+The optional `maintenance.setter` is the mirror image of the observer: when an operator puts
+the product into maintenance **from within ReadyStackGo** (not via the observer), RSGO actively
+propagates that state to the product. This keeps the RSGO operation mode and the product's own
+maintenance flag consistent, and lets the product warn/drain its clients.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `type` | string | **Yes** | `sqlExtendedProperty` or `webhook` |
+| `gracePeriod` | string | No | Delay between firing the setter and stopping containers (e.g. `10s`). Default `0` |
+
+:::note[No feedback loop]
+The setter fires **only for operator/manual transitions**, never for observer-initiated ones
+(where the product already set the flag). The SQL write is idempotent. Setter failures are
+non-fatal: they are logged and reported, but do not block the maintenance transition.
+:::
+
+#### SQL Extended Property (`sqlExtendedProperty`)
+
+Writes the **same** extended property the observer reads, keeping both sides in sync. Works
+even while the product is down.
+
+```yaml
+maintenance:
+  observer:
+    type: sqlExtendedProperty
+    connectionString: "${AMS_DB}"
+    propertyName: ams-MaintenanceMode
+    maintenanceValue: "1"
+    normalValue: "0"
+  setter:
+    type: sqlExtendedProperty
+    connectionString: "${AMS_DB}"
+    propertyName: ams-MaintenanceMode
+    maintenanceValue: "1"
+    normalValue: "0"
+    gracePeriod: "10s"
+```
+
+#### Webhook (`webhook`)
+
+Calls a product endpoint with `POST { "state": "maintenance" | "normal" }`, signed with
+HMAC-SHA256 over the body (header `X-RSGO-Signature: sha256=<hex>`). Good for a synchronous
+product reaction while it is still running. The external URL is never read back (no SSRF).
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `url` | string | **Yes** | Endpoint the product exposes (supports `${VAR}`) |
+| `secret` | string | No | HMAC secret to sign the body (supports `${VAR}`; never logged) |
+| `timeout` | string | No | Request timeout (e.g. `10s`). Default `10s` |
+| `retries` | int | No | Retries on failure. Default `2` |
+
+```yaml
+maintenance:
+  setter:
+    type: webhook
+    url: "${PRODUCT_BASE_URL}/internal/maintenance"
+    secret: "${MAINTENANCE_WEBHOOK_SECRET}"
+    timeout: "10s"
+    retries: 2
+    gracePeriod: "15s"
+```
+
 ---
 
 ## Multi-Stack Products

--- a/tests/ReadyStackGo.UnitTests/Application/Deployments/ChangeProductOperationModeHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Deployments/ChangeProductOperationModeHandlerTests.cs
@@ -19,6 +19,7 @@ public class ChangeProductOperationModeHandlerTests
     private readonly Mock<IDeploymentRepository> _deploymentRepositoryMock;
     private readonly Mock<IDockerService> _dockerServiceMock;
     private readonly Mock<IHealthNotificationService> _healthNotificationMock;
+    private readonly Mock<IMaintenanceSetterService> _setterServiceMock;
     private readonly Mock<ILogger<ChangeProductOperationModeHandler>> _loggerMock;
     private readonly ChangeProductOperationModeHandler _handler;
 
@@ -30,6 +31,10 @@ public class ChangeProductOperationModeHandlerTests
         _deploymentRepositoryMock = new Mock<IDeploymentRepository>();
         _dockerServiceMock = new Mock<IDockerService>();
         _healthNotificationMock = new Mock<IHealthNotificationService>();
+        _setterServiceMock = new Mock<IMaintenanceSetterService>();
+        _setterServiceMock
+            .Setup(s => s.ApplyAsync(It.IsAny<MaintenanceSetterConfig?>(), It.IsAny<MaintenanceState>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SetterResult.WasSkipped("no setter configured"));
         _loggerMock = new Mock<ILogger<ChangeProductOperationModeHandler>>();
 
         _handler = new ChangeProductOperationModeHandler(
@@ -37,6 +42,7 @@ public class ChangeProductOperationModeHandlerTests
             _deploymentRepositoryMock.Object,
             _dockerServiceMock.Object,
             _healthNotificationMock.Object,
+            _setterServiceMock.Object,
             _loggerMock.Object);
     }
 
@@ -89,6 +95,51 @@ public class ChangeProductOperationModeHandlerTests
             mode,
             reason,
             source);
+    }
+
+    #endregion
+
+    #region Maintenance setter (loop protection)
+
+    [Fact]
+    public async Task Handle_ManualEnterMaintenance_FiresSetterMaintenance()
+    {
+        var deployment = CreateRunningDeployment();
+        SetupDeploymentFound(deployment);
+
+        await _handler.Handle(CreateCommand(deployment, mode: "Maintenance", source: "Manual"), CancellationToken.None);
+
+        _setterServiceMock.Verify(s => s.ApplyAsync(
+            It.IsAny<MaintenanceSetterConfig?>(), MaintenanceState.Maintenance, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ObserverEnterMaintenance_DoesNotFireSetter()
+    {
+        // Loop protection: observer-initiated transitions must NOT write back.
+        var deployment = CreateRunningDeployment();
+        SetupDeploymentFound(deployment);
+
+        await _handler.Handle(CreateCommand(deployment, mode: "Maintenance", source: "Observer"), CancellationToken.None);
+
+        _setterServiceMock.Verify(s => s.ApplyAsync(
+            It.IsAny<MaintenanceSetterConfig?>(), It.IsAny<MaintenanceState>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ManualExitMaintenance_FiresSetterNormal()
+    {
+        var deployment = CreateRunningDeployment();
+        deployment.EnterMaintenance(MaintenanceTrigger.Manual("test"));
+        SetupDeploymentFound(deployment);
+
+        await _handler.Handle(CreateCommand(deployment, mode: "Normal", source: "Manual"), CancellationToken.None);
+
+        _setterServiceMock.Verify(s => s.ApplyAsync(
+            It.IsAny<MaintenanceSetterConfig?>(), MaintenanceState.Normal, It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     #endregion

--- a/tests/ReadyStackGo.UnitTests/Application/Deployments/MaintenanceSetterConfigMapperTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Deployments/MaintenanceSetterConfigMapperTests.cs
@@ -1,0 +1,122 @@
+using FluentAssertions;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Domain.Deployment.Observers;
+using ReadyStackGo.Domain.StackManagement.Manifests;
+
+namespace ReadyStackGo.UnitTests.Application.Deployments;
+
+public class MaintenanceSetterConfigMapperTests
+{
+    private static readonly Dictionary<string, string> NoVars = new();
+
+    [Fact]
+    public void Map_Null_ReturnsNull()
+    {
+        MaintenanceSetterConfigMapper.Map(null, NoVars).Should().BeNull();
+    }
+
+    [Fact]
+    public void Map_UnknownType_ReturnsNull()
+    {
+        var src = new RsgoMaintenanceSetter { Type = "carrierPigeon", PropertyName = "x", ConnectionString = "y" };
+        MaintenanceSetterConfigMapper.Map(src, NoVars).Should().BeNull();
+    }
+
+    [Fact]
+    public void Map_Sql_MapsConnectionPropertyValuesAndGrace()
+    {
+        var src = new RsgoMaintenanceSetter
+        {
+            Type = "sqlExtendedProperty",
+            ConnectionString = "Server=db;Database=ams;",
+            PropertyName = "ams-MaintenanceMode",
+            MaintenanceValue = "1",
+            NormalValue = "0",
+            GracePeriod = "15s"
+        };
+
+        var config = MaintenanceSetterConfigMapper.Map(src, NoVars);
+
+        config.Should().NotBeNull();
+        config!.Type.Should().Be(SetterType.SqlExtendedProperty);
+        config.MaintenanceValue.Should().Be("1");
+        config.NormalValue.Should().Be("0");
+        config.GracePeriod.Should().Be(TimeSpan.FromSeconds(15));
+        var sql = config.Settings.Should().BeOfType<SqlSetterSettings>().Subject;
+        sql.ConnectionString.Should().Be("Server=db;Database=ams;");
+        sql.PropertyName.Should().Be("ams-MaintenanceMode");
+    }
+
+    [Fact]
+    public void Map_Sql_ResolvesConnectionNameFromVariables()
+    {
+        var src = new RsgoMaintenanceSetter
+        {
+            Type = "sqlExtendedProperty",
+            ConnectionName = "AMS_DB",
+            PropertyName = "ams-MaintenanceMode"
+        };
+        var vars = new Dictionary<string, string> { ["AMS_DB"] = "Server=db;Database=ams;" };
+
+        var config = MaintenanceSetterConfigMapper.Map(src, vars);
+
+        config.Should().NotBeNull();
+        ((SqlSetterSettings)config!.Settings).ConnectionString.Should().Be("Server=db;Database=ams;");
+    }
+
+    [Fact]
+    public void Map_Sql_UnresolvedVariable_ReturnsNull()
+    {
+        var src = new RsgoMaintenanceSetter
+        {
+            Type = "sqlExtendedProperty",
+            ConnectionString = "Server=${MISSING};",
+            PropertyName = "p"
+        };
+
+        MaintenanceSetterConfigMapper.Map(src, NoVars).Should().BeNull();
+    }
+
+    [Fact]
+    public void Map_Sql_MissingPropertyName_ReturnsNull()
+    {
+        var src = new RsgoMaintenanceSetter { Type = "sqlExtendedProperty", ConnectionString = "Server=db;" };
+        MaintenanceSetterConfigMapper.Map(src, NoVars).Should().BeNull();
+    }
+
+    [Fact]
+    public void Map_Webhook_MapsUrlSecretTimeoutRetries()
+    {
+        var src = new RsgoMaintenanceSetter
+        {
+            Type = "webhook",
+            Url = "https://product.example.com/maintenance",
+            Secret = "s3cr3t",
+            Timeout = "5s",
+            Retries = 3
+        };
+
+        var config = MaintenanceSetterConfigMapper.Map(src, NoVars);
+
+        config.Should().NotBeNull();
+        config!.Type.Should().Be(SetterType.Webhook);
+        var wh = config.Settings.Should().BeOfType<WebhookSetterSettings>().Subject;
+        wh.Url.Should().Be("https://product.example.com/maintenance");
+        wh.Secret.Should().Be("s3cr3t");
+        wh.Timeout.Should().Be(TimeSpan.FromSeconds(5));
+        wh.MaxRetries.Should().Be(3);
+    }
+
+    [Fact]
+    public void Map_Webhook_DefaultsTimeoutAndRetries()
+    {
+        var src = new RsgoMaintenanceSetter { Type = "webhook", Url = "https://x/y" };
+
+        var config = MaintenanceSetterConfigMapper.Map(src, NoVars);
+
+        var wh = (WebhookSetterSettings)config!.Settings;
+        wh.Timeout.Should().Be(TimeSpan.FromSeconds(10));
+        wh.MaxRetries.Should().Be(2);
+        config.GracePeriod.Should().Be(TimeSpan.Zero);
+    }
+}

--- a/tests/ReadyStackGo.UnitTests/Infrastructure/Maintenance/WebhookSetterTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Infrastructure/Maintenance/WebhookSetterTests.cs
@@ -1,0 +1,108 @@
+using System.Net;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ReadyStackGo.Domain.Deployment.Observers;
+using ReadyStackGo.Infrastructure.Services.Health;
+
+namespace ReadyStackGo.UnitTests.Infrastructure.Maintenance;
+
+public class WebhookSetterTests
+{
+    private sealed class StubHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpStatusCode> _responses;
+        public int Calls { get; private set; }
+        public List<HttpRequestMessage> Requests { get; } = new();
+        public List<string> Bodies { get; } = new();
+
+        public StubHandler(params HttpStatusCode[] responses) => _responses = new Queue<HttpStatusCode>(responses);
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls++;
+            Requests.Add(request);
+            Bodies.Add(request.Content == null ? "" : await request.Content.ReadAsStringAsync(cancellationToken));
+            var status = _responses.Count > 0 ? _responses.Dequeue() : HttpStatusCode.InternalServerError;
+            return new HttpResponseMessage(status);
+        }
+    }
+
+    private sealed class StubFactory : IHttpClientFactory
+    {
+        private readonly HttpMessageHandler _handler;
+        public StubFactory(HttpMessageHandler handler) => _handler = handler;
+        public HttpClient CreateClient(string name) => new(_handler, disposeHandler: false);
+    }
+
+    private static WebhookSetter CreateSut(StubHandler handler, string? secret = null, int maxRetries = 2)
+    {
+        var settings = new WebhookSetterSettings("https://product.example.com/maintenance", secret, TimeSpan.FromSeconds(5), maxRetries);
+        var config = MaintenanceSetterConfig.Create(SetterType.Webhook, TimeSpan.Zero, "maintenance", "normal", settings);
+        return new WebhookSetter(config, new StubFactory(handler), new Mock<ILogger<WebhookSetter>>().Object);
+    }
+
+    [Fact]
+    public async Task SetAsync_Success_ReturnsOk_OneCall()
+    {
+        var handler = new StubHandler(HttpStatusCode.OK);
+        var sut = CreateSut(handler);
+
+        var result = await sut.SetAsync(MaintenanceState.Maintenance);
+
+        result.Success.Should().BeTrue();
+        handler.Calls.Should().Be(1);
+        handler.Bodies[0].Should().Contain("\"state\":\"maintenance\"");
+    }
+
+    [Fact]
+    public async Task SetAsync_RetriesThenSucceeds()
+    {
+        var handler = new StubHandler(HttpStatusCode.InternalServerError, HttpStatusCode.OK);
+        var sut = CreateSut(handler, maxRetries: 2);
+
+        var result = await sut.SetAsync(MaintenanceState.Normal);
+
+        result.Success.Should().BeTrue();
+        handler.Calls.Should().Be(2);
+        handler.Bodies[0].Should().Contain("\"state\":\"normal\"");
+    }
+
+    [Fact]
+    public async Task SetAsync_AllAttemptsFail_ReturnsFailure_NonFatal()
+    {
+        var handler = new StubHandler(HttpStatusCode.InternalServerError, HttpStatusCode.InternalServerError);
+        var sut = CreateSut(handler, maxRetries: 1);
+
+        var result = await sut.SetAsync(MaintenanceState.Maintenance);
+
+        result.Success.Should().BeFalse();
+        result.Error.Should().NotBeNullOrEmpty();
+        handler.Calls.Should().Be(2); // maxRetries(1) + 1
+    }
+
+    [Fact]
+    public async Task SetAsync_WithSecret_AddsSignatureHeader()
+    {
+        var handler = new StubHandler(HttpStatusCode.OK);
+        var sut = CreateSut(handler, secret: "s3cr3t");
+
+        await sut.SetAsync(MaintenanceState.Maintenance);
+
+        var header = handler.Requests[0].Headers.TryGetValues(WebhookSignature.HeaderName, out var values)
+            ? values.First() : null;
+        header.Should().NotBeNull();
+        header!.Should().Be(WebhookSignature.Compute("s3cr3t", handler.Bodies[0]));
+    }
+
+    [Fact]
+    public async Task SetAsync_WithoutSecret_NoSignatureHeader()
+    {
+        var handler = new StubHandler(HttpStatusCode.OK);
+        var sut = CreateSut(handler, secret: null);
+
+        await sut.SetAsync(MaintenanceState.Maintenance);
+
+        handler.Requests[0].Headers.Contains(WebhookSignature.HeaderName).Should().BeFalse();
+    }
+}

--- a/tests/ReadyStackGo.UnitTests/Infrastructure/Maintenance/WebhookSignatureTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Infrastructure/Maintenance/WebhookSignatureTests.cs
@@ -1,0 +1,44 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using ReadyStackGo.Infrastructure.Services.Health;
+
+namespace ReadyStackGo.UnitTests.Infrastructure.Maintenance;
+
+public class WebhookSignatureTests
+{
+    [Fact]
+    public void Compute_HasSha256PrefixAndHexDigest()
+    {
+        var sig = WebhookSignature.Compute("secret", "{\"state\":\"maintenance\"}");
+
+        sig.Should().StartWith("sha256=");
+        Regex.IsMatch(sig, "^sha256=[0-9a-f]{64}$").Should().BeTrue();
+    }
+
+    [Fact]
+    public void Compute_IsDeterministic()
+    {
+        var a = WebhookSignature.Compute("secret", "body");
+        var b = WebhookSignature.Compute("secret", "body");
+
+        a.Should().Be(b);
+    }
+
+    [Fact]
+    public void Compute_DiffersBySecretAndBody()
+    {
+        var baseline = WebhookSignature.Compute("secret", "body");
+
+        WebhookSignature.Compute("other", "body").Should().NotBe(baseline);
+        WebhookSignature.Compute("secret", "other").Should().NotBe(baseline);
+    }
+
+    [Fact]
+    public void Compute_MatchesKnownVector()
+    {
+        // HMAC-SHA256(key="key", msg="The quick brown fox jumps over the lazy dog")
+        var sig = WebhookSignature.Compute("key", "The quick brown fox jumps over the lazy dog");
+
+        sig.Should().Be("sha256=f7bc83f430538424b13298e6aa6fb143ef4d59a14946175997479dbc2d1a3cd8");
+    }
+}


### PR DESCRIPTION
> **Stacked on #428** (product-release-notes) — both touch `ProductDefinition`/the source loader. Review/merge after #428; this branch will be rebased onto main once #428 lands.

## Summary

Adds the write-side mirror of the maintenance observer. Today RSGO only **reads** a maintenance flag; if an operator triggers maintenance **inside RSGO**, the product never learns about it. This change actively **propagates** RSGO-initiated maintenance transitions to the product.

## What's included

- **Manifest**: optional `maintenance.setter` (`sqlExtendedProperty` | `webhook`), parsed alongside `maintenance.observer` and carried on `ProductDefinition`.
- **sqlExtendedProperty**: idempotent upsert of the **same** extended property the observer reads — keeps RSGO's mode and the SQL flag consistent; works even when the product is down.
- **webhook**: `POST { "state": "maintenance" | "normal" }` signed with **HMAC-SHA256** (`X-RSGO-Signature`), per-attempt timeout + bounded retries; the external URL is never read back (no SSRF), the secret is never logged.
- **Trigger**: hooked into `ChangeProductOperationModeHandler` — fire `maintenance` (+ optional `gracePeriod`) **before** stopping containers; fire `normal` **after** starting them.
- **Loop protection**: the setter fires **only for `Manual` transitions**, never observer-initiated ones (the product already set the flag). SQL writes are idempotent.
- **Best-effort**: setter failures are logged and surfaced in `ChangeProductOperationModeResponse.SetterError`, but never block the transition.
- **Persistence**: stored on `ProductDeployment` (`MaintenanceSetterConfigJson`) + EF migration; wired in Deploy/Redeploy.
- **Docs**: manifest-format reference (DE/EN) documents `maintenance.setter`.

## Acceptance criteria
1. ✅ Manifest can declare `maintenance.setter` (sqlExtendedProperty / webhook).
2. ✅ Manual RSGO maintenance writes the SQL flag / calls the webhook.
3. ✅ Return to Normal writes normalValue / calls webhook "normal" after containers start.
4. ✅ No observer↔setter loop; writes idempotent (setter skipped for observer-initiated transitions).
5. ✅ Optional `gracePeriod` delays the container stop; default 0 (no behavior change).
6. ✅ Setter errors non-fatal, logged (no secrets), reported in the response.
7. ✅ Existing observer behavior unchanged.

## Testing
- `dotnet build`: 0 errors, no new warnings
- Unit tests: **3052 passing** (+20: webhook HMAC/retries/non-fatal, mapper, loop-protection)
- PublicWeb build: green

## Follow-ups
- Supporting **both** sql + webhook in one setter block (currently one type per setter).
- AMS counterpart: no UI change needed; the manifest field is consumed by any product.