### PR TITLE
fix(deploy): remove product containers reliably with retry and verification passes

### DIFF
--- a/src/ReadyStackGo.Infrastructure/Services/Deployment/DeploymentEngine.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Deployment/DeploymentEngine.cs
@@ -37,6 +37,19 @@ public class DeploymentEngine : IDeploymentEngine
     /// </summary>
     public const int DefaultInitContainerTimeoutSeconds = 1800;
 
+    /// <summary>
+    /// Number of list-then-remove passes during stack teardown. After removing the current snapshot
+    /// the engine re-lists and removes any container that was missed or recreated by a restart policy.
+    /// Bounded so a genuinely un-removable container cannot spin forever.
+    /// </summary>
+    private const int MaxRemovalPasses = 3;
+
+    /// <summary>Attempts per container before a removal is treated as failed (transient Docker errors are retried).</summary>
+    private const int MaxRemoveAttemptsPerContainer = 3;
+
+    /// <summary>Back-off between container removal retries.</summary>
+    private static readonly TimeSpan RemoveRetryBackoff = TimeSpan.FromMilliseconds(500);
+
     private readonly IConfigStore _configStore;
     private readonly IDockerService _dockerService;
     private readonly IOrganizationRepository _organizationRepository;
@@ -56,6 +69,13 @@ public class DeploymentEngine : IDeploymentEngine
         _environmentRepository = environmentRepository;
         _logger = logger;
     }
+
+    /// <summary>
+    /// Back-off between retries of a transient container removal. Overridable so unit tests
+    /// can run the retry/verification loop without real delays.
+    /// </summary>
+    protected virtual Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+        => Task.Delay(delay, cancellationToken);
 
     public async Task<DeploymentPlan> GenerateDeploymentPlanAsync(ReleaseManifest manifest)
     {
@@ -524,7 +544,26 @@ public class DeploymentEngine : IDeploymentEngine
         return await ExecuteDeploymentAsync(plan);
     }
 
-    public async Task<DeploymentResult> RemoveStackAsync(string environmentId, string stackVersion)
+    public Task<DeploymentResult> RemoveStackAsync(string environmentId, string stackVersion)
+        => RemoveStackInternalAsync(environmentId, stackVersion, progressCallback: null);
+
+    public Task<DeploymentResult> RemoveStackAsync(string environmentId, string stackVersion, DeploymentProgressCallback? progressCallback)
+        => RemoveStackInternalAsync(environmentId, stackVersion, progressCallback);
+
+    /// <summary>
+    /// Robust stack teardown shared by both overloads. Removes every container carrying the
+    /// <c>rsgo.stack=stackVersion</c> label (survivors excluded), then re-lists and repeats until
+    /// none remain or <see cref="MaxRemovalPasses"/> is exhausted. Each individual removal is
+    /// retried up to <see cref="MaxRemoveAttemptsPerContainer"/> times on transient Docker errors
+    /// (e.g. "removal already in progress", "device or resource busy").
+    ///
+    /// The verification passes are the important part: a container that a restart policy recreates
+    /// mid-teardown — or that simply wasn't in the initial snapshot — would otherwise survive as an
+    /// orphan while the deployment is still reported as successfully removed. Success is therefore
+    /// keyed on the final re-list being empty, not merely on the first pass completing.
+    /// </summary>
+    private async Task<DeploymentResult> RemoveStackInternalAsync(
+        string environmentId, string stackVersion, DeploymentProgressCallback? progressCallback)
     {
         var result = new DeploymentResult
         {
@@ -537,101 +576,18 @@ public class DeploymentEngine : IDeploymentEngine
             _logger.LogInformation("Removing stack version {Version} from environment {EnvironmentId}",
                 stackVersion, environmentId);
 
-            // Get all containers with the rsgo.stack label matching stackVersion.
-            // Survival primitive: containers in the edge scope (rsgo.scope=edge) or carrying
-            // the generic rsgo.redeploy=ignore opt-out are NEVER torn down here — they live
-            // outside the product stack identity and must survive redeploys/removals.
-            var containers = await _dockerService.ListContainersAsync(environmentId);
-            var stackContainers = containers
-                .Where(c => c.Labels.TryGetValue("rsgo.stack", out var stack) && stack == stackVersion)
-                .Where(c => !IsSurvivorScoped(c))
-                .ToList();
-
-            if (!stackContainers.Any())
-            {
-                _logger.LogWarning("No containers found for stack {Version} in environment {EnvironmentId}",
-                    stackVersion, environmentId);
-            }
-
-            // Remove all containers for this stack
-            foreach (var container in stackContainers)
-            {
-                try
-                {
-                    _logger.LogInformation("Removing container {Name} ({Id})", container.Name, container.Id);
-                    await _dockerService.RemoveContainerAsync(environmentId, container.Id, force: true);
-
-                    // Extract context name from label
-                    if (container.Labels.TryGetValue("rsgo.context", out var contextName))
-                    {
-                        result.DeployedContexts.Add(contextName);
-                    }
-                    else
-                    {
-                        result.DeployedContexts.Add(container.Name);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "Failed to remove container {Name}", container.Name);
-                    result.Errors.Add($"Failed to remove {container.Name}: {ex.Message}");
-                }
-            }
-
-            // Clear release configuration
-            var releaseConfig = await _configStore.GetReleaseConfigAsync();
-            if (releaseConfig.InstalledStackVersion == stackVersion)
-            {
-                releaseConfig.InstalledStackVersion = null;
-                releaseConfig.InstalledContexts.Clear();
-                releaseConfig.InstallDate = null;
-                await _configStore.SaveReleaseConfigAsync(releaseConfig);
-            }
-
-            result.Success = result.Errors.Count == 0;
-            _logger.LogInformation("Stack removal completed for {Version}", stackVersion);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Stack removal failed");
-            result.Errors.Add($"Removal failed: {ex.Message}");
-            result.Success = false;
-        }
-
-        return result;
-    }
-
-    public async Task<DeploymentResult> RemoveStackAsync(string environmentId, string stackVersion, DeploymentProgressCallback? progressCallback)
-    {
-        var result = new DeploymentResult
-        {
-            StackVersion = stackVersion,
-            DeploymentTime = DateTime.UtcNow
-        };
-
-        try
-        {
-            _logger.LogInformation("Removing stack version {Version} from environment {EnvironmentId} with progress tracking",
-                stackVersion, environmentId);
-
             if (progressCallback != null)
             {
                 await progressCallback("Initializing", "Finding containers to remove...", 5, null, 0, 0, 0, 0);
             }
 
-            // Get all containers with the rsgo.stack label matching stackVersion.
-            // Survival primitive (see other overload): never tear down edge-scoped or
-            // rsgo.redeploy=ignore containers.
-            var containers = await _dockerService.ListContainersAsync(environmentId);
-            var stackContainers = containers
-                .Where(c => c.Labels.TryGetValue("rsgo.stack", out var stack) && stack == stackVersion)
-                .Where(c => !IsSurvivorScoped(c))
-                .ToList();
-
+            // Initial snapshot of the stack's containers (survivors excluded — see IsSurvivorScoped).
+            var stackContainers = await FindStackContainersAsync(environmentId, stackVersion);
             var totalContainers = stackContainers.Count;
             var removedCount = 0;
+            var removedContexts = new HashSet<string>();
 
-            if (!stackContainers.Any())
+            if (totalContainers == 0)
             {
                 _logger.LogWarning("No containers found for stack {Version} in environment {EnvironmentId}",
                     stackVersion, environmentId);
@@ -640,53 +596,60 @@ public class DeploymentEngine : IDeploymentEngine
                     await progressCallback("Complete", "No containers to remove", 100, null, 0, 0, 0, 0);
                 }
             }
-            else
+            else if (progressCallback != null)
             {
-                if (progressCallback != null)
+                await progressCallback("RemovingContainers", $"Found {totalContainers} container(s) to remove", 10, null, totalContainers, 0, 0, 0);
+            }
+
+            for (var pass = 1; pass <= MaxRemovalPasses && stackContainers.Count > 0; pass++)
+            {
+                if (pass > 1)
                 {
-                    await progressCallback("RemovingContainers", $"Found {totalContainers} container(s) to remove", 10, null, totalContainers, 0, 0, 0);
+                    _logger.LogInformation(
+                        "Stack {Version}: verification pass {Pass} found {Count} remaining container(s) to remove",
+                        stackVersion, pass, stackContainers.Count);
                 }
 
-                // Remove all containers for this stack
                 foreach (var container in stackContainers)
                 {
-                    try
+                    var containerName = container.Labels.TryGetValue("rsgo.context", out var ctx) ? ctx : container.Name;
+
+                    if (progressCallback != null)
                     {
-                        var containerName = container.Labels.TryGetValue("rsgo.context", out var ctx) ? ctx : container.Name;
-
-                        if (progressCallback != null)
-                        {
-                            var progressPercent = 10 + (int)((removedCount / (double)totalContainers) * 80);
-                            await progressCallback("RemovingContainers", $"Removing {containerName}...", progressPercent, containerName, totalContainers, removedCount, 0, 0);
-                        }
-
-                        _logger.LogInformation("Removing container {Name} ({Id})", container.Name, container.Id);
-                        await _dockerService.RemoveContainerAsync(environmentId, container.Id, force: true);
-
-                        removedCount++;
-
-                        // Extract context name from label
-                        if (container.Labels.TryGetValue("rsgo.context", out var contextName))
-                        {
-                            result.DeployedContexts.Add(contextName);
-                        }
-                        else
-                        {
-                            result.DeployedContexts.Add(container.Name);
-                        }
-
-                        if (progressCallback != null)
-                        {
-                            var progressPercent = 10 + (int)((removedCount / (double)totalContainers) * 80);
-                            await progressCallback("RemovingContainers", $"Removed {containerName}", progressPercent, null, totalContainers, removedCount, 0, 0);
-                        }
+                        await progressCallback("RemovingContainers", $"Removing {containerName}...",
+                            RemovalProgressPercent(removedCount, totalContainers), containerName, totalContainers, removedCount, 0, 0);
                     }
-                    catch (Exception ex)
+
+                    if (await TryRemoveContainerWithRetryAsync(environmentId, container, result))
                     {
-                        _logger.LogWarning(ex, "Failed to remove container {Name}", container.Name);
-                        result.Errors.Add($"Failed to remove {container.Name}: {ex.Message}");
+                        removedCount++;
+                        removedContexts.Add(containerName);
+
+                        if (progressCallback != null)
+                        {
+                            await progressCallback("RemovingContainers", $"Removed {containerName}",
+                                RemovalProgressPercent(removedCount, totalContainers), null, totalContainers, removedCount, 0, 0);
+                        }
                     }
                 }
+
+                // Re-list to catch containers missed by the snapshot or recreated by a restart policy.
+                stackContainers = await FindStackContainersAsync(environmentId, stackVersion);
+            }
+
+            result.DeployedContexts.AddRange(removedContexts);
+
+            // Anything still present after all passes is a genuine teardown failure. Record it so the
+            // caller does NOT mark the deployment as removed (which would turn the leftover into an orphan).
+            foreach (var leftover in stackContainers)
+            {
+                var name = leftover.Labels.TryGetValue("rsgo.context", out var c) ? c : leftover.Name;
+                if (!result.Errors.Any(e => e.Contains(name, StringComparison.Ordinal)))
+                {
+                    result.Errors.Add($"Container '{name}' still present after {MaxRemovalPasses} removal passes");
+                }
+                _logger.LogWarning("Container {Name} for stack {Version} could not be removed after {Passes} passes",
+                    name, stackVersion, MaxRemovalPasses);
             }
 
             if (progressCallback != null)
@@ -704,12 +667,20 @@ public class DeploymentEngine : IDeploymentEngine
                 await _configStore.SaveReleaseConfigAsync(releaseConfig);
             }
 
-            result.Success = result.Errors.Count == 0;
-            _logger.LogInformation("Stack removal completed for {Version}", stackVersion);
+            result.Success = result.Errors.Count == 0 && stackContainers.Count == 0;
+            _logger.LogInformation("Stack removal completed for {Version}: success={Success}, removed={Removed}",
+                stackVersion, result.Success, removedCount);
 
             if (progressCallback != null)
             {
-                await progressCallback("Complete", $"Successfully removed {removedCount} container(s)", 100, null, totalContainers, removedCount, 0, 0);
+                if (result.Success)
+                {
+                    await progressCallback("Complete", $"Successfully removed {removedCount} container(s)", 100, null, totalContainers, removedCount, 0, 0);
+                }
+                else
+                {
+                    await progressCallback("Error", $"Removal incomplete: {result.Errors.Count} container(s) could not be removed", 100, null, totalContainers, removedCount, 0, 0);
+                }
             }
         }
         catch (Exception ex)
@@ -725,6 +696,61 @@ public class DeploymentEngine : IDeploymentEngine
         }
 
         return result;
+    }
+
+    /// <summary>
+    /// Lists the stack's containers by the <c>rsgo.stack</c> label, excluding survivor-scoped
+    /// containers (edge scope / <c>rsgo.redeploy=ignore</c>) which must never be torn down here.
+    /// </summary>
+    private async Task<List<ContainerDto>> FindStackContainersAsync(string environmentId, string stackVersion)
+    {
+        var containers = await _dockerService.ListContainersAsync(environmentId);
+        return containers
+            .Where(c => c.Labels.TryGetValue("rsgo.stack", out var stack) && stack == stackVersion)
+            .Where(c => !IsSurvivorScoped(c))
+            .ToList();
+    }
+
+    /// <summary>
+    /// Force-removes a single container, retrying on transient Docker errors. Returns true if the
+    /// container was removed, false if all attempts failed (an error is appended to <paramref name="result"/>).
+    /// </summary>
+    private async Task<bool> TryRemoveContainerWithRetryAsync(string environmentId, ContainerDto container, DeploymentResult result)
+    {
+        for (var attempt = 1; attempt <= MaxRemoveAttemptsPerContainer; attempt++)
+        {
+            try
+            {
+                _logger.LogInformation("Removing container {Name} ({Id}) [attempt {Attempt}/{Max}]",
+                    container.Name, container.Id, attempt, MaxRemoveAttemptsPerContainer);
+                await _dockerService.RemoveContainerAsync(environmentId, container.Id, force: true);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                if (attempt >= MaxRemoveAttemptsPerContainer)
+                {
+                    _logger.LogWarning(ex, "Failed to remove container {Name} after {Max} attempts",
+                        container.Name, MaxRemoveAttemptsPerContainer);
+                    result.Errors.Add($"Failed to remove {container.Name}: {ex.Message}");
+                    return false;
+                }
+
+                _logger.LogWarning(ex, "Transient failure removing container {Name} (attempt {Attempt}/{Max}); retrying",
+                    container.Name, attempt, MaxRemoveAttemptsPerContainer);
+                await DelayAsync(RemoveRetryBackoff, CancellationToken.None);
+            }
+        }
+
+        return false;
+    }
+
+    private static int RemovalProgressPercent(int removedCount, int totalContainers)
+    {
+        if (totalContainers <= 0) return 50;
+        // Clamp: verification passes can push removedCount toward totalContainers without exceeding the 10-90 band.
+        var ratio = Math.Min(1.0, removedCount / (double)totalContainers);
+        return 10 + (int)(ratio * 80);
     }
 
     private Dictionary<string, string> GenerateGlobalEnvVars(

--- a/tests/ReadyStackGo.UnitTests/DeploymentEngineTests.cs
+++ b/tests/ReadyStackGo.UnitTests/DeploymentEngineTests.cs
@@ -969,10 +969,12 @@ public class DeploymentEngineTests
     {
         // Arrange
         var progressUpdates = new List<(string Phase, int TotalInitContainers, int CompletedInitContainers)>();
+        var removedIds = new HashSet<string>();
 
+        // Simulate the daemon: a removed container no longer appears on the verification re-list.
         _dockerServiceMock
             .Setup(x => x.ListContainersAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<ContainerDto>
+            .ReturnsAsync(() => new List<ContainerDto>
             {
                 new()
                 {
@@ -983,10 +985,11 @@ public class DeploymentEngineTests
                     Status = "running",
                     Labels = new Dictionary<string, string> { ["rsgo.stack"] = "test-stack", ["rsgo.context"] = "api" }
                 }
-            });
+            }.Where(c => !removedIds.Contains(c.Id)).ToList());
 
         _dockerServiceMock
             .Setup(x => x.RemoveContainerAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, bool, CancellationToken>((_, id, _, _) => removedIds.Add(id))
             .Returns(Task.CompletedTask);
 
         _configStoreMock

--- a/tests/ReadyStackGo.UnitTests/Edge/DeploymentEngineRemovalRobustnessTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Edge/DeploymentEngineRemovalRobustnessTests.cs
@@ -1,0 +1,127 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Application.UseCases.Containers;
+using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.IdentityAccess.Organizations;
+using ReadyStackGo.Infrastructure.Configuration;
+using ReadyStackGo.Infrastructure.Services.Deployment;
+using Xunit;
+
+namespace ReadyStackGo.UnitTests.Edge;
+
+/// <summary>
+/// Verifies that <see cref="DeploymentEngine.RemoveStackAsync(string,string)"/> removes ALL
+/// stack containers reliably even when Docker misbehaves during teardown:
+/// transient removal errors are retried, and containers that were missed or recreated by a
+/// restart policy are caught by a verification re-list pass. Without this, a straggler survives
+/// as an orphaned container while the deployment is still reported as removed.
+/// </summary>
+public class DeploymentEngineRemovalRobustnessTests
+{
+    private readonly Mock<IConfigStore> _configStore = new();
+    private readonly Mock<IDockerService> _docker = new();
+    private readonly Mock<IOrganizationRepository> _orgRepo = new();
+    private readonly Mock<IEnvironmentRepository> _envRepo = new();
+    private readonly TestableDeploymentEngine _sut;
+
+    private const string EnvId = "11111111-1111-1111-1111-111111111111";
+    private const string StackVersion = "test-stack";
+
+    public DeploymentEngineRemovalRobustnessTests()
+    {
+        _sut = new TestableDeploymentEngine(
+            _configStore.Object, _docker.Object, _orgRepo.Object, _envRepo.Object,
+            new Mock<ILogger<DeploymentEngine>>().Object);
+
+        _configStore.Setup(x => x.GetReleaseConfigAsync()).ReturnsAsync(new ReleaseConfig());
+        _configStore.Setup(x => x.SaveReleaseConfigAsync(It.IsAny<ReleaseConfig>())).Returns(Task.CompletedTask);
+    }
+
+    private static ContainerDto AppContainer() => new()
+    {
+        Id = "app", Name = "app", Image = "app:1", State = "running", Status = "running",
+        Labels = new Dictionary<string, string> { ["rsgo.stack"] = StackVersion, ["rsgo.context"] = "app" }
+    };
+
+    [Fact]
+    public async Task RemoveStackAsync_RetriesTransientRemovalFailure_AndSucceeds()
+    {
+        // ListContainers: snapshot shows the container, re-list shows it gone.
+        _docker.SetupSequence(x => x.ListContainersAsync(EnvId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ContainerDto> { AppContainer() })
+            .ReturnsAsync(new List<ContainerDto>());
+
+        // First remove attempt throws a transient Docker error, second succeeds.
+        var attempts = 0;
+        _docker.Setup(x => x.RemoveContainerAsync(EnvId, "app", true, It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                attempts++;
+                return attempts == 1
+                    ? throw new InvalidOperationException("removal of container app is already in progress")
+                    : Task.CompletedTask;
+            });
+
+        var result = await _sut.RemoveStackAsync(EnvId, StackVersion);
+
+        result.Success.Should().BeTrue("the transient failure was retried and the container was removed");
+        attempts.Should().Be(2, "the removal should be retried once after the transient failure");
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RemoveStackAsync_RemovesContainerRecreatedByRestartPolicy_ViaVerificationPass()
+    {
+        // The container reappears after the first removal (restart-policy race), then is gone.
+        _docker.SetupSequence(x => x.ListContainersAsync(EnvId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ContainerDto> { AppContainer() }) // initial snapshot
+            .ReturnsAsync(new List<ContainerDto> { AppContainer() }) // verification pass 1: still there
+            .ReturnsAsync(new List<ContainerDto>());                 // verification pass 2: gone
+
+        _docker.Setup(x => x.RemoveContainerAsync(EnvId, "app", true, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var result = await _sut.RemoveStackAsync(EnvId, StackVersion);
+
+        result.Success.Should().BeTrue("the reappearing container is caught by the verification pass");
+        _docker.Verify(x => x.RemoveContainerAsync(EnvId, "app", true, It.IsAny<CancellationToken>()),
+            Times.Exactly(2), "the container must be removed again after it reappeared");
+    }
+
+    [Fact]
+    public async Task RemoveStackAsync_FailsWhenContainerCannotBeRemoved()
+    {
+        // Container never disappears and every removal attempt fails.
+        _docker.Setup(x => x.ListContainersAsync(EnvId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new List<ContainerDto> { AppContainer() });
+
+        _docker.Setup(x => x.RemoveContainerAsync(EnvId, "app", true, It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("device or resource busy"));
+
+        var result = await _sut.RemoveStackAsync(EnvId, StackVersion);
+
+        result.Success.Should().BeFalse("a container that cannot be removed must be reported as a failure");
+        result.Errors.Should().NotBeEmpty();
+        _docker.Verify(x => x.RemoveContainerAsync(EnvId, "app", true, It.IsAny<CancellationToken>()),
+            Times.AtLeast(2), "removal must be retried before giving up");
+    }
+
+    /// <summary>
+    /// Subclass that removes the retry backoff delay so tests run instantly.
+    /// </summary>
+    private sealed class TestableDeploymentEngine : DeploymentEngine
+    {
+        public TestableDeploymentEngine(
+            IConfigStore configStore, IDockerService dockerService,
+            IOrganizationRepository organizationRepository, IEnvironmentRepository environmentRepository,
+            ILogger<DeploymentEngine> logger)
+            : base(configStore, dockerService, organizationRepository, environmentRepository, logger)
+        {
+        }
+
+        protected override Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+    }
+}

--- a/tests/ReadyStackGo.UnitTests/Edge/DeploymentEngineSurvivalTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Edge/DeploymentEngineSurvivalTests.cs
@@ -42,8 +42,11 @@ public class DeploymentEngineSurvivalTests
             .Callback<string, string, bool, CancellationToken>((_, id, _, _) => _removedIds.Add(id))
             .Returns(Task.CompletedTask);
 
+        // Simulate the daemon: a container that was removed no longer appears on a re-list.
+        // RemoveStackAsync re-lists to verify teardown, so a static list would look like the
+        // container never went away.
         _docker.Setup(x => x.ListContainersAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Containers());
+            .ReturnsAsync(() => Containers().Where(c => !_removedIds.Contains(c.Id)).ToList());
     }
 
     private static List<ContainerDto> Containers() => new()


### PR DESCRIPTION
## Problem

Removing a product sometimes left containers behind (visible as **orphaned** containers afterwards). Stack teardown listed a stack's containers once and force-removed each with a single attempt:

- A transient Docker error (`409 removal already in progress`, `device or resource busy`) left that container behind.
- A container recreated by its restart policy mid-teardown, or simply missing from the initial snapshot, was never removed.

In both cases `RemoveStackAsync` still returned `Success = true`, so the deployment was marked *removed* and the leftover became a silent orphan.

## Fix

Both `RemoveStackAsync` overloads now share one robust core (`RemoveStackInternalAsync`):

- **Retry** each container removal on transient Docker errors (bounded by `MaxRemoveAttemptsPerContainer`, with back-off).
- **Verification passes**: after removing the current snapshot, re-list and repeat until no stack containers remain (bounded by `MaxRemovalPasses`) — catching missed or restart-recreated containers.
- **Honest success**: `Success` is keyed on the final re-list being empty, not just the first pass completing. A genuine leftover now fails the removal (so the deployment is *not* marked removed) instead of orphaning silently.

Survivor-scoped containers (`rsgo.scope=edge` / `rsgo.redeploy=ignore`) remain excluded from teardown.

## Tests

New `DeploymentEngineRemovalRobustnessTests` (red → green):

- transient failure → retried → success
- container recreated by restart policy → removed via verification pass
- permanently un-removable container → `Success=false` + error, no infinite loop

Two existing tests used static container-list mocks (container stayed visible after removal); adjusted to simulate realistic daemon behaviour. Full unit suite green.