### PR TITLE
docs(installation): fix outdated image name and volume mapping

### DIFF
--- a/src/ReadyStackGo.PublicWeb/src/content/docs/de/getting-started/installation/docker-compose.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/de/getting-started/installation/docker-compose.md
@@ -35,17 +35,21 @@ Erstelle eine Datei `docker-compose.yml` mit folgendem Inhalt:
 ```yaml
 services:
   readystackgo:
-    image: ghcr.io/ams/readystackgo:latest
+    image: wiesenwischer/readystackgo:latest
     container_name: readystackgo
     restart: unless-stopped
     ports:
       - "8080:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - readystackgo-data:/data
+      - readystackgo-config:/app/config
+      - readystackgo-data:/app/data
+      - readystackgo-stacks:/app/stacks
 
 volumes:
+  readystackgo-config:
   readystackgo-data:
+  readystackgo-stacks:
 ```
 
 ### Schritt 3: Container starten
@@ -63,14 +67,16 @@ Du kannst die Compose-Datei nach Bedarf erweitern:
 ```yaml
 services:
   readystackgo:
-    image: ghcr.io/ams/readystackgo:latest
+    image: wiesenwischer/readystackgo:latest
     container_name: readystackgo
     restart: unless-stopped
     ports:
       - "8080:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - readystackgo-data:/data
+      - readystackgo-config:/app/config
+      - readystackgo-data:/app/data
+      - readystackgo-stacks:/app/stacks
     environment:
       - TZ=Europe/Berlin
     deploy:
@@ -79,7 +85,9 @@ services:
           memory: 512M
 
 volumes:
+  readystackgo-config:
   readystackgo-data:
+  readystackgo-stacks:
 ```
 
 ### Konfigurationsoptionen
@@ -127,7 +135,7 @@ Erfolgreiche Ausgabe:
 
 ```
 NAME              IMAGE                              STATUS         PORTS
-readystackgo      ghcr.io/ams/readystackgo:latest    Up 2 minutes   0.0.0.0:8080->8080/tcp
+readystackgo      wiesenwischer/readystackgo:latest  Up 2 minutes   0.0.0.0:8080->8080/tcp
 ```
 
 ---

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/de/getting-started/installation/docker-run.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/de/getting-started/installation/docker-run.md
@@ -21,13 +21,7 @@ sudo systemctl start docker
 
 ## Installation
 
-### Schritt 1: Datenverzeichnis erstellen
-
-```bash
-sudo mkdir -p /var/readystackgo
-```
-
-### Schritt 2: Container starten
+### Container starten
 
 ```bash
 docker run -d \
@@ -35,9 +29,13 @@ docker run -d \
   --restart unless-stopped \
   -p 8080:8080 \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -v /var/readystackgo:/data \
-  ghcr.io/ams/readystackgo:latest
+  -v readystackgo-config:/app/config \
+  -v readystackgo-data:/app/data \
+  -v readystackgo-stacks:/app/stacks \
+  wiesenwischer/readystackgo:latest
 ```
+
+Die benannten Volumes werden von Docker beim ersten Start automatisch angelegt – du musst vorab kein Verzeichnis erstellen.
 
 ---
 
@@ -50,7 +48,9 @@ docker run -d \
 | `--restart unless-stopped` | Automatischer Neustart nach System-Reboot |
 | `-p 8080:8080` | Port-Mapping (Host:Container) |
 | `-v /var/run/docker.sock:...` | Docker Socket für Container-Management |
-| `-v /var/readystackgo:/data` | Persistente Daten (Konfiguration, Deployments) |
+| `-v readystackgo-config:/app/config` | Persistente Konfiguration |
+| `-v readystackgo-data:/app/data` | Datenbank und Verschlüsselungsschlüssel (**kritisch** – ohne dieses Volume gehen bei einem Neustart alle verschlüsselten Zugangsdaten verloren) |
+| `-v readystackgo-stacks:/app/stacks` | Stack-Definitionen |
 
 ---
 
@@ -64,8 +64,10 @@ docker run -d \
   --restart unless-stopped \
   -p 3000:8080 \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -v /var/readystackgo:/data \
-  ghcr.io/ams/readystackgo:latest
+  -v readystackgo-config:/app/config \
+  -v readystackgo-data:/app/data \
+  -v readystackgo-stacks:/app/stacks \
+  wiesenwischer/readystackgo:latest
 ```
 
 In diesem Beispiel ist ReadyStackGo unter Port `3000` erreichbar.
@@ -86,7 +88,7 @@ Erfolgreiche Ausgabe:
 
 ```
 CONTAINER ID   IMAGE                              STATUS         PORTS                    NAMES
-abc123...      ghcr.io/ams/readystackgo:latest    Up 2 minutes   0.0.0.0:8080->8080/tcp   readystackgo
+abc123...      wiesenwischer/readystackgo:latest  Up 2 minutes   0.0.0.0:8080->8080/tcp   readystackgo
 ```
 
 ---

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/de/getting-started/installation/script.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/de/getting-started/installation/script.md
@@ -34,7 +34,7 @@ Das Bootstrap-Script führt automatisch folgende Schritte aus:
 | **1. Systemprüfung** | Erkennt deine Linux-Distribution und Paketmanager |
 | **2. Docker-Installation** | Installiert Docker falls nicht vorhanden (via `get.docker.com`) |
 | **3. Docker-Start** | Startet und aktiviert den Docker-Dienst |
-| **4. Verzeichnisstruktur** | Erstellt `/var/readystackgo` für persistente Daten |
+| **4. Volumes** | Legt die benannten Volumes `readystackgo-config`, `readystackgo-data` und `readystackgo-stacks` für persistente Daten an |
 | **5. Container-Start** | Lädt und startet den ReadyStackGo-Container |
 
 ---
@@ -65,7 +65,7 @@ Erfolgreiche Ausgabe:
 
 ```
 CONTAINER ID   IMAGE                              STATUS         PORTS                    NAMES
-abc123...      ghcr.io/ams/readystackgo:latest    Up 2 minutes   0.0.0.0:8080->8080/tcp   readystackgo
+abc123...      wiesenwischer/readystackgo:latest  Up 2 minutes   0.0.0.0:8080->8080/tcp   readystackgo
 ```
 
 ---

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/en/getting-started/installation/docker-compose.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/en/getting-started/installation/docker-compose.md
@@ -35,17 +35,21 @@ Create a file `docker-compose.yml` with the following content:
 ```yaml
 services:
   readystackgo:
-    image: ghcr.io/ams/readystackgo:latest
+    image: wiesenwischer/readystackgo:latest
     container_name: readystackgo
     restart: unless-stopped
     ports:
       - "8080:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - readystackgo-data:/data
+      - readystackgo-config:/app/config
+      - readystackgo-data:/app/data
+      - readystackgo-stacks:/app/stacks
 
 volumes:
+  readystackgo-config:
   readystackgo-data:
+  readystackgo-stacks:
 ```
 
 ### Step 3: Start Container
@@ -63,14 +67,16 @@ You can extend the Compose file as needed:
 ```yaml
 services:
   readystackgo:
-    image: ghcr.io/ams/readystackgo:latest
+    image: wiesenwischer/readystackgo:latest
     container_name: readystackgo
     restart: unless-stopped
     ports:
       - "8080:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - readystackgo-data:/data
+      - readystackgo-config:/app/config
+      - readystackgo-data:/app/data
+      - readystackgo-stacks:/app/stacks
     environment:
       - TZ=Europe/Berlin
     deploy:
@@ -79,7 +85,9 @@ services:
           memory: 512M
 
 volumes:
+  readystackgo-config:
   readystackgo-data:
+  readystackgo-stacks:
 ```
 
 ---

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/en/getting-started/installation/docker-run.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/en/getting-started/installation/docker-run.md
@@ -21,13 +21,7 @@ sudo systemctl start docker
 
 ## Installation
 
-### Step 1: Create Data Directory
-
-```bash
-sudo mkdir -p /var/readystackgo
-```
-
-### Step 2: Start Container
+### Start Container
 
 ```bash
 docker run -d \
@@ -35,9 +29,13 @@ docker run -d \
   --restart unless-stopped \
   -p 8080:8080 \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -v /var/readystackgo:/data \
-  ghcr.io/ams/readystackgo:latest
+  -v readystackgo-config:/app/config \
+  -v readystackgo-data:/app/data \
+  -v readystackgo-stacks:/app/stacks \
+  wiesenwischer/readystackgo:latest
 ```
+
+The named volumes are created automatically by Docker on first start – you do not need to create a directory beforehand.
 
 ---
 
@@ -50,7 +48,9 @@ docker run -d \
 | `--restart unless-stopped` | Auto-restart after system reboot |
 | `-p 8080:8080` | Port mapping (Host:Container) |
 | `-v /var/run/docker.sock:...` | Docker socket for container management |
-| `-v /var/readystackgo:/data` | Persistent data (configuration, deployments) |
+| `-v readystackgo-config:/app/config` | Persistent configuration |
+| `-v readystackgo-data:/app/data` | Database and encryption key (**critical** – without this volume all encrypted credentials are lost on restart) |
+| `-v readystackgo-stacks:/app/stacks` | Stack definitions |
 
 ---
 
@@ -64,8 +64,10 @@ docker run -d \
   --restart unless-stopped \
   -p 3000:8080 \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -v /var/readystackgo:/data \
-  ghcr.io/ams/readystackgo:latest
+  -v readystackgo-config:/app/config \
+  -v readystackgo-data:/app/data \
+  -v readystackgo-stacks:/app/stacks \
+  wiesenwischer/readystackgo:latest
 ```
 
 In this example, ReadyStackGo is accessible on port `3000`.

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/en/getting-started/installation/script.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/en/getting-started/installation/script.md
@@ -34,7 +34,7 @@ The bootstrap script automatically performs the following steps:
 | **1. System Check** | Detects your Linux distribution and package manager |
 | **2. Docker Installation** | Installs Docker if not present (via `get.docker.com`) |
 | **3. Docker Start** | Starts and enables the Docker service |
-| **4. Directory Structure** | Creates `/var/readystackgo` for persistent data |
+| **4. Volumes** | Creates the named volumes `readystackgo-config`, `readystackgo-data` and `readystackgo-stacks` for persistent data |
 | **5. Container Start** | Downloads and starts the ReadyStackGo container |
 
 ---
@@ -65,7 +65,7 @@ Successful output:
 
 ```
 CONTAINER ID   IMAGE                              STATUS         PORTS                    NAMES
-abc123...      ghcr.io/ams/readystackgo:latest    Up 2 minutes   0.0.0.0:8080->8080/tcp   readystackgo
+abc123...      wiesenwischer/readystackgo:latest  Up 2 minutes   0.0.0.0:8080->8080/tcp   readystackgo
 ```
 
 ---


### PR DESCRIPTION
## Problem

The installation docs still referenced a single `/data` volume that the current image does not use. Following them persisted nothing useful — configuration, the SQLite database and the auto-generated encryption key were lost on every container recreation. Without the key, previously encrypted credentials (PRTG tokens, SSH keys, SNMP passphrases) become unreadable ("Padding is invalid").

The image name was also inconsistent: the install pages used `ghcr.io/ams/readystackgo:latest`, while the bootstrap `install.sh`, self-update and `docker-compose.yml` all use `wiesenwischer/readystackgo`.

## Fix

Align the docker-run, docker-compose and bootstrap-script pages (DE + EN) with the bootstrap `install.sh`, which is the source of truth:

- Image `wiesenwischer/readystackgo:latest` instead of `ghcr.io/ams/readystackgo:latest`
- Three named volumes instead of the dead `/data` mount:
  - `readystackgo-config` → `/app/config`
  - `readystackgo-data` → `/app/data` (database + encryption key — flagged as critical)
  - `readystackgo-stacks` → `/app/stacks`
- Dropped the obsolete `mkdir` step (named volumes are created automatically)
- Updated verify-output snippets and parameter tables accordingly

## Files

- `docker-run.md` (DE + EN)
- `docker-compose.md` (DE + EN)
- `script.md` (DE + EN)
