### PR TITLE
fix: internal/LAN HTTP clients must bypass the forward proxy (#446)

### DIFF
--- a/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
+++ b/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
@@ -141,12 +141,8 @@ public static class DependencyInjection
         services.AddScoped<Application.Services.Edge.IEdgeReconciler, Application.Services.Impl.EdgeReconciler>();
         services.AddScoped<Application.Services.Edge.ISniRouterReconciler, Application.Services.Impl.SniRouterReconciler>();
 
-        // HTTP client for the Caddy admin API
-        services.AddHttpClient(Services.Edge.CaddyAdminClient.HttpClientName, client =>
-        {
-            client.DefaultRequestHeaders.Add("User-Agent", "ReadyStackGo-Edge");
-            client.Timeout = TimeSpan.FromSeconds(10);
-        });
+        // HTTP client for the Caddy admin API (internal — must bypass any forward proxy).
+        services.AddEdgeAdminHttpClient();
 
         // HTTP client for the webhook setter
         services.AddHttpClient("MaintenanceSetter", client =>
@@ -224,6 +220,23 @@ public static class DependencyInjection
         services.AddScoped<OrganizationProvisioningService>();
         services.AddScoped<AuthenticationService>();
 
+        return services;
+    }
+
+    /// <summary>
+    /// Registers the named <see cref="System.Net.Http.HttpClient"/> used to talk to a product
+    /// edge's Caddy admin API. This is always a container-internal call, so it must never
+    /// traverse a forward proxy (<c>HTTP_PROXY</c>/<c>HTTPS_PROXY</c>): otherwise, in
+    /// environments where a proxy is configured, the admin <c>/load</c> POST is routed to the
+    /// proxy, fails, and the edge never leaves its bootstrap holding page (issue #446).
+    /// </summary>
+    public static IServiceCollection AddEdgeAdminHttpClient(this IServiceCollection services)
+    {
+        services.AddHttpClient(Services.Edge.CaddyAdminClient.HttpClientName, client =>
+        {
+            client.DefaultRequestHeaders.Add("User-Agent", "ReadyStackGo-Edge");
+            client.Timeout = TimeSpan.FromSeconds(10);
+        });
         return services;
     }
 }

--- a/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
+++ b/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
@@ -112,19 +112,10 @@ public static class DependencyInjection
         services.AddScoped<IHealthCollectorService, HealthCollectorService>();
         services.AddSingleton<IHealthChangeTracker, HealthChangeTracker>();
 
-        // Maintenance Observers (v0.11)
+        // Maintenance Observers (v0.11) — the HTTP observer client is registered in
+        // AddInternalHttpClients (it targets a product endpoint and must bypass the proxy).
         services.AddSingleton<IMaintenanceObserverFactory, MaintenanceObserverFactory>();
         services.AddScoped<IMaintenanceObserverService, MaintenanceObserverService>();
-
-        // HTTP client for HTTP observer
-        services.AddHttpClient("MaintenanceObserver", client =>
-        {
-            client.DefaultRequestHeaders.Add("User-Agent", "ReadyStackGo-MaintenanceObserver");
-        })
-        .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
-        {
-            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-        });
 
         // Maintenance Setter (mirror of the observer — propagates RSGO-initiated transitions)
         services.AddSingleton<IMaintenanceSetterFactory, MaintenanceSetterFactory>();
@@ -141,28 +132,13 @@ public static class DependencyInjection
         services.AddScoped<Application.Services.Edge.IEdgeReconciler, Application.Services.Impl.EdgeReconciler>();
         services.AddScoped<Application.Services.Edge.ISniRouterReconciler, Application.Services.Impl.SniRouterReconciler>();
 
-        // HTTP client for the Caddy admin API (internal — must bypass any forward proxy).
-        services.AddEdgeAdminHttpClient();
+        // Internal/LAN HTTP clients — edge admin API, HTTP maintenance observer/setter, HTTP
+        // health checks and PRTG. All bypass any forward proxy (HTTP_PROXY/HTTPS_PROXY); see
+        // AddInternalHttpClients (issue #446).
+        services.AddInternalHttpClients();
 
-        // HTTP client for the webhook setter
-        services.AddHttpClient("MaintenanceSetter", client =>
-        {
-            client.DefaultRequestHeaders.Add("User-Agent", "ReadyStackGo-MaintenanceSetter");
-        })
-        .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
-        {
-            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-        });
-
-        // Health check infrastructure services
-        services.AddHttpClient<IHttpHealthChecker, HttpHealthChecker>(client =>
-        {
-            client.DefaultRequestHeaders.Add("User-Agent", "ReadyStackGo-HealthChecker");
-        })
-        .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
-        {
-            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-        });
+        // Health check infrastructure services (the HTTP checker client is registered in
+        // AddInternalHttpClients — it targets product containers and must bypass the proxy).
         services.AddSingleton<ITcpHealthChecker, TcpHealthChecker>();
 
         // Health check strategies (resolved by type via factory)
@@ -177,21 +153,8 @@ public static class DependencyInjection
         // are themselves Scoped, so no behavior changes.
         services.AddScoped<IHealthCheckStrategyFactory, HealthCheckStrategyFactory>();
 
-        // PRTG HTTP API client (Variant 3) — separate verify/no-verify-TLS clients
-        // so customers with self-signed PRTG certificates can opt out of cert
-        // validation per-connection (set on the PrtgConnection aggregate).
-        services.AddHttpClient("PrtgApiVerifyTls", c =>
-        {
-            c.DefaultRequestHeaders.Add("User-Agent", "ReadyStackGo-PrtgClient");
-        });
-        services.AddHttpClient("PrtgApiNoVerifyTls", c =>
-        {
-            c.DefaultRequestHeaders.Add("User-Agent", "ReadyStackGo-PrtgClient");
-        })
-        .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
-        {
-            ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
-        });
+        // PRTG HTTP API client (Variant 3): the verify / no-verify-TLS HttpClients are registered
+        // in AddInternalHttpClients — PRTG lives on the customer LAN and must bypass the proxy.
         services.AddSingleton<ReadyStackGo.Application.Services.IPrtgApiClient,
                               Services.Prtg.PrtgApiClient>();
 
@@ -224,11 +187,61 @@ public static class DependencyInjection
     }
 
     /// <summary>
+    /// Registers every HTTP client whose target is reachable directly — a product container on
+    /// the internal Docker network (edge admin API, HTTP maintenance observer/setter, HTTP health
+    /// checks) or the PRTG server on the customer LAN. All of these must bypass a forward proxy
+    /// (<c>HTTP_PROXY</c>/<c>HTTPS_PROXY</c>): routing an internal/LAN call through an internet
+    /// proxy makes it fail — issue #446, where the edge admin <c>/load</c> POST was hijacked by
+    /// the proxy, failed silently, and stranded the edge on its bootstrap holding page; the same
+    /// failure class hits health checks and the maintenance observer/setter. Clients that talk to
+    /// the public internet (registries, GitHub, Cloudflare) keep the default proxy behaviour and
+    /// are registered separately.
+    /// </summary>
+    public static IServiceCollection AddInternalHttpClients(this IServiceCollection services)
+    {
+        // Caddy admin API (edge container).
+        services.AddEdgeAdminHttpClient();
+
+        // HTTP maintenance observer — reads the product's flag from a product endpoint.
+        services.AddHttpClient("MaintenanceObserver", client =>
+        {
+            client.DefaultRequestHeaders.Add("User-Agent", "ReadyStackGo-MaintenanceObserver");
+        })
+        .ConfigurePrimaryHttpMessageHandler(() => InternalHttpClientHandler(acceptAnyServerCert: true));
+
+        // Webhook maintenance setter — pushes the transition to a product endpoint.
+        services.AddHttpClient("MaintenanceSetter", client =>
+        {
+            client.DefaultRequestHeaders.Add("User-Agent", "ReadyStackGo-MaintenanceSetter");
+        })
+        .ConfigurePrimaryHttpMessageHandler(() => InternalHttpClientHandler(acceptAnyServerCert: true));
+
+        // HTTP health checks against the deployed product containers.
+        services.AddHttpClient<IHttpHealthChecker, HttpHealthChecker>(client =>
+        {
+            client.DefaultRequestHeaders.Add("User-Agent", "ReadyStackGo-HealthChecker");
+        })
+        .ConfigurePrimaryHttpMessageHandler(() => InternalHttpClientHandler(acceptAnyServerCert: true));
+
+        // PRTG monitoring API on the customer LAN — separate verify / no-verify-TLS clients so
+        // customers with self-signed PRTG certificates can opt out of cert validation per-connection.
+        services.AddHttpClient("PrtgApiVerifyTls", c =>
+        {
+            c.DefaultRequestHeaders.Add("User-Agent", "ReadyStackGo-PrtgClient");
+        })
+        .ConfigurePrimaryHttpMessageHandler(() => InternalHttpClientHandler(acceptAnyServerCert: false));
+        services.AddHttpClient("PrtgApiNoVerifyTls", c =>
+        {
+            c.DefaultRequestHeaders.Add("User-Agent", "ReadyStackGo-PrtgClient");
+        })
+        .ConfigurePrimaryHttpMessageHandler(() => InternalHttpClientHandler(acceptAnyServerCert: true));
+
+        return services;
+    }
+
+    /// <summary>
     /// Registers the named <see cref="System.Net.Http.HttpClient"/> used to talk to a product
-    /// edge's Caddy admin API. This is always a container-internal call, so it must never
-    /// traverse a forward proxy (<c>HTTP_PROXY</c>/<c>HTTPS_PROXY</c>): otherwise, in
-    /// environments where a proxy is configured, the admin <c>/load</c> POST is routed to the
-    /// proxy, fails, and the edge never leaves its bootstrap holding page (issue #446).
+    /// edge's Caddy admin API. Container-internal — must bypass any forward proxy (issue #446).
     /// </summary>
     public static IServiceCollection AddEdgeAdminHttpClient(this IServiceCollection services)
     {
@@ -236,7 +249,22 @@ public static class DependencyInjection
         {
             client.DefaultRequestHeaders.Add("User-Agent", "ReadyStackGo-Edge");
             client.Timeout = TimeSpan.FromSeconds(10);
-        });
+        })
+        .ConfigurePrimaryHttpMessageHandler(() => InternalHttpClientHandler(acceptAnyServerCert: false));
         return services;
     }
+
+    /// <summary>
+    /// Primary handler for HTTP clients whose target is reachable directly (internal Docker
+    /// network or customer LAN). Sets <c>UseProxy = false</c> so a forward proxy configured via
+    /// <c>HTTP_PROXY</c>/<c>HTTPS_PROXY</c> can never hijack the call (issue #446), and optionally
+    /// accepts any server certificate (for self-signed product/PRTG endpoints).
+    /// </summary>
+    private static HttpClientHandler InternalHttpClientHandler(bool acceptAnyServerCert) => new()
+    {
+        UseProxy = false,
+        ServerCertificateCustomValidationCallback = acceptAnyServerCert
+            ? HttpClientHandler.DangerousAcceptAnyServerCertificateValidator
+            : null
+    };
 }

--- a/tests/ReadyStackGo.UnitTests/Edge/EdgeServiceRegistrationTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Edge/EdgeServiceRegistrationTests.cs
@@ -61,25 +61,34 @@ public class EdgeServiceRegistrationTests
     }
 
     /// <summary>
-    /// Regression guard for #446: the edge admin <c>/load</c> call is container-internal and must
-    /// never be routed through a forward proxy (<c>HTTP_PROXY</c>/<c>HTTPS_PROXY</c>). Otherwise,
-    /// in proxied environments, the POST is sent to the proxy, fails, and the edge never leaves
-    /// its bootstrap holding page — the maintenance page is shown forever.
+    /// Regression guard for #446: every HTTP client whose target is reachable directly — a
+    /// product container on the internal Docker network (edge admin, HTTP observer/setter, HTTP
+    /// health checks) or the PRTG server on the customer LAN — must bypass a forward proxy
+    /// (<c>HTTP_PROXY</c>/<c>HTTPS_PROXY</c>). Otherwise, in proxied environments, the call is
+    /// routed to the proxy and fails: the edge admin <c>/load</c> POST then strands the edge on
+    /// its holding page (the maintenance page is shown forever), and health/observer/setter/PRTG
+    /// all break the same way.
     /// </summary>
-    [Fact]
-    public void EdgeAdminHttpClient_BypassesForwardProxy()
+    [Theory]
+    [InlineData(CaddyAdminClient.HttpClientName)]
+    [InlineData("MaintenanceObserver")]
+    [InlineData("MaintenanceSetter")]
+    [InlineData("IHttpHealthChecker")] // typed client logical name = typeof(IHttpHealthChecker).Name
+    [InlineData("PrtgApiVerifyTls")]
+    [InlineData("PrtgApiNoVerifyTls")]
+    public void InternalHttpClients_BypassForwardProxy(string clientName)
     {
         var services = new ServiceCollection();
-        services.AddEdgeAdminHttpClient();
+        services.AddInternalHttpClients();
         using var provider = services.BuildServiceProvider();
 
         var factory = provider.GetRequiredService<IHttpMessageHandlerFactory>();
-        using var handler = factory.CreateHandler(CaddyAdminClient.HttpClientName);
+        using var handler = factory.CreateHandler(clientName);
 
         var primary = PrimaryHandler(handler);
         var httpClientHandler = Assert.IsType<HttpClientHandler>(primary);
         Assert.False(httpClientHandler.UseProxy,
-            "the internal edge admin client must not use a forward proxy (#446)");
+            $"internal/LAN client '{clientName}' must not use a forward proxy (#446)");
     }
 
     private static HttpMessageHandler PrimaryHandler(HttpMessageHandler handler)

--- a/tests/ReadyStackGo.UnitTests/Edge/EdgeServiceRegistrationTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Edge/EdgeServiceRegistrationTests.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
@@ -5,6 +6,7 @@ using ReadyStackGo.Application.Services;
 using ReadyStackGo.Application.Services.Edge;
 using ReadyStackGo.Application.Services.Impl;
 using ReadyStackGo.Domain.Deployment.ProductDeployments;
+using ReadyStackGo.Infrastructure;
 using ReadyStackGo.Infrastructure.Configuration;
 using ReadyStackGo.Infrastructure.Services.Edge;
 using Xunit;
@@ -56,5 +58,35 @@ public class EdgeServiceRegistrationTests
         });
 
         Assert.Null(ex);
+    }
+
+    /// <summary>
+    /// Regression guard for #446: the edge admin <c>/load</c> call is container-internal and must
+    /// never be routed through a forward proxy (<c>HTTP_PROXY</c>/<c>HTTPS_PROXY</c>). Otherwise,
+    /// in proxied environments, the POST is sent to the proxy, fails, and the edge never leaves
+    /// its bootstrap holding page — the maintenance page is shown forever.
+    /// </summary>
+    [Fact]
+    public void EdgeAdminHttpClient_BypassesForwardProxy()
+    {
+        var services = new ServiceCollection();
+        services.AddEdgeAdminHttpClient();
+        using var provider = services.BuildServiceProvider();
+
+        var factory = provider.GetRequiredService<IHttpMessageHandlerFactory>();
+        using var handler = factory.CreateHandler(CaddyAdminClient.HttpClientName);
+
+        var primary = PrimaryHandler(handler);
+        var httpClientHandler = Assert.IsType<HttpClientHandler>(primary);
+        Assert.False(httpClientHandler.UseProxy,
+            "the internal edge admin client must not use a forward proxy (#446)");
+    }
+
+    private static HttpMessageHandler PrimaryHandler(HttpMessageHandler handler)
+    {
+        var current = handler;
+        while (current is DelegatingHandler delegating && delegating.InnerHandler is not null)
+            current = delegating.InnerHandler;
+        return current;
     }
 }


### PR DESCRIPTION
## Bug
On a customer install the edge-proxy showed the maintenance/"deploying" holding page **permanently**, even though the product was healthy. Fixes #446.

## Root Cause
The edge boots with a bootstrap maintenance config (`EdgeProvisioner`) and only switches to proxy once RSGO successfully POSTs the config to the edge's Caddy admin API. That call uses the `EdgeAdmin` `HttpClient`, which had no primary-handler override — so on Linux .NET routed this **container-internal** call through the system/env forward proxy (`HTTP_PROXY`/`HTTPS_PROXY`, e.g. injected by a Docker daemon proxy). The proxy can't reach the internal container → the POST fails → `LoadConfigAsync` swallows it (Debug log) and returns false → the reconciler retries forever → the edge never leaves the holding page.

The same failure class affects **every** RSGO HTTP client that targets a directly-reachable host, not just the edge.

## Fix
Centralize all internal/LAN HTTP clients in a new `AddInternalHttpClients` behind a shared `InternalHttpClientHandler` with `UseProxy = false`:

| Client | Target | Proxy |
|---|---|---|
| `EdgeAdmin` | edge container admin API | **bypass** |
| `MaintenanceObserver` | product endpoint (HTTP observer) | **bypass** |
| `MaintenanceSetter` | product endpoint (webhook) | **bypass** |
| `IHttpHealthChecker` | product containers | **bypass** |
| `PrtgApiVerifyTls` / `PrtgApiNoVerifyTls` | PRTG on customer LAN | **bypass** |
| `RegistryCheck`, `OciRegistry`, `GitHub`, `Cloudflare` | public internet | keep proxy |

Existing per-client TLS behaviour (accept self-signed for product/PRTG) is preserved.

## Immediate mitigation (no upgrade needed)
Set `NO_PROXY`/`no_proxy` on the RSGO container to cover the internal docker network / edge alias / PRTG host.

## Verification
- [x] Test reproduces the bug (Red): default `HttpClientHandler.UseProxy == true`
- [x] Fix implemented
- [x] Test confirms the fix (Green) — `[Theory]` asserts all 6 internal clients bypass the proxy
- [x] Full solution build: 0 errors
- [x] Full unit suite green (3153)

Fixes #446