### PR TITLE
fix(catalog): proper SemVer precedence + same-channel update detection

### DIFF
--- a/src/ReadyStackGo.Domain/SharedKernel/SemanticVersion.cs
+++ b/src/ReadyStackGo.Domain/SharedKernel/SemanticVersion.cs
@@ -1,0 +1,141 @@
+namespace ReadyStackGo.Domain.SharedKernel;
+
+/// <summary>
+/// SemVer 2.0.0 precedence comparison + pre-release "channel" extraction.
+///
+/// Replaces naive string/<see cref="System.Version"/> comparisons that mis-ordered pre-release
+/// versions (e.g. treating <c>4.0.0-preview.1</c> as newer than <c>4.0.0-ci</c> by plain
+/// alphabetical compare, or a pre-release as newer than its final release).
+/// </summary>
+public static class SemanticVersion
+{
+    /// <summary>
+    /// Compares two version strings by SemVer 2.0.0 precedence. Returns &lt;0 if
+    /// <paramref name="a"/> precedes <paramref name="b"/>, 0 if equal precedence, &gt;0 otherwise.
+    /// Leading <c>v</c> and build metadata (<c>+...</c>) are ignored. Non-SemVer inputs fall back
+    /// to an ordinal string comparison.
+    /// </summary>
+    public static int Compare(string? a, string? b)
+    {
+        if (string.IsNullOrWhiteSpace(a) && string.IsNullOrWhiteSpace(b)) return 0;
+        if (string.IsNullOrWhiteSpace(a)) return -1;
+        if (string.IsNullOrWhiteSpace(b)) return 1;
+
+        var (aBase, aPre, aOk) = Split(a);
+        var (bBase, bPre, bOk) = Split(b);
+
+        // If either side is not parseable as SemVer base, fall back to ordinal compare.
+        if (!aOk || !bOk)
+            return string.Compare(Normalize(a), Normalize(b), StringComparison.OrdinalIgnoreCase);
+
+        // 1. Compare numeric base (major.minor.patch...).
+        var baseCmp = CompareBase(aBase, bBase);
+        if (baseCmp != 0) return baseCmp;
+
+        // 2. A version WITH a pre-release has LOWER precedence than the same version without.
+        var aHasPre = aPre.Length > 0;
+        var bHasPre = bPre.Length > 0;
+        if (!aHasPre && !bHasPre) return 0;
+        if (!aHasPre) return 1;   // a is the final release → greater
+        if (!bHasPre) return -1;  // b is the final release → greater
+
+        // 3. Compare pre-release identifiers left to right.
+        return ComparePreRelease(aPre, bPre);
+    }
+
+    /// <summary>True if <paramref name="candidate"/> has strictly higher precedence than <paramref name="current"/>.</summary>
+    public static bool IsNewer(string? candidate, string? current) => Compare(candidate, current) > 0;
+
+    /// <summary>
+    /// Extracts the release "channel" from a version: the pre-release stream a build belongs to.
+    /// <c>4.0.0-ci</c> → <c>ci</c>; <c>4.0.0-preview.1</c> → <c>preview</c>; <c>4.0.0-rc.2</c> → <c>rc</c>;
+    /// <c>4.0.0-beta3</c> → <c>beta</c>; a final release (<c>4.0.0</c>) → <c>""</c> (stable).
+    /// Used so an update is only offered within the same channel (no ci → preview jumps).
+    /// </summary>
+    public static string Channel(string? version)
+    {
+        if (string.IsNullOrWhiteSpace(version)) return string.Empty;
+        var (_, pre, _) = Split(version);
+        if (pre.Length == 0) return string.Empty; // stable / final release
+
+        var first = pre[0];                         // first dot-separated identifier
+        var letters = new string(first.TakeWhile(c => !char.IsDigit(c)).ToArray());
+        return (letters.Length > 0 ? letters : first).ToLowerInvariant();
+    }
+
+    /// <summary>True if both versions are on the same release channel.</summary>
+    public static bool SameChannel(string? a, string? b)
+        => string.Equals(Channel(a), Channel(b), StringComparison.OrdinalIgnoreCase);
+
+    // ── internals ─────────────────────────────────────────────────────
+
+    private static string Normalize(string v)
+    {
+        v = v.Trim().TrimStart('v', 'V');
+        var plus = v.IndexOf('+');           // strip build metadata
+        return plus >= 0 ? v[..plus] : v;
+    }
+
+    private static (int[] Base, string[] Pre, bool Ok) Split(string version)
+    {
+        var v = Normalize(version);
+
+        var dash = v.IndexOf('-');
+        var basePart = dash >= 0 ? v[..dash] : v;
+        var prePart = dash >= 0 ? v[(dash + 1)..] : string.Empty;
+
+        var baseTokens = basePart.Split('.');
+        var nums = new int[baseTokens.Length];
+        for (var i = 0; i < baseTokens.Length; i++)
+        {
+            if (!int.TryParse(baseTokens[i], out nums[i]))
+                return (Array.Empty<int>(), Array.Empty<string>(), false);
+        }
+
+        var pre = prePart.Length == 0
+            ? Array.Empty<string>()
+            : prePart.Split('.');
+
+        return (nums, pre, true);
+    }
+
+    private static int CompareBase(int[] a, int[] b)
+    {
+        var len = Math.Max(a.Length, b.Length);
+        for (var i = 0; i < len; i++)
+        {
+            var av = i < a.Length ? a[i] : 0;
+            var bv = i < b.Length ? b[i] : 0;
+            if (av != bv) return av.CompareTo(bv);
+        }
+        return 0;
+    }
+
+    private static int ComparePreRelease(string[] a, string[] b)
+    {
+        var len = Math.Min(a.Length, b.Length);
+        for (var i = 0; i < len; i++)
+        {
+            var aNum = int.TryParse(a[i], out var an);
+            var bNum = int.TryParse(b[i], out var bn);
+
+            if (aNum && bNum)
+            {
+                if (an != bn) return an.CompareTo(bn);
+            }
+            else if (aNum != bNum)
+            {
+                // Numeric identifiers always have LOWER precedence than alphanumeric ones.
+                return aNum ? -1 : 1;
+            }
+            else
+            {
+                var c = string.Compare(a[i], b[i], StringComparison.Ordinal);
+                if (c != 0) return c;
+            }
+        }
+
+        // All shared identifiers equal → more identifiers wins.
+        return a.Length.CompareTo(b.Length);
+    }
+}

--- a/src/ReadyStackGo.Infrastructure/Caching/InMemoryProductCache.cs
+++ b/src/ReadyStackGo.Infrastructure/Caching/InMemoryProductCache.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using ReadyStackGo.Application.Services;
+using ReadyStackGo.Domain.SharedKernel;
 using ReadyStackGo.Domain.StackManagement.Stacks;
 
 namespace ReadyStackGo.Infrastructure.Caching;
@@ -164,8 +165,15 @@ public class InMemoryProductCache : IProductCache
             return Enumerable.Empty<ProductDefinition>();
 
         var comparer = new SemVerComparer();
+
+        // Only offer upgrades within the SAME release channel as the deployed version
+        // (e.g. a `-ci` deployment is not "upgraded" to a `-preview` build, and vice versa).
+        // Channels are distinct streams, not a linear upgrade path.
+        var currentChannel = SemanticVersion.Channel(currentVersion);
+
         return versions.Values
             .Where(p => !string.IsNullOrEmpty(p.ProductVersion) &&
+                        SemanticVersion.Channel(p.ProductVersion) == currentChannel &&
                         comparer.Compare(p.ProductVersion, currentVersion) > 0)
             .OrderByDescending(p => p.ProductVersion, comparer)
             .ToList();
@@ -390,24 +398,8 @@ public class InMemoryProductCache : IProductCache
     /// </summary>
     private class SemVerComparer : IComparer<string?>
     {
-        public int Compare(string? x, string? y)
-        {
-            if (string.IsNullOrEmpty(x) && string.IsNullOrEmpty(y)) return 0;
-            if (string.IsNullOrEmpty(x)) return -1;
-            if (string.IsNullOrEmpty(y)) return 1;
-
-            var xNormalized = x.TrimStart('v', 'V');
-            var yNormalized = y.TrimStart('v', 'V');
-
-            // Try to parse as System.Version
-            if (Version.TryParse(xNormalized, out var xVer) &&
-                Version.TryParse(yNormalized, out var yVer))
-            {
-                return xVer.CompareTo(yVer);
-            }
-
-            // Fallback to string comparison
-            return string.Compare(xNormalized, yNormalized, StringComparison.OrdinalIgnoreCase);
-        }
+        // Proper SemVer 2.0.0 precedence (handles pre-release ordering correctly, unlike the
+        // previous System.Version + alphabetical fallback).
+        public int Compare(string? x, string? y) => SemanticVersion.Compare(x, y);
     }
 }

--- a/tests/ReadyStackGo.UnitTests/Domain/SemanticVersionTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Domain/SemanticVersionTests.cs
@@ -1,0 +1,81 @@
+using FluentAssertions;
+using ReadyStackGo.Domain.SharedKernel;
+using Xunit;
+
+namespace ReadyStackGo.UnitTests.Domain;
+
+public class SemanticVersionTests
+{
+    [Theory]
+    [InlineData("4.0.1", "4.0.0")]      // patch
+    [InlineData("4.1.0", "4.0.9")]      // minor beats higher patch
+    [InlineData("5.0.0", "4.9.9")]      // major
+    [InlineData("v2.0.0", "1.0.0")]     // leading v ignored
+    public void Compare_NumericBase(string greater, string lesser)
+    {
+        SemanticVersion.Compare(greater, lesser).Should().BePositive();
+        SemanticVersion.Compare(lesser, greater).Should().BeNegative();
+        SemanticVersion.Compare(greater, greater).Should().Be(0);
+    }
+
+    [Theory]
+    [InlineData("4.0.0", "4.0.0-ci")]            // final > pre-release
+    [InlineData("4.0.0", "4.0.0-preview.1")]
+    [InlineData("1.0.0", "1.0.0-rc.1")]
+    public void Compare_FinalBeatsPreRelease(string final, string pre)
+    {
+        SemanticVersion.Compare(final, pre).Should().BePositive();
+        SemanticVersion.Compare(pre, final).Should().BeNegative();
+    }
+
+    [Fact]
+    public void Compare_PreRelease_SpecExample_IsOrdered()
+    {
+        // From semver.org §11
+        var ordered = new[]
+        {
+            "1.0.0-alpha", "1.0.0-alpha.1", "1.0.0-alpha.beta", "1.0.0-beta",
+            "1.0.0-beta.2", "1.0.0-beta.11", "1.0.0-rc.1", "1.0.0"
+        };
+        for (var i = 0; i < ordered.Length - 1; i++)
+            SemanticVersion.Compare(ordered[i], ordered[i + 1])
+                .Should().BeNegative($"{ordered[i]} should precede {ordered[i + 1]}");
+    }
+
+    [Fact]
+    public void Compare_NumericIdentifier_LowerThanAlphanumeric()
+    {
+        // 1.0.0-1 < 1.0.0-alpha (numeric identifiers have lower precedence)
+        SemanticVersion.Compare("1.0.0-1", "1.0.0-alpha").Should().BeNegative();
+    }
+
+    [Fact]
+    public void Compare_CiVsPreview_IsAlphabeticalBySemver()
+    {
+        // Documents WHY semver alone doesn't help cross-channel: "ci" < "preview" lexically,
+        // so preview.1 ranks higher. The channel filter (not the comparer) is what prevents
+        // offering it as an upgrade.
+        SemanticVersion.Compare("4.0.0-preview.1", "4.0.0-ci").Should().BePositive();
+    }
+
+    [Theory]
+    [InlineData("4.0.0-ci", "ci")]
+    [InlineData("4.0.0-preview.1", "preview")]
+    [InlineData("4.0.0-rc.2", "rc")]
+    [InlineData("4.0.0-beta3", "beta")]
+    [InlineData("v1.2.3-alpha.7+build9", "alpha")]
+    [InlineData("4.0.0", "")]            // stable / final
+    [InlineData("", "")]
+    public void Channel_Extraction(string version, string expected)
+    {
+        SemanticVersion.Channel(version).Should().Be(expected);
+    }
+
+    [Fact]
+    public void SameChannel()
+    {
+        SemanticVersion.SameChannel("4.0.0-ci", "4.0.1-ci").Should().BeTrue();
+        SemanticVersion.SameChannel("4.0.0-ci", "4.0.0-preview.1").Should().BeFalse();
+        SemanticVersion.SameChannel("4.0.0", "4.1.0").Should().BeTrue();   // both stable
+    }
+}

--- a/tests/ReadyStackGo.UnitTests/Infrastructure/Caching/InMemoryProductCacheTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Infrastructure/Caching/InMemoryProductCacheTests.cs
@@ -183,6 +183,32 @@ public class InMemoryProductCacheTests
     }
 
     [Fact]
+    public void GetAvailableUpgrades_OnlyWithinSameChannel()
+    {
+        // A -ci deployment must not be "upgraded" to a -preview build (different channel),
+        // only to a newer -ci build. (Regression: 4.0.0-preview.1 offered over 4.0.0-ci.)
+        _cache.Set(CreateProduct("local", "Whoami", "4.0.0-ci"));
+        _cache.Set(CreateProduct("local", "Whoami", "4.0.0-preview.1"));
+        _cache.Set(CreateProduct("local", "Whoami", "4.0.1-ci"));
+
+        var upgrades = _cache.GetAvailableUpgrades("local:Whoami", "4.0.0-ci").ToList();
+
+        upgrades.Should().ContainSingle();
+        upgrades[0].ProductVersion.Should().Be("4.0.1-ci");
+        upgrades.Should().NotContain(p => p.ProductVersion == "4.0.0-preview.1");
+    }
+
+    [Fact]
+    public void GetAvailableUpgrades_NoCrossChannelUpgrade_ReturnsEmpty()
+    {
+        // Exactly the reported case: deployed 4.0.0-ci, catalog also has 4.0.0-preview.1.
+        _cache.Set(CreateProduct("local", "Whoami", "4.0.0-ci"));
+        _cache.Set(CreateProduct("local", "Whoami", "4.0.0-preview.1"));
+
+        _cache.GetAvailableUpgrades("local:Whoami", "4.0.0-ci").Should().BeEmpty();
+    }
+
+    [Fact]
     public void GetAvailableUpgrades_ReturnsEmptyWhenOnLatest()
     {
         // Arrange


### PR DESCRIPTION
## Problem

A deployed `4.0.0-ci` product showed *'Update available: v4.0.0-preview.1'*. Two root causes:

1. **Naive version ordering** — `SemVerComparer` used `System.Version.TryParse` (which fails for any pre-release) and fell back to a plain **alphabetical** string compare. That mis-orders pre-releases and even ranks a pre-release above its final release.
2. **Cross-channel updates** — `-ci` was 'upgraded' to `-preview` only because *ci < preview* alphabetically. These are separate release channels, not a linear upgrade path.

## Fix

- New `SemanticVersion` (Domain) implementing **SemVer 2.0.0 precedence** (numeric base; final > pre-release; dot-separated identifier rules). `InMemoryProductCache` now uses it.
- `GetAvailableUpgrades` only returns versions in the **same channel** as the deployed version (`ci→ci`, `preview→preview`, `stable→stable`). Channel = the pre-release stream (`4.0.0-preview.1` → `preview`).

Result: a `4.0.0-ci` deployment is no longer offered `4.0.0-preview.1`; it's only offered newer `-ci` builds.

## Tests

- `SemanticVersionTests` incl. the semver.org §11 ordering example + channel extraction.
- `InMemoryProductCacheTests`: same-channel filter + the exact ci/preview case.

Note: the deeper question of *which* channel a deployment should follow is honoured by 'same channel'; switching channels intentionally is still possible via explicit redeploy/upgrade to a chosen version.