### PR TITLE
fix(deploy): fail deployment on image pull failure instead of silently using a stale local image

### DIFF
--- a/src/ReadyStackGo.Infrastructure/Configuration/SystemConfig.cs
+++ b/src/ReadyStackGo.Infrastructure/Configuration/SystemConfig.cs
@@ -64,4 +64,16 @@ public class SystemConfig
     /// Default: 300 seconds (5 minutes).
     /// </summary>
     public int HealthNotificationCooldownSeconds { get; set; } = 300;
+
+    /// <summary>
+    /// When an image pull fails during deployment but a local copy of the image already exists,
+    /// controls whether the deployment falls back to that (potentially outdated) local image.
+    /// <para>
+    /// Default <c>false</c>: a failed pull fails the deployment, so broken registry access can never
+    /// silently deploy a stale image while the deployment (and any calling CI pipeline) still reports
+    /// success. Set to <c>true</c> only for environments that intentionally rely on cached local images
+    /// (e.g. air-gapped/offline installations) and accept the risk of running an outdated version.
+    /// </para>
+    /// </summary>
+    public bool AllowStaleImageOnPullFailure { get; set; }
 }

--- a/src/ReadyStackGo.Infrastructure/Services/Deployment/DeploymentEngine.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Deployment/DeploymentEngine.cs
@@ -265,6 +265,13 @@ public class DeploymentEngine : IDeploymentEngine
             var pulledImages = 0;
             var totalImages = plan.Steps.Count;
 
+            // Pull-failure policy: by DEFAULT a failed image pull fails the deployment. Silently
+            // falling back to a stale local image masks broken registry access — a service then keeps
+            // running an outdated image while the deploy (and thus the CI pipeline) reports success.
+            // Operators can opt back into the lenient local-fallback via SystemConfig
+            // (AllowStaleImageOnPullFailure), e.g. for air-gapped/offline environments.
+            var allowStaleImageOnPullFailure = (await _configStore.GetSystemConfigAsync()).AllowStaleImageOnPullFailure;
+
             await ReportProgress("PullingImages", $"Pulling {totalImages} images...", 0);
 
             // Helper to report progress during pull phase - passes pulledImages as completedSteps
@@ -312,8 +319,24 @@ public class DeploymentEngine : IDeploymentEngine
                         return result;
                     }
 
-                    pullWarnings[step.ContextName] = $"Image '{fullImageName}' could not be pulled - using existing local image. The deployed version may be outdated.";
-                    _logger.LogWarning("Using existing local image {Image} (pull failed: {Error})", fullImageName, ex.Message);
+                    // A local copy exists, but using it would silently deploy an outdated image.
+                    // Default: fail the deployment so the problem (registry access/credentials) is
+                    // visible. Only fall back to the local image when explicitly opted in.
+                    if (!allowStaleImageOnPullFailure)
+                    {
+                        var errorMessage = $"Service '{step.ContextName}': Failed to pull image '{imageName}' (tag: {imageTag}). " +
+                            $"A local copy exists, but deploying it would run an outdated version, so the deployment is failed. " +
+                            $"Fix the registry access/credentials for this image, or set SystemConfig.AllowStaleImageOnPullFailure " +
+                            $"to permit the stale local fallback. Error: {ex.Message}";
+                        _logger.LogError(errorMessage);
+                        result.Errors.Add(errorMessage);
+                        result.Success = false;
+                        await ReportProgress("Failed", errorMessage, 0, step.ContextName);
+                        return result;
+                    }
+
+                    pullWarnings[step.ContextName] = $"Image '{fullImageName}' could not be pulled - using existing local image (allowStaleImageOnPullFailure). The deployed version may be outdated.";
+                    _logger.LogWarning("Using existing local image {Image} (pull failed; stale fallback allowed by feature flag: {Error})", fullImageName, ex.Message);
                 }
 
                 pulledImages++;

--- a/tests/ReadyStackGo.UnitTests/DeploymentEngineTests.cs
+++ b/tests/ReadyStackGo.UnitTests/DeploymentEngineTests.cs
@@ -78,12 +78,69 @@ public class DeploymentEngineTests
 
         _configStoreMock.Setup(x => x.GetFeaturesConfigAsync()).ReturnsAsync(new FeaturesConfig());
         _configStoreMock.Setup(x => x.GetReleaseConfigAsync()).ReturnsAsync(new ReleaseConfig());
+        // Default: AllowStaleImageOnPullFailure = false → a failed pull fails the deployment.
+        _configStoreMock.Setup(x => x.GetSystemConfigAsync()).ReturnsAsync(new SystemConfig());
     }
 
     [Fact]
-    public async Task ExecuteDeploymentAsync_WhenImagePullFails_AndLocalImageExists_ShouldSucceedWithWarning()
+    public async Task ExecuteDeploymentAsync_WhenImagePullFails_AndLocalImageExists_ByDefault_ShouldFail()
     {
         // Arrange
+        var plan = new DeploymentPlan
+        {
+            StackVersion = "1.0.0",
+            EnvironmentId = _testEnvId.ToString(),
+            Steps = new List<DeploymentStep>
+            {
+                new()
+                {
+                    ContextName = "api",
+                    Image = "myregistry.com/api",
+                    Version = "1.0.0",
+                    ContainerName = "rsgo-api",
+                    EnvVars = new Dictionary<string, string>(),
+                    Ports = new List<string>(),
+                    Volumes = new Dictionary<string, string>(),
+                    DependsOn = new List<string>()
+                }
+            }
+        };
+
+        // Mock image pull failure
+        _dockerServiceMock
+            .Setup(x => x.PullImageAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Connection refused - registry unreachable"));
+
+        // Mock local image exists (a stale fallback would otherwise be available)
+        _dockerServiceMock
+            .Setup(x => x.ImageExistsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var startCalled = false;
+        _dockerServiceMock
+            .Setup(x => x.CreateAndStartContainerAsync(It.IsAny<string>(), It.IsAny<CreateContainerRequest>(), It.IsAny<CancellationToken>()))
+            .Callback(() => startCalled = true)
+            .ReturnsAsync("container-id-123");
+
+        // Act
+        var result = await _sut.ExecuteDeploymentAsync(plan);
+
+        // Assert — without the opt-in flag a failed pull fails the deployment, even though a
+        // local copy exists, so a stale image is never silently deployed (and CI goes red).
+        result.Success.Should().BeFalse("a failed pull must fail the deployment by default");
+        result.Errors.Should().ContainSingle();
+        result.Errors[0].Should().Contain("Failed to pull image");
+        result.Errors[0].Should().Contain("AllowStaleImageOnPullFailure");
+        startCalled.Should().BeFalse("no containers should be started when the pull phase fails");
+    }
+
+    [Fact]
+    public async Task ExecuteDeploymentAsync_WhenImagePullFails_AndLocalImageExists_WithAllowStaleFlag_ShouldSucceedWithWarning()
+    {
+        // Arrange — opt back into the lenient local-image fallback via SystemConfig.
+        _configStoreMock.Setup(x => x.GetSystemConfigAsync())
+            .ReturnsAsync(new SystemConfig { AllowStaleImageOnPullFailure = true });
+
         var plan = new DeploymentPlan
         {
             StackVersion = "1.0.0",
@@ -123,7 +180,7 @@ public class DeploymentEngineTests
         var result = await _sut.ExecuteDeploymentAsync(plan);
 
         // Assert
-        result.Success.Should().BeTrue("deployment should succeed when local image is available");
+        result.Success.Should().BeTrue("deployment should succeed when local image is available and the flag is set");
         result.Warnings.Should().ContainSingle("there should be one warning about using local image");
         result.Warnings[0].Should().Contain("could not be pulled");
         result.Warnings[0].Should().Contain("using existing local image");
@@ -220,7 +277,10 @@ public class DeploymentEngineTests
     [Fact]
     public async Task ExecuteDeploymentAsync_WithMultipleServices_WhenOneImagePullFails_ShouldIncludeWarningForThatService()
     {
-        // Arrange
+        // Arrange — the lenient local-image fallback (warning instead of failure) is now opt-in.
+        _configStoreMock.Setup(x => x.GetSystemConfigAsync())
+            .ReturnsAsync(new SystemConfig { AllowStaleImageOnPullFailure = true });
+
         var plan = new DeploymentPlan
         {
             StackVersion = "1.0.0",


### PR DESCRIPTION
## Problem

When pulling an image fails during deployment but a local copy of that image already exists, the deployment engine logs a warning and continues with the cached image — and the deployment (and any calling CI/redeploy pipeline) still reports **success**.

This silently masks broken registry access: a service keeps running an **outdated** image while everything looks green. Observed in the field — an installer image whose pull was denied (`pull access denied ... repository does not exist or may require 'docker login'`) kept redeploying the weeks-old cached image, with every deploy reporting success.

## Change

A failed pull now **fails the deployment by default**, even when a local copy exists — so a stale image is never silently deployed and the pipeline goes red.

Operators that intentionally rely on cached local images (e.g. air-gapped / offline installations) can opt back into the previous lenient behaviour via the new **`SystemConfig.AllowStaleImageOnPullFailure`** flag (default `false`).

The flag lives in `SystemConfig`, not `FeaturesConfig`: `FeaturesConfig` entries are injected into every deployed container as `RSGO_FEATURE_*` env vars, whereas this is an internal deployment-engine policy.

## Behaviour matrix (pull fails)

| Local image exists | Flag | Before | After |
|---|---|---|---|
| no  | – | fail | fail (unchanged) |
| yes | `false` (default) | succeed + warning | **fail** |
| yes | `true` | succeed + warning | succeed + warning (unchanged) |

## Tests

`DeploymentEngineTests` updated: the old "succeed with warning" case is now the default-fail case, a new opt-in test covers `AllowStaleImageOnPullFailure = true`, and the multi-service warning test sets the flag. **22/22 green.**