### PR TITLE
feat: apply changed edge.mss on redeploy/upgrade and log the effective tuning

### DIFF
--- a/src/ReadyStackGo.Application/Services/Edge/EdgeConstants.cs
+++ b/src/ReadyStackGo.Application/Services/Edge/EdgeConstants.cs
@@ -1,5 +1,7 @@
 namespace ReadyStackGo.Application.Services.Edge;
 
+using ReadyStackGo.Domain.Deployment.Edge;
+
 /// <summary>
 /// Shared constants for the managed maintenance edge-proxy feature.
 /// </summary>
@@ -78,6 +80,32 @@ public static class EdgeConstants
     /// the edge network MTU to <c>n + MssHeaderOverhead</c>.
     /// </summary>
     public const int MssHeaderOverhead = 40;
+
+    /// <summary>
+    /// Label recording the client-facing MSS tuning the edge container was <em>created</em> with.
+    /// Sysctls and the network MTU cannot be changed on a live container, so this label is the
+    /// drift fingerprint: when it no longer matches <see cref="MssFingerprint"/> of the current
+    /// config, the container has to be recreated for the setting to take effect.
+    /// </summary>
+    public const string MssLabel = "rsgo.edge.mss";
+
+    /// <summary>
+    /// Fingerprint of the configured client-facing MSS tuning: <c>pmtu</c>, the plain number for
+    /// a fixed MSS, or <c>off</c>. Stored in <see cref="MssLabel"/> at container creation.
+    /// </summary>
+    public static string MssFingerprint(EdgeConfig config) => config.MssMode switch
+    {
+        EdgeMssMode.Pmtu => "pmtu",
+        EdgeMssMode.Fixed => config.MssValue!.Value.ToString(System.Globalization.CultureInfo.InvariantCulture),
+        _ => MssFingerprintOff
+    };
+
+    /// <summary>
+    /// Fingerprint of an edge container that applies no MSS tuning at all. Also the assumed
+    /// fingerprint of a container created before the <c>mss</c> option existed (no label): such a
+    /// container carries neither sysctls nor a lowered MTU, which is exactly <c>off</c>.
+    /// </summary>
+    public const string MssFingerprintOff = "off";
 
     /// <summary>
     /// Derives the deterministic edge container name from the product deployment name.

--- a/src/ReadyStackGo.Application/Services/Edge/IEdgeConfigCache.cs
+++ b/src/ReadyStackGo.Application/Services/Edge/IEdgeConfigCache.cs
@@ -15,6 +15,13 @@ public interface IEdgeConfigCache
 
     /// <summary>Records the config most recently pushed successfully for a deployment.</summary>
     void Set(Guid productDeploymentId, string configJson);
+
+    /// <summary>
+    /// Drops the recorded config for a deployment, forcing the next reconcile cycle to push
+    /// again. Required whenever the edge container is replaced: the fresh container only carries
+    /// the bootstrap config, so a cache hit would leave it stuck on the maintenance page.
+    /// </summary>
+    void Invalidate(Guid productDeploymentId);
 }
 
 /// <summary>Default <see cref="IEdgeConfigCache"/> backed by a concurrent dictionary.</summary>
@@ -27,4 +34,7 @@ public class EdgeConfigCache : IEdgeConfigCache
 
     public void Set(Guid productDeploymentId, string configJson)
         => _lastPushed[productDeploymentId] = configJson;
+
+    public void Invalidate(Guid productDeploymentId)
+        => _lastPushed.TryRemove(productDeploymentId, out _);
 }

--- a/src/ReadyStackGo.Application/Services/Edge/IEdgeProvisioner.cs
+++ b/src/ReadyStackGo.Application/Services/Edge/IEdgeProvisioner.cs
@@ -24,6 +24,26 @@ public interface IEdgeProvisioner
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Recreates the edge container when the client-facing MSS tuning it was <em>created</em> with
+    /// no longer matches the configured one. Container sysctls and the network MTU cannot be
+    /// changed on a live container, so recreation is the only way such a change takes effect.
+    ///
+    /// Deliberately NOT part of <see cref="EnsureEdgeAsync"/>: this briefly takes the product's
+    /// front door down, so it only runs on an explicit operator action (redeploy / upgrade),
+    /// never from the background reconcile loop.
+    /// </summary>
+    /// <returns>
+    /// <c>true</c> when the container was recreated — the caller must then invalidate the cached
+    /// edge config so the reconciler pushes the live config to the fresh container.
+    /// </returns>
+    Task<bool> ReconcileEdgeMssAsync(
+        string environmentId,
+        string deploymentName,
+        string productGroupId,
+        EdgeConfig config,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Idempotently ensures the optional shared host-level SNI passthrough router exists and is
     /// running (Phase 4). Survivor-scoped, attached to the management network, host-binds the
     /// configured listen port, and boots with an admin-reachable empty Layer-4 config that the

--- a/src/ReadyStackGo.Application/Services/Edge/IEdgeSettingsReconciler.cs
+++ b/src/ReadyStackGo.Application/Services/Edge/IEdgeSettingsReconciler.cs
@@ -1,0 +1,28 @@
+using ReadyStackGo.Domain.Deployment.ProductDeployments;
+
+namespace ReadyStackGo.Application.Services.Edge;
+
+/// <summary>
+/// Applies edge settings that can only be set when the edge container is <em>created</em>
+/// (currently the client-facing MSS tuning: namespaced sysctls / the edge network MTU).
+///
+/// Called from the redeploy and upgrade use cases — the two operations where the operator
+/// explicitly asks RSGO to re-apply the product's manifest — because recreating the container
+/// briefly takes the product's front door down. The background edge reconciler deliberately
+/// leaves an existing container alone.
+/// </summary>
+public interface IEdgeSettingsReconciler
+{
+    /// <summary>
+    /// Recreates the product's edge container when its live create-time settings drifted from
+    /// <see cref="ProductDeployment.EdgeConfig"/>, and invalidates the cached Caddy config so
+    /// the reconciler pushes the live config to the fresh container.
+    ///
+    /// A no-op when the product has no edge configured. Never throws: a failure to re-apply a
+    /// tuning value must not fail the surrounding redeploy/upgrade.
+    /// </summary>
+    /// <returns><c>true</c> when the edge container was recreated.</returns>
+    Task<bool> ApplyCreateTimeSettingsAsync(
+        ProductDeployment productDeployment,
+        CancellationToken cancellationToken = default);
+}

--- a/src/ReadyStackGo.Application/Services/Impl/EdgeSettingsReconciler.cs
+++ b/src/ReadyStackGo.Application/Services/Impl/EdgeSettingsReconciler.cs
@@ -1,0 +1,68 @@
+using Microsoft.Extensions.Logging;
+using ReadyStackGo.Application.Services.Edge;
+using ReadyStackGo.Domain.Deployment.ProductDeployments;
+
+namespace ReadyStackGo.Application.Services.Impl;
+
+/// <summary>
+/// Default <see cref="IEdgeSettingsReconciler"/>: delegates the drift check to the provisioner
+/// and, when it recreated the container, drops the cached Caddy config so the fresh container
+/// gets the live config on the next reconcile cycle instead of staying on its bootstrap
+/// maintenance page.
+/// </summary>
+public class EdgeSettingsReconciler : IEdgeSettingsReconciler
+{
+    private readonly IEdgeProvisioner _provisioner;
+    private readonly IEdgeConfigCache _configCache;
+    private readonly ILogger<EdgeSettingsReconciler> _logger;
+
+    public EdgeSettingsReconciler(
+        IEdgeProvisioner provisioner,
+        IEdgeConfigCache configCache,
+        ILogger<EdgeSettingsReconciler> logger)
+    {
+        _provisioner = provisioner;
+        _configCache = configCache;
+        _logger = logger;
+    }
+
+    public async Task<bool> ApplyCreateTimeSettingsAsync(
+        ProductDeployment productDeployment,
+        CancellationToken cancellationToken = default)
+    {
+        var edgeConfig = productDeployment.EdgeConfig;
+        if (edgeConfig is null)
+            return false;
+
+        try
+        {
+            var recreated = await _provisioner.ReconcileEdgeMssAsync(
+                productDeployment.EnvironmentId.Value.ToString(),
+                productDeployment.DeploymentName,
+                productDeployment.ProductGroupId,
+                edgeConfig,
+                cancellationToken);
+
+            if (!recreated)
+                return false;
+
+            // The replacement container only has the bootstrap config — force a fresh push.
+            _configCache.Invalidate(productDeployment.Id.Value);
+
+            _logger.LogInformation(
+                "Edge container of product {ProductName} recreated to apply MSS mode {MssMode}",
+                productDeployment.ProductName, edgeConfig.MssMode);
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            // The front door keeps running with its previous tuning — worth a warning, not a
+            // failed redeploy/upgrade.
+            _logger.LogWarning(ex,
+                "Could not re-apply create-time edge settings for product {ProductName} — the edge keeps its current tuning",
+                productDeployment.ProductName);
+            return false;
+        }
+    }
+}

--- a/src/ReadyStackGo.Application/UseCases/Deployments/RedeployProduct/RedeployProductHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/RedeployProduct/RedeployProductHandler.cs
@@ -23,6 +23,8 @@ public class RedeployProductHandler : IRequestHandler<RedeployProductCommand, De
     private readonly INotificationService? _inAppNotificationService;
     private readonly ILogger<RedeployProductHandler> _logger;
     private readonly TimeProvider _timeProvider;
+    private readonly Application.Services.Edge.IEdgeBundleReader? _edgeBundleReader;
+    private readonly Application.Services.Edge.IEdgeSettingsReconciler? _edgeSettingsReconciler;
 
     public RedeployProductHandler(
         IProductDeploymentRepository repository,
@@ -32,7 +34,9 @@ public class RedeployProductHandler : IRequestHandler<RedeployProductCommand, De
         ILogger<RedeployProductHandler> logger,
         IDeploymentNotificationService? notificationService = null,
         INotificationService? inAppNotificationService = null,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        Application.Services.Edge.IEdgeBundleReader? edgeBundleReader = null,
+        Application.Services.Edge.IEdgeSettingsReconciler? edgeSettingsReconciler = null)
     {
         _repository = repository;
         _productSourceService = productSourceService;
@@ -42,6 +46,8 @@ public class RedeployProductHandler : IRequestHandler<RedeployProductCommand, De
         _notificationService = notificationService;
         _inAppNotificationService = inAppNotificationService;
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _edgeBundleReader = edgeBundleReader;
+        _edgeSettingsReconciler = edgeSettingsReconciler;
     }
 
     public async Task<DeployProductResponse> Handle(RedeployProductCommand request, CancellationToken cancellationToken)
@@ -92,6 +98,8 @@ public class RedeployProductHandler : IRequestHandler<RedeployProductCommand, De
                 productDeployment.SetMaintenanceSetterConfig(
                     MaintenanceSetterConfigMapper.Map(product.MaintenanceSetter, observerVariables));
 
+                await RefreshEdgeConfigAsync(productDeployment, product, observerVariables, cancellationToken);
+
                 if (observerConfig != null)
                 {
                     _logger.LogInformation(
@@ -118,6 +126,14 @@ public class RedeployProductHandler : IRequestHandler<RedeployProductCommand, De
 
         _repository.Update(productDeployment);
         _repository.SaveChanges();
+
+        // Edge settings that are fixed when the container is created (the client-facing MSS
+        // tuning) only take effect on a fresh container. Recreate it here — before the stacks
+        // go down — so the whole redeploy already runs behind the configured edge.
+        if (_edgeSettingsReconciler != null)
+        {
+            await _edgeSettingsReconciler.ApplyCreateTimeSettingsAsync(productDeployment, cancellationToken);
+        }
 
         var pendingStacks = productDeployment.Stacks.Count(s => s.Status == StackDeploymentStatus.Pending);
         _logger.LogInformation(
@@ -304,6 +320,50 @@ public class RedeployProductHandler : IRequestHandler<RedeployProductCommand, De
             SessionId = sessionId,
             StackResults = stackResults
         };
+    }
+
+    /// <summary>
+    /// Re-resolves the optional managed-edge config from the current catalog, mirroring the
+    /// maintenance-observer refresh: this is how manifest edits to the <c>edge:</c> block (e.g.
+    /// <c>edge.mss</c>) reach a running deployment on redeploy.
+    /// </summary>
+    private async Task RefreshEdgeConfigAsync(
+        ProductDeployment productDeployment,
+        Domain.StackManagement.Stacks.ProductDefinition product,
+        IReadOnlyDictionary<string, string> variables,
+        CancellationToken cancellationToken)
+    {
+        string? edgeBundleHtml = null;
+        if (_edgeBundleReader != null &&
+            string.Equals(product.Edge?.MaintenancePage?.Mode, "bundle", StringComparison.OrdinalIgnoreCase))
+        {
+            edgeBundleHtml = await _edgeBundleReader.ReadBundleHtmlAsync(
+                product.FilePath, product.Edge!.MaintenancePage!.BundlePath, cancellationToken);
+        }
+
+        var edgeConfig = EdgeConfigMapper.Map(product.Edge, variables, edgeBundleHtml);
+
+        if (edgeConfig == null)
+        {
+            if (productDeployment.EdgeConfig != null)
+            {
+                // Deliberately keep the stored config: tearing down a product's front door
+                // because a manifest value stopped resolving is worse than an outdated setting.
+                _logger.LogWarning(
+                    "Product {ProductName} has a stored edge config but the manifest edge: block could not be resolved on redeploy (removed or unresolved variables?) — keeping the existing edge",
+                    productDeployment.ProductName);
+            }
+            return;
+        }
+
+        if (edgeConfig.Equals(productDeployment.EdgeConfig))
+            return;
+
+        productDeployment.SetEdgeConfig(edgeConfig);
+        _logger.LogInformation(
+            "Redeploy {ProductDeploymentId} refreshed edge config for host {Hostname} -> {Upstream}:{Port} (MSS mode: {MssMode})",
+            productDeployment.Id, edgeConfig.PublicHostname, edgeConfig.UpstreamService,
+            edgeConfig.UpstreamPort, edgeConfig.MssMode);
     }
 
     // Merge shared variables with redeploy overrides for observer placeholder resolution.

--- a/src/ReadyStackGo.Application/UseCases/Deployments/UpgradeProduct/UpgradeProductHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/UpgradeProduct/UpgradeProductHandler.cs
@@ -24,6 +24,7 @@ public class UpgradeProductHandler : IRequestHandler<UpgradeProductCommand, Upgr
     private readonly ILogger<UpgradeProductHandler> _logger;
     private readonly TimeProvider _timeProvider;
     private readonly Application.Services.Edge.IEdgeBundleReader? _edgeBundleReader;
+    private readonly Application.Services.Edge.IEdgeSettingsReconciler? _edgeSettingsReconciler;
 
     public UpgradeProductHandler(
         IProductSourceService productSourceService,
@@ -34,7 +35,8 @@ public class UpgradeProductHandler : IRequestHandler<UpgradeProductCommand, Upgr
         IDeploymentNotificationService? notificationService = null,
         INotificationService? inAppNotificationService = null,
         TimeProvider? timeProvider = null,
-        Application.Services.Edge.IEdgeBundleReader? edgeBundleReader = null)
+        Application.Services.Edge.IEdgeBundleReader? edgeBundleReader = null,
+        Application.Services.Edge.IEdgeSettingsReconciler? edgeSettingsReconciler = null)
     {
         _productSourceService = productSourceService;
         _repository = repository;
@@ -45,6 +47,7 @@ public class UpgradeProductHandler : IRequestHandler<UpgradeProductCommand, Upgr
         _inAppNotificationService = inAppNotificationService;
         _timeProvider = timeProvider ?? TimeProvider.System;
         _edgeBundleReader = edgeBundleReader;
+        _edgeSettingsReconciler = edgeSettingsReconciler;
     }
 
     public async Task<UpgradeProductResponse> Handle(UpgradeProductCommand request, CancellationToken cancellationToken)
@@ -207,6 +210,15 @@ public class UpgradeProductHandler : IRequestHandler<UpgradeProductCommand, Upgr
         {
             productDeployment.SetEdgeConfig(edgeConfig);
         }
+        else if (existing.EdgeConfig != null)
+        {
+            // The target manifest's edge: block did not resolve — carry the running config
+            // forward instead of leaving the live edge container without a config to reconcile.
+            productDeployment.SetEdgeConfig(existing.EdgeConfig);
+            _logger.LogWarning(
+                "Target version of {ProductName} has no resolvable edge: block — keeping the edge config of the running deployment",
+                targetProduct.Name);
+        }
 
         _repository.Add(productDeployment);
 
@@ -222,6 +234,14 @@ public class UpgradeProductHandler : IRequestHandler<UpgradeProductCommand, Upgr
         _logger.LogInformation(
             "Product upgrade {ProductDeploymentId} initiated for {ProductName} from v{PreviousVersion} to v{TargetVersion} with {StackCount} stacks (superseded {OldId})",
             newDeploymentId, targetProduct.Name, previousVersion, targetVersion, stackConfigs.Count, existing.Id);
+
+        // Edge settings that are fixed at container creation (the client-facing MSS tuning) only
+        // take effect on a fresh container. Recreate it before the stacks are touched so the
+        // upgrade already runs behind the edge the target version asks for.
+        if (_edgeSettingsReconciler != null)
+        {
+            await _edgeSettingsReconciler.ApplyCreateTimeSettingsAsync(productDeployment, cancellationToken);
+        }
 
         // 8. Generate session ID
         var sessionId = !string.IsNullOrEmpty(request.SessionId)

--- a/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
+++ b/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
@@ -130,6 +130,7 @@ public static class DependencyInjection
         services.AddSingleton<Application.Services.Edge.IEdgeBundleReader, Services.Edge.EdgeBundleReader>();
         services.AddSingleton<Application.Services.Edge.IEdgeConfigCache, Application.Services.Edge.EdgeConfigCache>();
         services.AddScoped<Application.Services.Edge.IEdgeReconciler, Application.Services.Impl.EdgeReconciler>();
+        services.AddScoped<Application.Services.Edge.IEdgeSettingsReconciler, Application.Services.Impl.EdgeSettingsReconciler>();
         services.AddScoped<Application.Services.Edge.ISniRouterReconciler, Application.Services.Impl.SniRouterReconciler>();
 
         // Internal/LAN HTTP clients — edge admin API, HTTP maintenance observer/setter, HTTP

--- a/src/ReadyStackGo.Infrastructure/Services/Edge/EdgeProvisioner.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Edge/EdgeProvisioner.cs
@@ -20,6 +20,52 @@ public class EdgeProvisioner : IEdgeProvisioner
 {
     private const string ManagementNetwork = "rsgo-net";
 
+    /// <summary>
+    /// Container entrypoint: materialise the bootstrap config, print one stable line stating
+    /// whether the configured client-facing MSS tuning is actually in effect, then run Caddy.
+    ///
+    /// The banner is the field-support answer to "did this customer's edge really get the new
+    /// setting?" — <c>docker logs &lt;deployment&gt;-edge | head -1</c> shows it, because sysctls
+    /// and the interface MTU are read from the live container, not from RSGO's intent. A mismatch
+    /// (verdict=INACTIVE) means the container predates the setting or the network MTU could not
+    /// be applied.
+    /// </summary>
+    private const string StartupScript = """
+        printf '%s' "$CADDY_BOOTSTRAP_CONFIG" > /etc/caddy/bootstrap.json
+        mode="${RSGO_EDGE_MSS_MODE:-off}"
+        probing="$(cat /proc/sys/net/ipv4/tcp_mtu_probing 2>/dev/null || echo '?')"
+        base_mss="$(cat /proc/sys/net/ipv4/tcp_base_mss 2>/dev/null || echo '?')"
+        ifmtus=""
+        lowest=""
+        for dev in /sys/class/net/*; do
+          name="${dev##*/}"
+          if [ "$name" != "lo" ]; then
+            m="$(cat "$dev/mtu" 2>/dev/null || echo '?')"
+            ifmtus="$ifmtus $name=$m"
+            case "$m" in
+              ''|*[!0-9]*) ;;
+              *) if [ -z "$lowest" ] || [ "$m" -lt "$lowest" ]; then lowest="$m"; fi ;;
+            esac
+          fi
+        done
+        case "$mode" in
+          pmtu)
+            expected="tcp_mtu_probing=1"
+            if [ "$probing" = "1" ]; then verdict=ACTIVE; else verdict=INACTIVE; fi ;;
+          off)
+            expected="none"
+            verdict=DISABLED ;;
+          ''|*[!0-9]*)
+            expected="?"
+            verdict=UNKNOWN ;;
+          *)
+            expected="edge network mtu<=$((mode + 40))"
+            if [ -n "$lowest" ] && [ "$lowest" -le "$((mode + 40))" ]; then verdict=ACTIVE; else verdict=INACTIVE; fi ;;
+        esac
+        echo "rsgo-edge: client-facing MSS tuning mode=$mode verdict=$verdict (expected: $expected | tcp_mtu_probing=$probing tcp_base_mss=$base_mss iface_mtu:$ifmtus)"
+        exec caddy run --config /etc/caddy/bootstrap.json
+        """;
+
     private readonly IDockerService _dockerService;
     private readonly ILogger<EdgeProvisioner> _logger;
 
@@ -49,6 +95,8 @@ public class EdgeProvisioner : IEdgeProvisioner
         await _dockerService.EnsureNetworkAsync(environmentId, ManagementNetwork, cancellationToken);
 
         // Idempotency: reuse an existing edge container; just make sure it is running.
+        // Create-time settings (MSS tuning) of an existing container are NOT touched here —
+        // that would restart the front door from a background loop. See ReconcileEdgeMssAsync.
         var existing = await _dockerService.GetContainerByNameAsync(environmentId, containerName, cancellationToken);
         if (existing != null)
         {
@@ -61,6 +109,79 @@ public class EdgeProvisioner : IEdgeProvisioner
             return adminBaseUrl;
         }
 
+        await CreateEdgeContainerAsync(
+            environmentId, containerName, deploymentName, productGroupId, config, sysctls, cancellationToken);
+
+        return adminBaseUrl;
+    }
+
+    public async Task<bool> ReconcileEdgeMssAsync(
+        string environmentId,
+        string deploymentName,
+        string productGroupId,
+        EdgeConfig config,
+        CancellationToken cancellationToken = default)
+    {
+        var containerName = EdgeConstants.EdgeContainerName(deploymentName);
+        var desiredFingerprint = EdgeConstants.MssFingerprint(config);
+
+        var existing = await _dockerService.GetContainerByNameAsync(environmentId, containerName, cancellationToken);
+        if (existing == null)
+        {
+            // Nothing to reconcile — the next EnsureEdgeAsync creates it with the current tuning.
+            return false;
+        }
+
+        // A container created before the mss option existed carries no label and no tuning,
+        // which is exactly what "off" means.
+        var currentFingerprint = existing.Labels.TryGetValue(EdgeConstants.MssLabel, out var label)
+            && !string.IsNullOrWhiteSpace(label)
+                ? label
+                : EdgeConstants.MssFingerprintOff;
+
+        if (string.Equals(currentFingerprint, desiredFingerprint, StringComparison.OrdinalIgnoreCase))
+        {
+            _logger.LogDebug(
+                "Edge container {Name} already runs the configured MSS tuning ({Fingerprint}) — no recreation needed",
+                containerName, desiredFingerprint);
+            return false;
+        }
+
+        var (sysctls, networkMtu) = ResolveMssTuning(config);
+
+        // Recreate: sysctls and the network MTU are fixed at creation time. The fresh container
+        // boots with the maintenance bootstrap config; the reconciler pushes the live config on
+        // its next cycle (the caller invalidates the config cache so that push actually happens).
+        _logger.LogInformation(
+            "Edge container {Name} was created with MSS tuning '{Current}' but '{Desired}' is configured — recreating it",
+            containerName, currentFingerprint, desiredFingerprint);
+
+        // Creates the edge network with the requested MTU when it is missing; logs a warning when
+        // it exists with a different MTU (Docker cannot change that without recreating the network).
+        await _dockerService.EnsureNetworkAsync(environmentId, config.Network, networkMtu, cancellationToken);
+        await _dockerService.EnsureNetworkAsync(environmentId, ManagementNetwork, cancellationToken);
+
+        await _dockerService.RemoveContainerAsync(environmentId, existing.Id, force: true, cancellationToken);
+
+        await CreateEdgeContainerAsync(
+            environmentId, containerName, deploymentName, productGroupId, config, sysctls, cancellationToken);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Creates and starts a fresh edge container with the survival labels, the MSS fingerprint
+    /// label and a bootstrap maintenance config. Shared by initial provisioning and recreation.
+    /// </summary>
+    private async Task CreateEdgeContainerAsync(
+        string environmentId,
+        string containerName,
+        string deploymentName,
+        string productGroupId,
+        EdgeConfig config,
+        Dictionary<string, string> sysctls,
+        CancellationToken cancellationToken)
+    {
         // Pull the edge image (best-effort; container create surfaces a hard failure clearly).
         await EnsureImageAsync(environmentId, config.Image, cancellationToken);
 
@@ -83,16 +204,14 @@ public class EdgeProvisioner : IEdgeProvisioner
             Ports = new List<string> { $"{config.PublicPort}:{config.PublicPort}" },
             EnvironmentVariables = new Dictionary<string, string>
             {
-                ["CADDY_BOOTSTRAP_CONFIG"] = bootstrapConfig
+                ["CADDY_BOOTSTRAP_CONFIG"] = bootstrapConfig,
+                // Consumed by the startup banner below so the log states the intended mode.
+                ["RSGO_EDGE_MSS_MODE"] = EdgeConstants.MssFingerprint(config)
             },
             // Override the image entrypoint (the official caddy image's ENTRYPOINT is "caddy",
             // so a plain Cmd would be appended to it). Write the bootstrap config from the env
-            // var, then run Caddy against it.
-            Entrypoint = new List<string>
-            {
-                "sh", "-c",
-                "printf '%s' \"$CADDY_BOOTSTRAP_CONFIG\" > /etc/caddy/bootstrap.json && exec caddy run --config /etc/caddy/bootstrap.json"
-            },
+            // var, log the effective MSS tuning, then run Caddy against it.
+            Entrypoint = new List<string> { "sh", "-c", StartupScript },
             Sysctls = sysctls,
             Labels = new Dictionary<string, string>
             {
@@ -100,7 +219,9 @@ public class EdgeProvisioner : IEdgeProvisioner
                 [EdgeConstants.RedeployLabel] = EdgeConstants.RedeployIgnore,
                 ["rsgo.maintenance"] = "ignore",
                 [EdgeConstants.ProductLabel] = productGroupId,
-                [EdgeConstants.ContextLabel] = EdgeConstants.ContextEdge
+                [EdgeConstants.ContextLabel] = EdgeConstants.ContextEdge,
+                // Drift fingerprint of the create-time MSS tuning (see ReconcileEdgeMssAsync).
+                [EdgeConstants.MssLabel] = EdgeConstants.MssFingerprint(config)
             },
             RestartPolicy = "unless-stopped"
         };
@@ -109,8 +230,6 @@ public class EdgeProvisioner : IEdgeProvisioner
         _logger.LogInformation(
             "Provisioned managed edge container {Name} ({Id}) for product {Product} on {PublicPort} -> {Upstream}:{UpstreamPort} (MSS mode: {MssMode})",
             containerName, id, productGroupId, config.PublicPort, config.UpstreamService, config.UpstreamPort, config.MssMode);
-
-        return adminBaseUrl;
     }
 
     public async Task<string> EnsureSniRouterAsync(

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/configuration/maintenance-edge-proxy.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/configuration/maintenance-edge-proxy.md
@@ -299,6 +299,38 @@ Der Standard (`pmtu`) wird über **namespace-lokale Kernel-Sysctls** (`net.ipv4.
 
 > **Einschränkung im festen Modus:** Ein fester MSS-Wert wird angewendet, wenn RSGO das Edge-Netz **anlegt**. Existiert das Netz bereits (z. B. weil es zuerst vom Produkt-Stack erstellt wurde), lässt sich seine MTU nicht ohne Neuanlage ändern; RSGO schreibt eine Warnung ins Log und die feste Grenze greift nicht. Bevorzuge in diesem Fall `pmtu` (funktioniert unabhängig davon, wer das Netz besitzt) oder lass RSGO das Netz anlegen.
 
+### Wann eine Änderung greift
+
+Sysctls und die Netz-MTU sind **Erstellungs-Parameter** eines Containers — sie lassen sich an einem laufenden Container nicht ändern. Der Edge-Container überlebt außerdem bewusst jeden Redeploy (Label `rsgo.redeploy=ignore`), damit die Wartungsseite während des Redeploys erreichbar bleibt.
+
+Damit eine geänderte `mss`-Einstellung trotzdem ankommt, gilt:
+
+- **Redeploy und Upgrade lesen den `edge:`-Block neu aus dem Manifest** und vergleichen die eingestellte Tuning-Variante mit der, mit der der laufende Edge-Container erzeugt wurde (Label `rsgo.edge.mss`). Bei einer Abweichung wird der Edge-Container **einmalig neu erstellt** — noch bevor die Produkt-Stacks angefasst werden. Die Vordertür ist dabei wenige Sekunden nicht erreichbar; das Produkt ist zu diesem Zeitpunkt ohnehin im Redeploy.
+- **Der Hintergrund-Reconciler tut das nicht.** Er hält den Edge nur am Leben und schiebt Caddy-Konfiguration nach; er würde die Vordertür nie von sich aus neu starten.
+- Ein Edge-Container **aus einer RSGO-Version vor dieser Option** trägt kein Label und damit auch kein Tuning — er zählt als `off` und wird beim nächsten Redeploy/Upgrade auf die konfigurierte Variante (Standard `pmtu`) umgestellt.
+- Für einen **festen** Wert gilt zusätzlich die Netz-Einschränkung oben: Der neue Container allein hebt die MTU eines bestehenden Netzes nicht an.
+
+### Prüfen, ob das Clamping wirklich greift
+
+Der Edge-Container schreibt beim Start **eine Zeile** mit den Werten, die er selbst im Kernel vorfindet — damit lässt sich beim Kunden ohne Rätselraten feststellen, ob der Container tatsächlich aktualisiert wurde:
+
+```bash
+docker logs <deployment>-edge 2>&1 | head -1
+# rsgo-edge: client-facing MSS tuning mode=pmtu verdict=ACTIVE (expected: tcp_mtu_probing=1 | tcp_mtu_probing=1 tcp_base_mss=1024 iface_mtu: eth0=1500 eth1=1500)
+```
+
+| `verdict` | Bedeutung |
+|-----------|-----------|
+| `ACTIVE` | Die konfigurierte Variante ist im Container wirksam. |
+| `DISABLED` | `mss: off` — bewusst keine Anpassung. |
+| `INACTIVE` | Der Container läuft **nicht** mit der konfigurierten Variante (z. B. Container älter als die Einstellung, oder feste MTU am bestehenden Netz nicht anwendbar) → Redeploy ausführen bzw. Netz-Einschränkung prüfen. |
+
+Ergänzend zeigt das Label, mit welcher Variante der Container erzeugt wurde:
+
+```bash
+docker inspect -f '{{index .Config.Labels "rsgo.edge.mss"}}' <deployment>-edge
+```
+
 ---
 
 ## Status-Vertrag: `GET /__status`

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/configuration/maintenance-edge-proxy.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/configuration/maintenance-edge-proxy.md
@@ -299,6 +299,38 @@ The default (`pmtu`) is implemented with **namespaced kernel sysctls** (`net.ipv
 
 > **Fixed-mode caveat:** a fixed MSS is applied when RSGO **creates** the edge network. If the network already exists (e.g. it was created by the product stack first) its MTU cannot be changed without recreating it; RSGO logs a warning and the fixed cap does not take effect. In that case, prefer `pmtu` (which works regardless of who owns the network) or let RSGO create the network.
 
+### When a change takes effect
+
+Sysctls and the network MTU are **create-time** container settings — they cannot be changed on a running container. On top of that, the edge container deliberately survives every redeploy (label `rsgo.redeploy=ignore`) so the maintenance page stays reachable while the product is down.
+
+So a changed `mss` value reaches a running deployment like this:
+
+- **Redeploy and upgrade re-read the `edge:` block from the manifest** and compare the configured tuning against the one the live edge container was created with (label `rsgo.edge.mss`). On a mismatch the edge container is **recreated once** — before the product stacks are touched. The front door is unreachable for a few seconds, at a point where the product is being redeployed anyway.
+- **The background reconciler does not do this.** It only keeps the edge alive and pushes Caddy config; it never restarts the front door on its own.
+- An edge container **from an RSGO version older than this option** carries no label and no tuning — it counts as `off` and is switched to the configured mode (`pmtu` by default) on the next redeploy/upgrade.
+- For a **fixed** value the network caveat above still applies: a fresh container alone does not change the MTU of an existing network.
+
+### Verifying that clamping is actually in effect
+
+At startup the edge container logs **one line** with the values it reads from its own kernel — so you can tell at a customer site whether the container really got updated:
+
+```bash
+docker logs <deployment>-edge 2>&1 | head -1
+# rsgo-edge: client-facing MSS tuning mode=pmtu verdict=ACTIVE (expected: tcp_mtu_probing=1 | tcp_mtu_probing=1 tcp_base_mss=1024 iface_mtu: eth0=1500 eth1=1500)
+```
+
+| `verdict` | Meaning |
+|-----------|---------|
+| `ACTIVE` | The configured mode is in effect inside the container. |
+| `DISABLED` | `mss: off` — no tuning by choice. |
+| `INACTIVE` | The container is **not** running the configured mode (e.g. it predates the setting, or a fixed MTU could not be applied to the existing network) → run a redeploy, or check the network caveat. |
+
+The label additionally shows which mode the container was created with:
+
+```bash
+docker inspect -f '{{index .Config.Labels "rsgo.edge.mss"}}' <deployment>-edge
+```
+
 ---
 
 ## Status contract: `GET /__status`

--- a/tests/ReadyStackGo.UnitTests/Application/Deployments/RedeployProductHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Deployments/RedeployProductHandlerTests.cs
@@ -8,6 +8,7 @@ using ReadyStackGo.Application.UseCases.Deployments;
 using ReadyStackGo.Application.UseCases.Deployments.DeployStack;
 using ReadyStackGo.Application.UseCases.Deployments.RedeployProduct;
 using ReadyStackGo.Domain.Deployment.Deployments;
+using ReadyStackGo.Domain.Deployment.Edge;
 using ReadyStackGo.Domain.Deployment.Environments;
 using ReadyStackGo.Domain.Deployment.ProductDeployments;
 using UserId = ReadyStackGo.Domain.Deployment.UserId;
@@ -21,6 +22,7 @@ public class RedeployProductHandlerTests
     private readonly Mock<IMediator> _mediatorMock;
     private readonly Mock<IDeploymentService> _deploymentServiceMock;
     private readonly Mock<ILogger<RedeployProductHandler>> _loggerMock;
+    private readonly Mock<ReadyStackGo.Application.Services.Edge.IEdgeSettingsReconciler> _edgeSettingsMock;
     private readonly FakeTimeProvider _timeProvider;
     private readonly RedeployProductHandler _handler;
 
@@ -45,13 +47,16 @@ public class RedeployProductHandlerTests
             .Setup(m => m.Send(It.IsAny<DeployStackCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new DeployStackResponse { Success = true, DeploymentId = Guid.NewGuid().ToString() });
 
+        _edgeSettingsMock = new Mock<ReadyStackGo.Application.Services.Edge.IEdgeSettingsReconciler>();
+
         _handler = new RedeployProductHandler(
             _repositoryMock.Object,
             _productSourceServiceMock.Object,
             _mediatorMock.Object,
             _deploymentServiceMock.Object,
             _loggerMock.Object,
-            timeProvider: _timeProvider);
+            timeProvider: _timeProvider,
+            edgeSettingsReconciler: _edgeSettingsMock.Object);
     }
 
     #region Helpers
@@ -472,6 +477,184 @@ public class RedeployProductHandlerTests
             stacks: new[] { stack },
             productVersion: "1.0.0",
             productId: productId);
+    }
+
+    #endregion
+
+    #region Edge Config Refresh
+
+    [Fact]
+    public async Task Handle_ReResolvesEdgeConfigFromCatalog()
+    {
+        var pd = CreateRunningDeploymentWithSharedVars(new Dictionary<string, string>());
+        pd.SetEdgeConfig(CreateEdgeConfig(EdgeMssMode.Pmtu));
+        SetupDeploymentFound(pd);
+
+        // Manifest was edited to mss: off since the initial deploy.
+        _productSourceServiceMock
+            .Setup(s => s.GetProductAsync(pd.ProductId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateCatalogProductWithEdge(pd.ProductId, mss: "off"));
+
+        await _handler.Handle(CreateCommand(pd.Id.Value.ToString()), CancellationToken.None);
+
+        pd.EdgeConfig!.MssMode.Should().Be(EdgeMssMode.Off,
+            "redeploy must re-read the edge: block so manifest edits to edge.mss take effect");
+    }
+
+    [Fact]
+    public async Task Handle_FixedMssInManifest_IsStoredWithItsValue()
+    {
+        var pd = CreateRunningDeploymentWithSharedVars(new Dictionary<string, string>());
+        pd.SetEdgeConfig(CreateEdgeConfig(EdgeMssMode.Pmtu));
+        SetupDeploymentFound(pd);
+
+        _productSourceServiceMock
+            .Setup(s => s.GetProductAsync(pd.ProductId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateCatalogProductWithEdge(pd.ProductId, mss: "1360"));
+
+        await _handler.Handle(CreateCommand(pd.Id.Value.ToString()), CancellationToken.None);
+
+        pd.EdgeConfig!.MssMode.Should().Be(EdgeMssMode.Fixed);
+        pd.EdgeConfig.MssValue.Should().Be(1360);
+    }
+
+    [Fact]
+    public async Task Handle_EdgeBlockNoLongerResolvable_KeepsRunningEdgeConfig()
+    {
+        var pd = CreateRunningDeploymentWithSharedVars(new Dictionary<string, string>());
+        pd.SetEdgeConfig(CreateEdgeConfig(EdgeMssMode.Fixed, 1360));
+        SetupDeploymentFound(pd);
+
+        // Catalog product without any edge: block (removed, or variables no longer resolve).
+        _productSourceServiceMock
+            .Setup(s => s.GetProductAsync(pd.ProductId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateCatalogProductWithoutObserver(pd.ProductId));
+
+        await _handler.Handle(CreateCommand(pd.Id.Value.ToString()), CancellationToken.None);
+
+        pd.EdgeConfig.Should().NotBeNull(
+            "tearing down the product's front door because a manifest value stopped resolving is worse than an outdated setting");
+        pd.EdgeConfig!.MssValue.Should().Be(1360);
+    }
+
+    [Fact]
+    public async Task Handle_UnresolvedHostnamePlaceholder_KeepsRunningEdgeConfig()
+    {
+        var pd = CreateRunningDeploymentWithSharedVars(new Dictionary<string, string>());
+        pd.SetEdgeConfig(CreateEdgeConfig(EdgeMssMode.Pmtu));
+        SetupDeploymentFound(pd);
+
+        // ${EDGE_HOST} is not among the shared variables → the mapper cannot resolve the block.
+        _productSourceServiceMock
+            .Setup(s => s.GetProductAsync(pd.ProductId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateCatalogProductWithEdge(pd.ProductId, mss: "off", hostname: "${EDGE_HOST}"));
+
+        await _handler.Handle(CreateCommand(pd.Id.Value.ToString()), CancellationToken.None);
+
+        pd.EdgeConfig.Should().NotBeNull();
+        pd.EdgeConfig!.MssMode.Should().Be(EdgeMssMode.Pmtu, "the unresolvable block must not be applied");
+    }
+
+    [Fact]
+    public async Task Handle_ProductWithoutEdge_LeavesEdgeInert()
+    {
+        var pd = CreateRunningDeploymentWithSharedVars(new Dictionary<string, string>());
+        SetupDeploymentFound(pd);
+
+        _productSourceServiceMock
+            .Setup(s => s.GetProductAsync(pd.ProductId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateCatalogProductWithoutObserver(pd.ProductId));
+
+        await _handler.Handle(CreateCommand(pd.Id.Value.ToString()), CancellationToken.None);
+
+        pd.EdgeConfig.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_AppliesCreateTimeEdgeSettingsBeforeTheStacksGoDown()
+    {
+        var pd = CreateRunningDeploymentWithSharedVars(new Dictionary<string, string>());
+        pd.SetEdgeConfig(CreateEdgeConfig(EdgeMssMode.Pmtu));
+        SetupDeploymentFound(pd);
+
+        var order = new List<string>();
+        _edgeSettingsMock
+            .Setup(r => r.ApplyCreateTimeSettingsAsync(It.IsAny<ProductDeployment>(), It.IsAny<CancellationToken>()))
+            .Callback(() => order.Add("edge"))
+            .ReturnsAsync(true);
+        _deploymentServiceMock
+            .Setup(d => d.RemoveDeploymentAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Func<StackContainerProgress, Task>>()))
+            .Callback(() => order.Add("remove-stack"))
+            .ReturnsAsync(new DeployComposeResponse { Success = true });
+
+        await _handler.Handle(CreateCommand(pd.Id.Value.ToString()), CancellationToken.None);
+
+        _edgeSettingsMock.Verify(r => r.ApplyCreateTimeSettingsAsync(pd, It.IsAny<CancellationToken>()), Times.Once);
+        order.Should().Contain("remove-stack");
+        order[0].Should().Be("edge",
+            "the edge is recreated first so the whole redeploy already runs behind the configured edge");
+    }
+
+    [Fact]
+    public async Task Handle_EdgeRecreationFails_RedeployStillSucceeds()
+    {
+        var pd = CreateRunningDeploymentWithSharedVars(new Dictionary<string, string>());
+        pd.SetEdgeConfig(CreateEdgeConfig(EdgeMssMode.Pmtu));
+        SetupDeploymentFound(pd);
+
+        _edgeSettingsMock
+            .Setup(r => r.ApplyCreateTimeSettingsAsync(It.IsAny<ProductDeployment>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var result = await _handler.Handle(CreateCommand(pd.Id.Value.ToString()), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+    }
+
+    private static ReadyStackGo.Domain.Deployment.Edge.EdgeConfig CreateEdgeConfig(
+        EdgeMssMode mode, int? mssValue = null)
+        => ReadyStackGo.Domain.Deployment.Edge.EdgeConfig.Create(
+            "app.test", 443, "bff", 8080, "edge-net", "caddy:2.8.4",
+            mssMode: mode, mssValue: mssValue);
+
+    private static global::ReadyStackGo.Domain.StackManagement.Stacks.ProductDefinition CreateCatalogProductWithEdge(
+        string productId, string mss, string hostname = "app.test")
+    {
+        var stack = new global::ReadyStackGo.Domain.StackManagement.Stacks.StackDefinition(
+            "stacks",
+            "stack-0",
+            new global::ReadyStackGo.Domain.StackManagement.Stacks.ProductId(productId),
+            services: new[]
+            {
+                new global::ReadyStackGo.Domain.StackManagement.Stacks.ServiceTemplate
+                {
+                    Name = "svc", Image = "test:latest"
+                }
+            },
+            variables: Array.Empty<global::ReadyStackGo.Domain.StackManagement.Stacks.Variable>(),
+            productName: "testproduct",
+            productDisplayName: "Test Product",
+            productVersion: "1.0.0");
+
+        return new global::ReadyStackGo.Domain.StackManagement.Stacks.ProductDefinition(
+            sourceId: "stacks",
+            name: "testproduct",
+            displayName: "Test Product",
+            stacks: new[] { stack },
+            productVersion: "1.0.0",
+            productId: productId,
+            edge: new global::ReadyStackGo.Domain.StackManagement.Manifests.RsgoEdge
+            {
+                Enabled = true,
+                PublicHostname = hostname,
+                Network = "edge-net",
+                Upstream = new global::ReadyStackGo.Domain.StackManagement.Manifests.RsgoEdgeUpstream
+                {
+                    Service = "bff",
+                    Port = "8080"
+                },
+                Mss = mss
+            });
     }
 
     #endregion

--- a/tests/ReadyStackGo.UnitTests/Application/Deployments/UpgradeProductHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Deployments/UpgradeProductHandlerTests.cs
@@ -8,6 +8,7 @@ using ReadyStackGo.Application.UseCases.Deployments;
 using ReadyStackGo.Application.UseCases.Deployments.DeployStack;
 using ReadyStackGo.Application.UseCases.Deployments.UpgradeProduct;
 using ReadyStackGo.Domain.Deployment.Deployments;
+using ReadyStackGo.Domain.Deployment.Edge;
 using ReadyStackGo.Domain.Deployment.Environments;
 using ReadyStackGo.Domain.Deployment.ProductDeployments;
 using ReadyStackGo.Domain.StackManagement.Stacks;
@@ -24,6 +25,7 @@ public class UpgradeProductHandlerTests
     private readonly Mock<IDeploymentNotificationService> _notificationMock;
     private readonly Mock<INotificationService> _inAppNotificationMock;
     private readonly Mock<ILogger<UpgradeProductHandler>> _loggerMock;
+    private readonly Mock<ReadyStackGo.Application.Services.Edge.IEdgeSettingsReconciler> _edgeSettingsMock;
     private readonly FakeTimeProvider _timeProvider;
     private readonly UpgradeProductHandler _handler;
 
@@ -54,6 +56,8 @@ public class UpgradeProductHandlerTests
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Func<StackContainerProgress, Task>>()))
             .ReturnsAsync(new DeployComposeResponse { Success = true });
 
+        _edgeSettingsMock = new Mock<ReadyStackGo.Application.Services.Edge.IEdgeSettingsReconciler>();
+
         _handler = new UpgradeProductHandler(
             _productSourceMock.Object,
             _repositoryMock.Object,
@@ -62,7 +66,8 @@ public class UpgradeProductHandlerTests
             _loggerMock.Object,
             _notificationMock.Object,
             _inAppNotificationMock.Object,
-            _timeProvider);
+            _timeProvider,
+            edgeSettingsReconciler: _edgeSettingsMock.Object);
     }
 
     #region Test Helpers
@@ -1307,6 +1312,89 @@ public class UpgradeProductHandlerTests
         result["SHARED_VAR"].Should().Be("user-configured");
         result["STACK_0_VAR"].Should().Be("user-configured-stack");
     }
+
+    #endregion
+
+    #region Edge Config Carry-Over
+
+    [Fact]
+    public async Task Handle_AppliesCreateTimeEdgeSettingsOfTheSuccessor()
+    {
+        var currentProduct = CreateTestProduct(1, version: "1.0.0");
+        var targetProduct = CreateTestProduct(1, version: "2.0.0");
+        var existing = CreateExistingDeployment(currentProduct);
+        existing.SetEdgeConfig(CreateEdgeConfig(EdgeMssMode.Off));
+
+        SetupExistingDeployment(existing);
+        SetupTargetProductFound(targetProduct);
+        SetupAllStacksSucceed();
+
+        ProductDeployment? captured = null;
+        _repositoryMock
+            .Setup(r => r.Add(It.IsAny<ProductDeployment>()))
+            .Callback<ProductDeployment>(pd => captured = pd);
+
+        await _handler.Handle(CreateUpgradeCommand(existing, targetProduct), CancellationToken.None);
+
+        _edgeSettingsMock.Verify(
+            r => r.ApplyCreateTimeSettingsAsync(captured!, It.IsAny<CancellationToken>()), Times.Once,
+            "the successor aggregate carries the edge config the upgraded product should run behind");
+    }
+
+    [Fact]
+    public async Task Handle_TargetVersionWithoutResolvableEdge_CarriesRunningEdgeConfigForward()
+    {
+        var currentProduct = CreateTestProduct(1, version: "1.0.0");
+        var targetProduct = CreateTestProduct(1, version: "2.0.0");
+        var existing = CreateExistingDeployment(currentProduct);
+        existing.SetEdgeConfig(CreateEdgeConfig(EdgeMssMode.Fixed, 1360));
+
+        SetupExistingDeployment(existing);
+        SetupTargetProductFound(targetProduct); // CreateTestProduct has no edge: block
+        SetupAllStacksSucceed();
+
+        ProductDeployment? captured = null;
+        _repositoryMock
+            .Setup(r => r.Add(It.IsAny<ProductDeployment>()))
+            .Callback<ProductDeployment>(pd => captured = pd);
+
+        await _handler.Handle(CreateUpgradeCommand(existing, targetProduct), CancellationToken.None);
+
+        captured!.EdgeConfig.Should().NotBeNull(
+            "a live edge container without a config on the active aggregate would never be reconciled again");
+        captured.EdgeConfig!.MssValue.Should().Be(1360);
+    }
+
+    [Fact]
+    public async Task Handle_NoEdgeAnywhere_LeavesSuccessorEdgeInert()
+    {
+        var currentProduct = CreateTestProduct(1, version: "1.0.0");
+        var targetProduct = CreateTestProduct(1, version: "2.0.0");
+        var existing = CreateExistingDeployment(currentProduct);
+
+        SetupExistingDeployment(existing);
+        SetupTargetProductFound(targetProduct);
+        SetupAllStacksSucceed();
+
+        ProductDeployment? captured = null;
+        _repositoryMock
+            .Setup(r => r.Add(It.IsAny<ProductDeployment>()))
+            .Callback<ProductDeployment>(pd => captured = pd);
+
+        await _handler.Handle(CreateUpgradeCommand(existing, targetProduct), CancellationToken.None);
+
+        captured!.EdgeConfig.Should().BeNull();
+        _edgeSettingsMock.Verify(
+            r => r.ApplyCreateTimeSettingsAsync(It.IsAny<ProductDeployment>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the reconciler itself is the no-op guard for products without an edge");
+    }
+
+    private static ReadyStackGo.Domain.Deployment.Edge.EdgeConfig CreateEdgeConfig(
+        EdgeMssMode mode, int? mssValue = null)
+        => ReadyStackGo.Domain.Deployment.Edge.EdgeConfig.Create(
+            "app.test", 443, "bff", 8080, "edge-net", "caddy:2.8.4",
+            mssMode: mode, mssValue: mssValue);
 
     #endregion
 }

--- a/tests/ReadyStackGo.UnitTests/Edge/EdgeMssDriftTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Edge/EdgeMssDriftTests.cs
@@ -1,0 +1,255 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Application.Services.Edge;
+using ReadyStackGo.Application.UseCases.Containers;
+using ReadyStackGo.Domain.Deployment.Edge;
+using ReadyStackGo.Infrastructure.Services.Edge;
+using Xunit;
+
+namespace ReadyStackGo.UnitTests.Edge;
+
+/// <summary>
+/// Covers drift detection for the client-facing MSS tuning: sysctls and the network MTU are
+/// fixed when the edge container is created, so a changed <c>edge.mss</c> only takes effect
+/// once the container is recreated. The container carries the tuning it was created with as
+/// the <c>rsgo.edge.mss</c> label — that label is the fingerprint compared here.
+/// </summary>
+public class EdgeMssDriftTests
+{
+    private const string EnvironmentId = "env";
+    private const string DeploymentName = "ams.project";
+    private const string ContainerName = "ams-project-edge";
+    private const string ExistingContainerId = "existing-edge-id";
+
+    private static EdgeConfig Config(EdgeMssMode mode, int? value = null) => EdgeConfig.Create(
+        publicHostname: "app.test",
+        publicPort: 443,
+        upstreamService: "bff",
+        upstreamPort: 8080,
+        network: "edge-net",
+        image: "caddy:2.8.4",
+        mssMode: mode,
+        mssValue: value);
+
+    // ---- Fingerprint -------------------------------------------------------
+
+    [Fact]
+    public void MssFingerprint_IsStableAndModeSpecific()
+    {
+        EdgeConstants.MssFingerprint(Config(EdgeMssMode.Pmtu)).Should().Be("pmtu");
+        EdgeConstants.MssFingerprint(Config(EdgeMssMode.Fixed, 1360)).Should().Be("1360");
+        EdgeConstants.MssFingerprint(Config(EdgeMssMode.Off)).Should().Be(EdgeConstants.MssFingerprintOff);
+    }
+
+    [Fact]
+    public async Task EnsureEdge_LabelsCreatedContainerWithFingerprint_AndExportsItToTheStartupBanner()
+    {
+        var (docker, capture) = MockDocker();
+        var provisioner = new EdgeProvisioner(docker.Object, NullLogger<EdgeProvisioner>.Instance);
+
+        await provisioner.EnsureEdgeAsync(EnvironmentId, DeploymentName, "group", Config(EdgeMssMode.Fixed, 1360));
+
+        capture.Request!.Labels.Should().Contain(EdgeConstants.MssLabel, "1360");
+        capture.Request.EnvironmentVariables.Should().Contain("RSGO_EDGE_MSS_MODE", "1360",
+            "the container logs the configured mode next to the values it actually reads from the kernel");
+    }
+
+    // ---- No drift → no recreation -----------------------------------------
+
+    [Theory]
+    [InlineData("pmtu", EdgeMssMode.Pmtu, null)]
+    [InlineData("1360", EdgeMssMode.Fixed, 1360)]
+    [InlineData("off", EdgeMssMode.Off, null)]
+    public async Task ReconcileEdgeMss_MatchingLabel_KeepsContainer(
+        string label, EdgeMssMode mode, int? value)
+    {
+        var (docker, capture) = MockDocker(ExistingWithLabels(new() { [EdgeConstants.MssLabel] = label }));
+        var provisioner = new EdgeProvisioner(docker.Object, NullLogger<EdgeProvisioner>.Instance);
+
+        var recreated = await provisioner.ReconcileEdgeMssAsync(
+            EnvironmentId, DeploymentName, "group", Config(mode, value));
+
+        recreated.Should().BeFalse();
+        capture.Request.Should().BeNull("no container may be created when the tuning is unchanged");
+        docker.Verify(d => d.RemoveContainerAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ReconcileEdgeMss_LabelCasingDiffers_KeepsContainer()
+    {
+        var (docker, _) = MockDocker(ExistingWithLabels(new() { [EdgeConstants.MssLabel] = "PMTU" }));
+        var provisioner = new EdgeProvisioner(docker.Object, NullLogger<EdgeProvisioner>.Instance);
+
+        var recreated = await provisioner.ReconcileEdgeMssAsync(
+            EnvironmentId, DeploymentName, "group", Config(EdgeMssMode.Pmtu));
+
+        recreated.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task ReconcileEdgeMss_PreFeatureContainerAndOffConfigured_KeepsContainer()
+    {
+        // No label at all = created before the option existed = no sysctls, default MTU = "off".
+        var (docker, capture) = MockDocker(ExistingWithLabels(new()));
+        var provisioner = new EdgeProvisioner(docker.Object, NullLogger<EdgeProvisioner>.Instance);
+
+        var recreated = await provisioner.ReconcileEdgeMssAsync(
+            EnvironmentId, DeploymentName, "group", Config(EdgeMssMode.Off));
+
+        recreated.Should().BeFalse();
+        capture.Request.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task ReconcileEdgeMss_NoEdgeContainerYet_DoesNothing()
+    {
+        var (docker, capture) = MockDocker(existing: null);
+        var provisioner = new EdgeProvisioner(docker.Object, NullLogger<EdgeProvisioner>.Instance);
+
+        var recreated = await provisioner.ReconcileEdgeMssAsync(
+            EnvironmentId, DeploymentName, "group", Config(EdgeMssMode.Pmtu));
+
+        recreated.Should().BeFalse("EnsureEdgeAsync creates it with the current tuning anyway");
+        capture.Request.Should().BeNull();
+        docker.Verify(d => d.RemoveContainerAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ---- Drift → recreation ------------------------------------------------
+
+    [Fact]
+    public async Task ReconcileEdgeMss_PreFeatureContainerAndPmtuConfigured_Recreates()
+    {
+        // The exact case that made a redeploy look like a no-op before: the default pmtu tuning
+        // was configured but never applied because the container predates it.
+        var (docker, capture) = MockDocker(ExistingWithLabels(new()));
+        var provisioner = new EdgeProvisioner(docker.Object, NullLogger<EdgeProvisioner>.Instance);
+
+        var recreated = await provisioner.ReconcileEdgeMssAsync(
+            EnvironmentId, DeploymentName, "group", Config(EdgeMssMode.Pmtu));
+
+        recreated.Should().BeTrue();
+        docker.Verify(d => d.RemoveContainerAsync(
+            EnvironmentId, ExistingContainerId, true, It.IsAny<CancellationToken>()), Times.Once);
+        capture.Request!.Name.Should().Be(ContainerName);
+        capture.Request.Sysctls.Should().Contain(EdgeConstants.TcpMtuProbingSysctl, EdgeConstants.AdaptiveMtuProbing);
+        capture.Request.Labels.Should().Contain(EdgeConstants.MssLabel, "pmtu");
+    }
+
+    [Fact]
+    public async Task ReconcileEdgeMss_PmtuToOff_RecreatesWithoutSysctls()
+    {
+        var (docker, capture) = MockDocker(ExistingWithLabels(new() { [EdgeConstants.MssLabel] = "pmtu" }));
+        var provisioner = new EdgeProvisioner(docker.Object, NullLogger<EdgeProvisioner>.Instance);
+
+        var recreated = await provisioner.ReconcileEdgeMssAsync(
+            EnvironmentId, DeploymentName, "group", Config(EdgeMssMode.Off));
+
+        recreated.Should().BeTrue();
+        capture.Request!.Sysctls.Should().BeEmpty();
+        capture.Request.Labels.Should().Contain(EdgeConstants.MssLabel, "off");
+    }
+
+    [Fact]
+    public async Task ReconcileEdgeMss_ChangedFixedValue_RecreatesAndRequestsNewNetworkMtu()
+    {
+        var (docker, capture) = MockDocker(ExistingWithLabels(new() { [EdgeConstants.MssLabel] = "1360" }));
+        var provisioner = new EdgeProvisioner(docker.Object, NullLogger<EdgeProvisioner>.Instance);
+
+        var recreated = await provisioner.ReconcileEdgeMssAsync(
+            EnvironmentId, DeploymentName, "group", Config(EdgeMssMode.Fixed, 1200));
+
+        recreated.Should().BeTrue("a different fixed value is drift, not just a different mode");
+        capture.EdgeNetworkMtu.Should().Be(1200 + EdgeConstants.MssHeaderOverhead);
+        capture.Request!.Labels.Should().Contain(EdgeConstants.MssLabel, "1200");
+    }
+
+    [Fact]
+    public async Task ReconcileEdgeMss_RemovesBeforeCreating()
+    {
+        var order = new List<string>();
+        var (docker, _) = MockDocker(ExistingWithLabels(new() { [EdgeConstants.MssLabel] = "off" }));
+        docker.Setup(d => d.RemoveContainerAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Callback(() => order.Add("remove"))
+            .Returns(Task.CompletedTask);
+        docker.Setup(d => d.CreateAndStartContainerAsync(
+                It.IsAny<string>(), It.IsAny<CreateContainerRequest>(), It.IsAny<CancellationToken>()))
+            .Callback(() => order.Add("create"))
+            .ReturnsAsync("new-edge-id");
+        var provisioner = new EdgeProvisioner(docker.Object, NullLogger<EdgeProvisioner>.Instance);
+
+        await provisioner.ReconcileEdgeMssAsync(
+            EnvironmentId, DeploymentName, "group", Config(EdgeMssMode.Pmtu));
+
+        // The container name stays taken until the old container is gone.
+        order.Should().Equal(new[] { "remove", "create" });
+    }
+
+    // ---- The background loop must never restart the front door -------------
+
+    [Fact]
+    public async Task EnsureEdge_ExistingContainerWithDriftedTuning_IsLeftAlone()
+    {
+        var (docker, capture) = MockDocker(ExistingWithLabels(new() { [EdgeConstants.MssLabel] = "off" }));
+        var provisioner = new EdgeProvisioner(docker.Object, NullLogger<EdgeProvisioner>.Instance);
+
+        await provisioner.EnsureEdgeAsync(EnvironmentId, DeploymentName, "group", Config(EdgeMssMode.Pmtu));
+
+        capture.Request.Should().BeNull("only an explicit redeploy/upgrade may recreate the edge");
+        docker.Verify(d => d.RemoveContainerAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ---- Helpers -----------------------------------------------------------
+
+    private static ContainerDto ExistingWithLabels(Dictionary<string, string> labels) => new()
+    {
+        Id = ExistingContainerId,
+        Name = ContainerName,
+        Image = "caddy:2.8.4",
+        State = "running",
+        Status = "Up 3 hours",
+        Labels = labels
+    };
+
+    private sealed class Capture
+    {
+        public CreateContainerRequest? Request { get; set; }
+        public int? EdgeNetworkMtu { get; set; }
+    }
+
+    private static (Mock<IDockerService> Docker, Capture Capture) MockDocker(ContainerDto? existing = null)
+    {
+        var docker = new Mock<IDockerService>();
+        var capture = new Capture();
+
+        // Only the edge network is ensured through the MTU-aware overload.
+        docker.Setup(d => d.EnsureNetworkAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, int?, CancellationToken>((_, _, mtu, _) => capture.EdgeNetworkMtu = mtu)
+            .Returns(Task.CompletedTask);
+
+        docker.Setup(d => d.GetContainerByNameAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existing);
+
+        docker.Setup(d => d.ImageExistsAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        docker.Setup(d => d.RemoveContainerAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        docker.Setup(d => d.CreateAndStartContainerAsync(
+                It.IsAny<string>(), It.IsAny<CreateContainerRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<string, CreateContainerRequest, CancellationToken>((_, req, _) => capture.Request = req)
+            .ReturnsAsync("new-edge-id");
+
+        return (docker, capture);
+    }
+}

--- a/tests/ReadyStackGo.UnitTests/Edge/EdgeSettingsReconcilerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Edge/EdgeSettingsReconcilerTests.cs
@@ -1,0 +1,123 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using ReadyStackGo.Application.Services.Edge;
+using ReadyStackGo.Application.Services.Impl;
+using ReadyStackGo.Domain.Deployment.Deployments;
+using ReadyStackGo.Domain.Deployment.Edge;
+using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.Deployment.ProductDeployments;
+using Xunit;
+using UserId = ReadyStackGo.Domain.Deployment.UserId;
+
+namespace ReadyStackGo.UnitTests.Edge;
+
+/// <summary>
+/// The redeploy/upgrade-facing wrapper around the provisioner's drift check. Its job beyond
+/// delegating is the cache invalidation: a recreated container only holds the bootstrap
+/// maintenance config, so a stale "already pushed" cache entry would leave the product's front
+/// door stuck on the maintenance page.
+/// </summary>
+public class EdgeSettingsReconcilerTests
+{
+    private readonly Mock<IEdgeProvisioner> _provisioner = new();
+    private readonly Mock<IEdgeConfigCache> _cache = new();
+    private readonly EdgeSettingsReconciler _sut;
+
+    public EdgeSettingsReconcilerTests()
+    {
+        _sut = new EdgeSettingsReconciler(
+            _provisioner.Object, _cache.Object, NullLogger<EdgeSettingsReconciler>.Instance);
+    }
+
+    [Fact]
+    public async Task ApplyCreateTimeSettings_NoEdgeConfigured_DoesNotTouchDocker()
+    {
+        var pd = CreateDeployment(edge: null);
+
+        var recreated = await _sut.ApplyCreateTimeSettingsAsync(pd);
+
+        recreated.Should().BeFalse();
+        _provisioner.Verify(p => p.ReconcileEdgeMssAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<EdgeConfig>(), It.IsAny<CancellationToken>()), Times.Never);
+        _cache.Verify(c => c.Invalidate(It.IsAny<Guid>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ApplyCreateTimeSettings_ContainerRecreated_InvalidatesCachedConfig()
+    {
+        var pd = CreateDeployment(EdgeMssMode.Pmtu);
+        SetupProvisioner(recreated: true);
+
+        var recreated = await _sut.ApplyCreateTimeSettingsAsync(pd);
+
+        recreated.Should().BeTrue();
+        _cache.Verify(c => c.Invalidate(pd.Id.Value), Times.Once);
+        _provisioner.Verify(p => p.ReconcileEdgeMssAsync(
+            pd.EnvironmentId.Value.ToString(), pd.DeploymentName, pd.ProductGroupId,
+            pd.EdgeConfig!, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task ApplyCreateTimeSettings_NothingRecreated_KeepsCache()
+    {
+        var pd = CreateDeployment(EdgeMssMode.Pmtu);
+        SetupProvisioner(recreated: false);
+
+        var recreated = await _sut.ApplyCreateTimeSettingsAsync(pd);
+
+        recreated.Should().BeFalse();
+        _cache.Verify(c => c.Invalidate(It.IsAny<Guid>()), Times.Never,
+            "an untouched edge still runs the config the reconciler pushed");
+    }
+
+    [Fact]
+    public async Task ApplyCreateTimeSettings_ProvisionerFails_DoesNotBreakTheCallingOperation()
+    {
+        var pd = CreateDeployment(EdgeMssMode.Fixed, 1360);
+        _provisioner.Setup(p => p.ReconcileEdgeMssAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<EdgeConfig>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("docker unreachable"));
+
+        var recreated = await _sut.ApplyCreateTimeSettingsAsync(pd);
+
+        recreated.Should().BeFalse();
+        _cache.Verify(c => c.Invalidate(It.IsAny<Guid>()), Times.Never,
+            "the old container is still running its old config");
+    }
+
+    private void SetupProvisioner(bool recreated)
+    {
+        _provisioner.Setup(p => p.ReconcileEdgeMssAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<EdgeConfig>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(recreated);
+    }
+
+    private static ProductDeployment CreateDeployment(EdgeMssMode? edge, int? mssValue = null)
+    {
+        var pd = ProductDeployment.InitiateDeployment(
+            ProductDeploymentId.NewId(), EnvironmentId.NewId(),
+            "stacks:testproduct", "stacks:testproduct:1.0.0",
+            "testproduct", "Test Product", "1.0.0",
+            UserId.NewId(), "test-deploy",
+            new List<StackDeploymentConfig>
+            {
+                new("stack-0", "Stack 0", "sid:0", 1, new Dictionary<string, string>())
+            },
+            new Dictionary<string, string>());
+
+        if (edge.HasValue)
+        {
+            pd.SetEdgeConfig(EdgeConfig.Create(
+                "app.test", 443, "bff", 8080, "edge-net", "caddy:2.8.4",
+                mssMode: edge.Value, mssValue: mssValue));
+        }
+
+        pd.StartStack("stack-0", DeploymentId.NewId());
+        pd.CompleteStack("stack-0");
+        return pd;
+    }
+}


### PR DESCRIPTION
## Problem

`edge.mss` (the VPN-robustness option from #460) never reached a running deployment.

Two independent reasons:

1. **The edge container survives redeploys by design** (`rsgo.redeploy=ignore`, so the maintenance page stays up), and `EnsureEdgeAsync` reuses an existing container unchanged. Sysctls (`tcp_mtu_probing`, `tcp_base_mss`) are only set at container creation, and a network's MTU cannot be changed at all without recreating it.
2. **Redeploy never re-read the `edge:` block.** `SetEdgeConfig` was only called by deploy and upgrade, so a changed `edge.mss` in the manifest did not even reach the database.

Net effect: a customer running an edge created before the option (or before a value change) kept the old behaviour, and there was no way to see that from the outside.

## Change

**Drift detection via a fingerprint label.** The edge container is labelled `rsgo.edge.mss` with the tuning it was created with (`pmtu` / the fixed number / `off`). A container created before the option exists carries no label and no tuning — which is exactly `off`, so that case is handled without an extra inspect call.

**`IEdgeProvisioner.ReconcileEdgeMssAsync`** compares the label against the configured fingerprint and recreates the container on a mismatch (remove → create, networks ensured first). Deliberately *not* folded into `EnsureEdgeAsync`: recreating briefly takes the product's front door down, so it only runs on an explicit operator action, never from the background reconcile loop.

**`IEdgeSettingsReconciler`** (new, Application layer) wraps that for the two use cases and **invalidates the cached Caddy config** — without it, a recreated container would keep only its bootstrap maintenance config, because the reconciler's "already pushed" cache would short-circuit the push. Failures are logged, never propagated: a tuning value that cannot be re-applied must not fail a redeploy.

**Redeploy** now re-resolves the manifest `edge:` block, mirroring the existing maintenance-observer refresh, then applies drift *before* the stacks go down. An unresolvable/removed block keeps the stored config rather than tearing down the front door. **Upgrade** gained the same carry-forward for a target version whose `edge:` block does not resolve (previously the successor aggregate silently lost the edge config, leaving a live container nothing would reconcile).

## Verifiability at the customer site

The container logs one line at startup with the values it reads from its own kernel:

```
$ docker logs <deployment>-edge 2>&1 | head -1
rsgo-edge: client-facing MSS tuning mode=pmtu verdict=ACTIVE (expected: tcp_mtu_probing=1 | tcp_mtu_probing=1 tcp_base_mss=1024 iface_mtu: eth0=1500)
```

`ACTIVE` = in effect, `DISABLED` = `mss: off`, `INACTIVE` = container does not run the configured tuning (predates it, or a fixed MTU could not be applied to an existing network). `docker inspect -f '{{index .Config.Labels "rsgo.edge.mss"}}'` shows what it was created with.

Verified against real containers: all five verdict paths (`pmtu` with/without sysctls, `off`, no env var, garbage value) plus fixed mode on a 1400-MTU network vs. the 1500 default bridge, and the full entrypoint on `caddy:2.8.4` — banner is line 1, Caddy boots and serves.

## Tests

`dotnet build`: 0 errors, no new warnings. Full suite green (3255 unit + 412 integration).

New edge cases covered: matching label / case-insensitive label / pre-feature container with `off` configured / no container yet → no recreation; pre-feature container with `pmtu`, `pmtu`→`off`, changed fixed value → recreation with the right sysctls, MTU and label; remove-before-create ordering; `EnsureEdgeAsync` leaving a drifted container alone; cache invalidated only on an actual recreation; provisioner failure not breaking the redeploy; unresolvable and removed `edge:` blocks keeping the running config.

## Docs

`maintenance-edge-proxy.md` (de + en): new sections "when a change takes effect" and "verifying that clamping is actually in effect".
