### PR TITLE
fix(edge): allow ${VAR} placeholders in edge port fields (catalog-load regression)

### DIFF
--- a/src/ReadyStackGo.Application/Services/Edge/EdgeConfigMapper.cs
+++ b/src/ReadyStackGo.Application/Services/Edge/EdgeConfigMapper.cs
@@ -42,8 +42,8 @@ public static class EdgeConfigMapper
         if (string.IsNullOrWhiteSpace(image))
             image = EdgeConstants.DefaultCaddyImage;
 
-        var publicPort = source.PublicPort ?? EdgeConstants.DefaultPublicPort;
-        var upstreamPort = source.Upstream?.Port ?? EdgeConstants.DefaultUpstreamPort;
+        var publicPort = ResolvePort(source.PublicPort, variables, EdgeConstants.DefaultPublicPort);
+        var upstreamPort = ResolvePort(source.Upstream?.Port, variables, EdgeConstants.DefaultUpstreamPort);
 
         var tlsMode = ParseTlsMode(source.Tls?.Mode);
         var tlsCertRef = Resolve(source.Tls?.CertRef, variables);
@@ -53,7 +53,7 @@ public static class EdgeConfigMapper
         var pageMode = ParsePageMode(source.MaintenancePage?.Mode);
         var bundlePath = Resolve(source.MaintenancePage?.BundlePath, variables);
         var maintenanceContainerService = Resolve(source.MaintenancePage?.Container?.Service, variables);
-        var maintenanceContainerPort = source.MaintenancePage?.Container?.Port ?? 80;
+        var maintenanceContainerPort = ResolvePort(source.MaintenancePage?.Container?.Port, variables, 80);
 
         var branding = MapBranding(source.MaintenancePage?.Branding, variables);
 
@@ -113,6 +113,23 @@ public static class EdgeConfigMapper
         "container" => EdgeMaintenancePageMode.Container,
         _ => EdgeMaintenancePageMode.Default
     };
+
+    /// <summary>
+    /// Resolves a port value that may be a literal (<c>443</c>) or a <c>${VAR}</c> placeholder.
+    /// Falls back to <paramref name="fallback"/> when empty, unresolved, or not a valid port.
+    /// Port fields are string-typed in the manifest so a placeholder does not break YAML
+    /// deserialization at catalog-load time (before deploy variables are known).
+    /// </summary>
+    private static int ResolvePort(string? template, IReadOnlyDictionary<string, string> variables, int fallback)
+    {
+        if (string.IsNullOrWhiteSpace(template))
+            return fallback;
+
+        var resolved = Resolve(template, variables);
+        return int.TryParse(resolved?.Trim(), out var port) && port is > 0 and <= 65535
+            ? port
+            : fallback;
+    }
 
     /// <summary>
     /// Resolves <c>${VAR}</c> placeholders. Returns null when a placeholder remains

--- a/src/ReadyStackGo.Domain/StackManagement/Manifests/RsgoEdge.cs
+++ b/src/ReadyStackGo.Domain/StackManagement/Manifests/RsgoEdge.cs
@@ -27,9 +27,10 @@ public class RsgoEdge
     public string? PublicHostname { get; set; }
 
     /// <summary>
-    /// Public port the edge listens on. Defaults to 443.
+    /// Public port the edge listens on. Defaults to 443. String-typed so it can hold a
+    /// <c>${VAR}</c> placeholder (resolved at deploy time); literal numbers also work.
     /// </summary>
-    public int? PublicPort { get; set; }
+    public string? PublicPort { get; set; }
 
     /// <summary>
     /// Optional override for the Caddy edge image. Defaults to a digest-pinned official
@@ -71,9 +72,9 @@ public class RsgoEdgeUpstream
     public string? Service { get; set; }
 
     /// <summary>
-    /// Upstream port. Defaults to 8080.
+    /// Upstream port. Defaults to 8080. String-typed so it can hold a <c>${VAR}</c> placeholder.
     /// </summary>
-    public int? Port { get; set; }
+    public string? Port { get; set; }
 }
 
 /// <summary>
@@ -156,9 +157,10 @@ public class RsgoEdgeMaintenanceContainer
     public string? Service { get; set; }
 
     /// <summary>
-    /// Port the maintenance container serves on. Defaults to 80.
+    /// Port the maintenance container serves on. Defaults to 80. String-typed so it can hold
+    /// a <c>${VAR}</c> placeholder.
     /// </summary>
-    public int? Port { get; set; }
+    public string? Port { get; set; }
 }
 
 /// <summary>

--- a/tests/ReadyStackGo.UnitTests/Edge/EdgeConfigMapperTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Edge/EdgeConfigMapperTests.cs
@@ -88,10 +88,10 @@ public class EdgeConfigMapperTests
         {
             Enabled = true,
             PublicHostname = "${PUBLIC_HOST}",
-            PublicPort = 443,
+            PublicPort = "443",
             Image = "caddy:2.8.4",
             Network = "${EDGE_NET}",
-            Upstream = new() { Service = "web-bff", Port = 9090 },
+            Upstream = new() { Service = "web-bff", Port = "9090" },
             Tls = new() { Mode = "custom", CertRef = "my-cert" },
             MaintenancePage = new()
             {
@@ -126,7 +126,7 @@ public class EdgeConfigMapperTests
             MaintenancePage = new()
             {
                 Mode = "container",
-                Container = new() { Service = "maint-web", Port = 8090 }
+                Container = new() { Service = "maint-web", Port = "8090" }
             }
         };
 

--- a/tests/ReadyStackGo.UnitTests/Edge/EdgeManifestParsingTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Edge/EdgeManifestParsingTests.cs
@@ -50,9 +50,9 @@ public class EdgeManifestParsingTests
         manifest.Edge.Should().NotBeNull();
         manifest.Edge!.Enabled.Should().BeTrue();
         manifest.Edge.PublicHostname.Should().Be("project.customer.tld");
-        manifest.Edge.PublicPort.Should().Be(443);
+        manifest.Edge.PublicPort.Should().Be("443");
         manifest.Edge.Upstream!.Service.Should().Be("web-bff");
-        manifest.Edge.Upstream.Port.Should().Be(8080);
+        manifest.Edge.Upstream.Port.Should().Be("8080");
         manifest.Edge.Network.Should().Be("ams-project-edge-net");
         manifest.Edge.Tls!.Mode.Should().Be("selfsigned");
         manifest.Edge.MaintenancePage!.Branding!.ProductName.Should().Be("ams.project");
@@ -63,6 +63,53 @@ public class EdgeManifestParsingTests
         config.Should().NotBeNull();
         config!.TlsMode.Should().Be(EdgeTlsMode.SelfSigned);
         config.UpstreamService.Should().Be("web-bff");
+    }
+
+    [Fact]
+    public async Task ParsesEdgeBlock_WithVariablePlaceholderPorts()
+    {
+        // Regression: ${VAR} placeholders in port fields must NOT break catalog-load
+        // deserialization (ports are string-typed; resolved at deploy time).
+        const string yaml = """
+            metadata:
+              name: ams.project
+              productVersion: "1.0.0"
+            services:
+              web-bff:
+                image: ams/bff:1.0.0
+            edge:
+              enabled: true
+              publicHostname: ${AMS_PROJECT_EXTERNAL_DNS_NAME_OR_IP}
+              publicPort: ${BFF_PORT}
+              upstream:
+                service: web-bff
+                port: 8080
+              network: ams-project-edge
+              maintenancePage:
+                mode: default
+            """;
+
+        // Must not throw — the product would otherwise disappear from the catalog.
+        var manifest = await CreateParser().ParseAsync(yaml);
+        manifest.Edge.Should().NotBeNull();
+        manifest.Edge!.PublicPort.Should().Be("${BFF_PORT}");
+
+        // At deploy time the placeholder resolves to the real port.
+        var resolved = EdgeConfigMapper.Map(manifest.Edge, new Dictionary<string, string>
+        {
+            ["AMS_PROJECT_EXTERNAL_DNS_NAME_OR_IP"] = "ams.kunde.tld",
+            ["BFF_PORT"] = "8443",
+        });
+        resolved.Should().NotBeNull();
+        resolved!.PublicHostname.Should().Be("ams.kunde.tld");
+        resolved.PublicPort.Should().Be(8443);
+
+        // Unresolved placeholder falls back to the default port (still a valid config).
+        var fallback = EdgeConfigMapper.Map(manifest.Edge, new Dictionary<string, string>
+        {
+            ["AMS_PROJECT_EXTERNAL_DNS_NAME_OR_IP"] = "ams.kunde.tld",
+        });
+        fallback!.PublicPort.Should().Be(443);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

A product manifest with a `${VAR}` placeholder in an edge port (e.g. `publicPort: ${BFF_PORT}`, as used by the ams.project CI manifest) failed to load: the edge port fields were typed `int?`, so YAML deserialization at **catalog-load time** (before deploy variables are known) threw, and the **whole product manifest** fell out of the catalog. Regression introduced in v0.75.0 (#431).

## Fix

- `publicPort`, `upstream.port`, `maintenancePage.container.port` are now **string-typed** in the manifest model — they tolerate `${VAR}` placeholders and literal numbers.
- `EdgeConfigMapper.ResolvePort` resolves the placeholder against deploy variables and parses to int, falling back to the default (443 / 8080 / 80) when empty, unresolved, or invalid.
- Regression test: an edge block with `${VAR}` ports parses without throwing and resolves at deploy.

Full unit suite green (3115). Fixes the ams.project manifest disappearing from the selection on test-ux-dokker.