### PR TITLE
fix(deployments): stop per-stack notification spam on product removal

### DIFF
--- a/src/ReadyStackGo.Application/UseCases/Deployments/RemoveDeployment/RemoveDeploymentHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/RemoveDeployment/RemoveDeploymentHandler.cs
@@ -45,7 +45,10 @@ public class RemoveDeploymentByIdHandler : IRequestHandler<RemoveDeploymentByIdC
         if (string.IsNullOrEmpty(request.SessionId))
         {
             var simpleResult = await _deploymentService.RemoveDeploymentByIdAsync(request.EnvironmentId, request.DeploymentId);
-            await CreateRemoveNotificationAsync(simpleResult, cancellationToken);
+            // Suppress the per-stack in-app notification when invoked from product removal —
+            // the parent RemoveProductHandler emits a single aggregated product notification.
+            if (!request.SuppressNotification)
+                await CreateRemoveNotificationAsync(simpleResult, cancellationToken);
             return simpleResult;
         }
 
@@ -100,7 +103,9 @@ public class RemoveDeploymentByIdHandler : IRequestHandler<RemoveDeploymentByIdC
             progressCallback,
             cancellationToken);
 
-        await CreateRemoveNotificationAsync(result, cancellationToken);
+        // See above: skip the per-stack in-app notification under product removal.
+        if (!request.SuppressNotification)
+            await CreateRemoveNotificationAsync(result, cancellationToken);
         return result;
     }
 

--- a/tests/ReadyStackGo.UnitTests/Application/Deployments/RemoveDeploymentHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Deployments/RemoveDeploymentHandlerTests.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ReadyStackGo.Application.Notifications;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Application.UseCases.Deployments;
+using ReadyStackGo.Application.UseCases.Deployments.RemoveDeployment;
+using Xunit;
+
+namespace ReadyStackGo.UnitTests.Application.Deployments;
+
+/// <summary>
+/// Verifies that per-stack in-app notifications are suppressed when a stack removal is part of
+/// a product removal (SuppressNotification=true) — the parent RemoveProductHandler emits a
+/// single aggregated product notification, so per-stack ones would just spam the bell.
+/// </summary>
+public class RemoveDeploymentHandlerTests
+{
+    private readonly Mock<IDeploymentService> _deploymentService = new();
+    private readonly Mock<IDeploymentNotificationService> _signalR = new();
+    private readonly Mock<INotificationService> _inApp = new();
+
+    private RemoveDeploymentByIdHandler CreateSut() => new(
+        _deploymentService.Object, _signalR.Object,
+        new Mock<ILogger<RemoveDeploymentByIdHandler>>().Object, _inApp.Object);
+
+    private void SetupRemove() =>
+        _deploymentService
+            .Setup(s => s.RemoveDeploymentByIdAsync(It.IsAny<string>(), It.IsAny<string>()))
+            .ReturnsAsync(new DeployComposeResponse { Success = true, StackName = "ams-project-memo", Message = "removed" });
+
+    [Fact]
+    public async Task SuppressNotification_True_DoesNotCreateInAppNotification()
+    {
+        SetupRemove();
+        var cmd = new RemoveDeploymentByIdCommand("env", "dep", SessionId: null, SuppressNotification: true);
+
+        await CreateSut().Handle(cmd, CancellationToken.None);
+
+        _inApp.Verify(n => n.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()), Times.Never,
+            "product removal suppresses per-stack notifications to avoid bell spam");
+    }
+
+    [Fact]
+    public async Task SuppressNotification_False_CreatesOneInAppNotification()
+    {
+        SetupRemove();
+        var cmd = new RemoveDeploymentByIdCommand("env", "dep", SessionId: null, SuppressNotification: false);
+
+        await CreateSut().Handle(cmd, CancellationToken.None);
+
+        _inApp.Verify(n => n.AddAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()), Times.Once,
+            "a standalone single-stack removal still notifies once");
+    }
+}


### PR DESCRIPTION
Removing a multi-stack product (e.g. ams.project, ~15 stacks) flooded the notification bell with one 'Remove Successful' per stack. RemoveDeploymentByIdHandler emitted the in-app notification unconditionally; SuppressNotification (set by RemoveProductHandler) only suppressed the SignalR events. Now the in-app notification is also gated on !SuppressNotification. RemoveProductHandler already emits one aggregated 'Product Remove Successful' notification, so product removal yields exactly one bell notification; standalone single-stack removals still notify once. Adds tests.