### PR TITLE
fix: observer no longer holds a session on a product database (#463)

### DIFF
--- a/docs/Operations/Operation-Mode.md
+++ b/docs/Operations/Operation-Mode.md
@@ -370,7 +370,6 @@ maintenanceObserver:
 | `timeout` | string | No | Timeout for each check (default: `10s`) |
 | `maintenanceValue` | string | **Yes** | Value that triggers maintenance mode |
 | `normalValue` | string | **Yes** | Value that exits maintenance mode |
-| `enabled` | boolean | No | Enable/disable observer (default: `true`) |
 
 **Type-specific properties:**
 
@@ -419,14 +418,39 @@ If a user manually changes the mode while an observer is active:
 |----------|----------|
 | Observer says "maintenance", user sets "normal" | Observer wins on next poll |
 | Observer says "normal", user sets "maintenance" | User wins (observer doesn't override manual) |
-| Observer disabled | Manual control only |
 
-To override the observer temporarily, disable it via API:
+Ownership decides: only the source that activated maintenance can end it. Manual maintenance is
+therefore never lifted by an observer — and because the observer could not act on a result anyway,
+RSGO **suspends observer polling entirely** while maintenance is manually active. For a SQL observer
+that means RSGO opens no connection to the product at all during a manual maintenance window.
 
-```http
-PUT /api/deployments/{id}/maintenance-observer
-{ "enabled": false }
-```
+Entering maintenance manually is thus also the way to keep RSGO off a product while working on it
+directly; polling resumes when maintenance is exited.
+
+### Databases Held Exclusively
+
+A product that maintains itself often takes its own database exclusively — an update switching it to
+`SINGLE_USER`, a restore. That interacts with a SQL observer in two ways RSGO handles explicitly:
+
+- **RSGO keeps no idle session.** Connections RSGO opens for observers and setters are non-pooled, so
+  a session exists only for the duration of a single read. Product routines that wait for all
+  sessions to close before taking the database exclusively are not blocked by RSGO. Product
+  containers are unaffected — RSGO does not build their connection strings, and they keep their
+  pools. RSGO's own sessions carry the application name `ReadyStackGo-Maintenance`, so they can be
+  identified in `sys.dm_exec_sessions` or `sp_who2`.
+
+- **RSGO does not read a database it may not touch.** Before every read, a SQL observer checks the
+  database's availability in `sys.databases` over a `master` connection derived from the same
+  credentials. `master` stays reachable while another database is `SINGLE_USER`, `RESTORING` or
+  `OFFLINE`, and reading it takes no lock on the target database and cannot occupy a single-user
+  slot. While the database is unavailable, the observer reports maintenance with an observed value of
+  `database-exclusive (<state>/<user access>)` and leaves the database alone. Once it is `ONLINE` and
+  `MULTI_USER` again, the next poll reads the flag normally — so the automatic return to normal
+  operation keeps working without anyone intervening, however long the product takes.
+
+  If the availability cannot be determined (the observer login has no access to `master`), RSGO logs a
+  warning once and falls back to reading the flag directly. Granting the login access to `master`
+  restores the protection.
 
 #### Failure Handling
 
@@ -435,7 +459,8 @@ PUT /api/deployments/{id}/maintenance-observer
 | Connection timeout | Log warning, retry on next poll |
 | Query error | Log error, retain current state |
 | Invalid response | Log error, retain current state |
-| 3 consecutive failures | Log critical, send notification |
+| Database not available (`SINGLE_USER`, `RESTORING`, `OFFLINE`) | Report maintenance, leave the database untouched until it is available again |
+| Availability not determinable (no access to `master`) | Log warning once, fall back to reading the flag directly |
 
 ### Dashboard Integration
 
@@ -446,10 +471,8 @@ When an observer is configured, the UI shows:
 │ Operation Mode: 🔧 Maintenance                      │
 │ ─────────────────────────────────────────────────── │
 │ Triggered by: SQL Extended Property Observer        │
-│ Property: ams.MaintenanceMode = 1                   │
+│ Observed: app.MaintenanceMode = 1                   │
 │ Last checked: 15 seconds ago                        │
-│ ─────────────────────────────────────────────────── │
-│ [Disable Observer] [View History]                   │
 └─────────────────────────────────────────────────────┘
 ```
 

--- a/docs/Reference/Manifest-Schema.md
+++ b/docs/Reference/Manifest-Schema.md
@@ -1211,7 +1211,6 @@ maintenanceObserver:
 | `normalValue` | string | **Yes** | Value that exits maintenance mode |
 | `pollingInterval` | string | No | Check interval (default: `30s`) |
 | `timeout` | string | No | Query timeout (default: `10s`) |
-| `enabled` | boolean | No | Enable/disable observer (default: `true`) |
 
 *Use either `connectionString` OR `connectionName`, not both. `connectionName` is recommended when you already have a connection variable defined.
 

--- a/src/ReadyStackGo.Api/Endpoints/Connections/TestSqlServerConnectionEndpoint.cs
+++ b/src/ReadyStackGo.Api/Endpoints/Connections/TestSqlServerConnectionEndpoint.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using Microsoft.Data.SqlClient;
+using ReadyStackGo.Infrastructure.Services.Health;
 
 namespace ReadyStackGo.API.Endpoints.Connections;
 
@@ -53,7 +54,11 @@ public class TestSqlServerConnectionEndpoint : Endpoint<TestSqlServerConnectionR
                 builder.ConnectTimeout = 5;
             }
 
-            await using var connection = new SqlConnection(builder.ConnectionString);
+            // Non-pooled: a connection test must not leave an idle session behind on the product
+            // database. Pooling would keep it alive for minutes, long enough to block a product
+            // maintenance routine started right after someone validated the connection here.
+            await using var connection = new SqlConnection(
+                SqlObserverConnection.Normalize(builder.ConnectionString, "ReadyStackGo-ConnectionTest"));
             await connection.OpenAsync(ct);
 
             Response = new TestSqlServerConnectionResponse

--- a/src/ReadyStackGo.Application/Services/IMaintenanceObserverStateStore.cs
+++ b/src/ReadyStackGo.Application/Services/IMaintenanceObserverStateStore.cs
@@ -1,0 +1,42 @@
+using ReadyStackGo.Domain.Deployment.Observers;
+using ReadyStackGo.Domain.Deployment.ProductDeployments;
+
+namespace ReadyStackGo.Application.Services;
+
+/// <summary>
+/// Cross-scope state of the maintenance observers: the observer instances, their last result and
+/// the time of their last check.
+///
+/// This state has to outlive a single check cycle. <see cref="IMaintenanceObserverService"/> is
+/// scoped — it depends on repositories and the mediator — and the background service creates a
+/// fresh scope per cycle, so state kept on the service itself is discarded every time. That made the
+/// configured pollingInterval ineffective (every cycle looked like a first check) and left the
+/// observer-status endpoint permanently empty. Mirrors IHealthChangeTracker and IEdgeConfigCache.
+/// </summary>
+public interface IMaintenanceObserverStateStore
+{
+    /// <summary>
+    /// Returns the cached observer for the product, creating it via <paramref name="create"/> when
+    /// absent. A configuration that differs from the cached one replaces the observer, so manifest
+    /// changes picked up by a redeploy take effect without restarting RSGO.
+    /// </summary>
+    IMaintenanceObserver GetOrCreateObserver(
+        ProductDeploymentId productDeploymentId,
+        MaintenanceObserverConfig config,
+        Func<MaintenanceObserverConfig, IMaintenanceObserver> create);
+
+    /// <summary>The configuration the cached observer was created from, if any.</summary>
+    MaintenanceObserverConfig? GetConfig(ProductDeploymentId productDeploymentId);
+
+    /// <summary>Whether <paramref name="interval"/> has elapsed since the last recorded check.</summary>
+    bool ShouldCheck(ProductDeploymentId productDeploymentId, TimeSpan interval);
+
+    /// <summary>Records a completed check and its result.</summary>
+    void RecordResult(ProductDeploymentId productDeploymentId, ObserverResult result);
+
+    /// <summary>The last recorded result, or null if the product was never checked.</summary>
+    ObserverResult? GetLastResult(ProductDeploymentId productDeploymentId);
+
+    /// <summary>Drops all state for a product (no longer deployed, or no longer observed).</summary>
+    void Forget(ProductDeploymentId productDeploymentId);
+}

--- a/src/ReadyStackGo.Application/Services/Impl/MaintenanceObserverService.cs
+++ b/src/ReadyStackGo.Application/Services/Impl/MaintenanceObserverService.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using ReadyStackGo.Application.Services;
@@ -12,32 +11,23 @@ namespace ReadyStackGo.Application.Services.Impl;
 
 /// <summary>
 /// Service that coordinates maintenance observer checks across all product deployments.
-/// Caches observer instances and last results per product deployment.
 /// Uses observer configuration stored on ProductDeployment entities (one check per product).
+/// Observer instances, results and check timestamps live in <see cref="IMaintenanceObserverStateStore"/>
+/// because this service is scoped and re-created for every check cycle.
 /// </summary>
 public class MaintenanceObserverService : IMaintenanceObserverService
 {
     private readonly IMaintenanceObserverFactory _observerFactory;
+    private readonly IMaintenanceObserverStateStore _state;
     private readonly IProductDeploymentRepository _productDeploymentRepository;
     private readonly IHealthSnapshotRepository _healthSnapshotRepository;
     private readonly IHealthNotificationService _notificationService;
     private readonly ISender _mediator;
     private readonly ILogger<MaintenanceObserverService> _logger;
 
-    // Cache for observer instances per product deployment
-    private readonly ConcurrentDictionary<Guid, IMaintenanceObserver> _observers = new();
-
-    // Cache for last results per product deployment
-    private readonly ConcurrentDictionary<Guid, ObserverResult> _lastResults = new();
-
-    // Track last check time per product deployment to respect individual polling intervals
-    private readonly ConcurrentDictionary<Guid, DateTimeOffset> _lastCheckTimes = new();
-
-    // Cache for observer configs per product deployment
-    private readonly ConcurrentDictionary<Guid, MaintenanceObserverConfig> _configs = new();
-
     public MaintenanceObserverService(
         IMaintenanceObserverFactory observerFactory,
+        IMaintenanceObserverStateStore state,
         IProductDeploymentRepository productDeploymentRepository,
         IHealthSnapshotRepository healthSnapshotRepository,
         IHealthNotificationService notificationService,
@@ -45,6 +35,7 @@ public class MaintenanceObserverService : IMaintenanceObserverService
         ILogger<MaintenanceObserverService> logger)
     {
         _observerFactory = observerFactory;
+        _state = state;
         _productDeploymentRepository = productDeploymentRepository;
         _healthSnapshotRepository = healthSnapshotRepository;
         _notificationService = notificationService;
@@ -86,6 +77,7 @@ public class MaintenanceObserverService : IMaintenanceObserverService
         if (productDeployment == null)
         {
             _logger.LogDebug("Product deployment {ProductDeploymentId} not found", productDeploymentId);
+            _state.Forget(productDeploymentId);
             return null;
         }
 
@@ -95,37 +87,50 @@ public class MaintenanceObserverService : IMaintenanceObserverService
             return null;
         }
 
-        // Get or create observer for this product deployment
-        var observer = GetOrCreateObserver(productDeployment);
-        if (observer == null)
+        var observerConfig = productDeployment.MaintenanceObserverConfig;
+        if (observerConfig == null)
         {
+            _logger.LogDebug("No maintenance observer configured for product {ProductName}",
+                productDeployment.ProductName);
+            _state.Forget(productDeploymentId);
             return null;
         }
 
-        // Check if enough time has passed since last check (respecting polling interval)
-        if (!ShouldCheck(productDeploymentId.Value))
+        if (IsSkippedForManualMaintenance(productDeployment))
         {
-            return _lastResults.GetValueOrDefault(productDeploymentId.Value);
+            return _state.GetLastResult(productDeploymentId);
         }
+
+        // Check if enough time has passed since last check (respecting polling interval)
+        if (!_state.ShouldCheck(productDeploymentId, observerConfig.PollingInterval))
+        {
+            return _state.GetLastResult(productDeploymentId);
+        }
+
+        var observer = _state.GetOrCreateObserver(productDeploymentId, observerConfig, config =>
+        {
+            var created = _observerFactory.Create(config);
+
+            _logger.LogInformation(
+                "Created maintenance observer for product {ProductName}: type={ObserverType}, interval={Interval}s",
+                productDeployment.ProductName, created.Type.DisplayName, config.PollingInterval.TotalSeconds);
+
+            return created;
+        });
 
         // Perform the check
         var result = await observer.CheckAsync(cancellationToken);
 
-        // Update caches
-        _lastResults[productDeploymentId.Value] = result;
-        _lastCheckTimes[productDeploymentId.Value] = DateTimeOffset.UtcNow;
+        _state.RecordResult(productDeploymentId, result);
 
         // Handle result
-        await HandleObserverResultAsync(productDeployment, result, cancellationToken);
+        await HandleObserverResultAsync(productDeployment, observerConfig, result, cancellationToken);
 
         return result;
     }
 
     public Task<ObserverResult?> GetLastResultAsync(ProductDeploymentId productDeploymentId)
-    {
-        var result = _lastResults.GetValueOrDefault(productDeploymentId.Value);
-        return Task.FromResult(result);
-    }
+        => Task.FromResult(_state.GetLastResult(productDeploymentId));
 
     public async Task<ObserverResult?> CheckDeploymentObserverAsync(
         DeploymentId deploymentId,
@@ -154,64 +159,36 @@ public class MaintenanceObserverService : IMaintenanceObserverService
         return GetLastResultAsync(productDeployment.Id);
     }
 
-    private IMaintenanceObserver? GetOrCreateObserver(ProductDeployment productDeployment)
+    /// <summary>
+    /// Manually activated maintenance is owned by the operator: the observer is not allowed to end it
+    /// (see <see cref="HandleObserverResultAsync"/>), so a check could not act on its own result.
+    /// Skipping it entirely means RSGO opens no connection to the product at all while an operator
+    /// works on it — a product maintenance routine that waits for every session to close before
+    /// taking its database exclusively must never end up waiting on RSGO.
+    /// </summary>
+    private bool IsSkippedForManualMaintenance(ProductDeployment productDeployment)
     {
-        var id = productDeployment.Id.Value;
-
-        // Try to get cached observer
-        if (_observers.TryGetValue(id, out var cachedObserver))
+        if (productDeployment.OperationMode != OperationMode.Maintenance ||
+            productDeployment.MaintenanceTrigger?.IsManual != true)
         {
-            return cachedObserver;
+            return false;
         }
 
-        // Get observer configuration from the product deployment
-        var observerConfig = productDeployment.MaintenanceObserverConfig;
-        if (observerConfig == null)
-        {
-            _logger.LogDebug("No maintenance observer configured for product {ProductName}",
-                productDeployment.ProductName);
-            return null;
-        }
+        _logger.LogDebug(
+            "Skipping maintenance observer check for product {ProductName}: maintenance was activated " +
+            "manually, so the observer cannot act on the result and stays off the product",
+            productDeployment.ProductName);
 
-        // Create observer and cache it
-        var observer = _observerFactory.Create(observerConfig);
-        _observers[id] = observer;
-        _configs[id] = observerConfig;
-
-        _logger.LogInformation(
-            "Created maintenance observer for product {ProductName}: type={ObserverType}",
-            productDeployment.ProductName, observer.Type.DisplayName);
-
-        return observer;
-    }
-
-    private bool ShouldCheck(Guid productDeploymentId)
-    {
-        if (!_lastCheckTimes.TryGetValue(productDeploymentId, out var lastCheck))
-        {
-            return true;
-        }
-
-        var interval = TimeSpan.FromSeconds(30);
-        if (_configs.TryGetValue(productDeploymentId, out var config))
-        {
-            interval = config.PollingInterval;
-        }
-
-        return DateTimeOffset.UtcNow - lastCheck >= interval;
+        return true;
     }
 
     private async Task HandleObserverResultAsync(
         ProductDeployment productDeployment,
+        MaintenanceObserverConfig observerConfig,
         ObserverResult result,
         CancellationToken cancellationToken)
     {
-        var id = productDeployment.Id.Value;
-
-        // Get observer type for notification
-        var observerType = _configs.TryGetValue(id, out var config)
-            ? config.Type.Value
-            : null;
+        var observerType = observerConfig.Type.Value;
 
         // Notify clients about observer results for each running stack
         var resultDto = ObserverResultDto.FromDomain(result, observerType);
@@ -243,8 +220,12 @@ public class MaintenanceObserverService : IMaintenanceObserverService
         // Handle mode transitions via ChangeProductOperationModeCommand
         if (shouldBeMaintenance && currentMode != OperationMode.Maintenance)
         {
+            // Logged at Information level with the observed value so a blocked product maintenance
+            // window can be verified in the field: RSGO reacted, and its own connections are
+            // non-pooled, so no RSGO session remains on the product database once containers stop.
             _logger.LogInformation(
-                "Maintenance observer triggered maintenance mode for product {ProductName} (observed: {Value})",
+                "Maintenance observer triggered maintenance mode for product {ProductName} (observed: {Value}); " +
+                "stopping containers, RSGO keeps no pooled session on the product",
                 productDeployment.ProductName, result.ObservedValue);
 
             var command = new ChangeProductOperationModeCommand(

--- a/src/ReadyStackGo.Application/Services/Impl/MaintenanceObserverStateStore.cs
+++ b/src/ReadyStackGo.Application/Services/Impl/MaintenanceObserverStateStore.cs
@@ -1,0 +1,87 @@
+using System.Collections.Concurrent;
+using ReadyStackGo.Domain.Deployment.Observers;
+using ReadyStackGo.Domain.Deployment.ProductDeployments;
+
+namespace ReadyStackGo.Application.Services.Impl;
+
+/// <summary>
+/// In-memory implementation of <see cref="IMaintenanceObserverStateStore"/>. Registered as a
+/// singleton; every member is safe to call from concurrent check cycles.
+/// </summary>
+public sealed class MaintenanceObserverStateStore : IMaintenanceObserverStateStore
+{
+    private sealed class Entry
+    {
+        public required MaintenanceObserverConfig Config { get; init; }
+        public required IMaintenanceObserver Observer { get; init; }
+        public ObserverResult? LastResult { get; set; }
+        public DateTimeOffset? LastCheckedAt { get; set; }
+    }
+
+    private readonly ConcurrentDictionary<Guid, Entry> _entries = new();
+
+    public IMaintenanceObserver GetOrCreateObserver(
+        ProductDeploymentId productDeploymentId,
+        MaintenanceObserverConfig config,
+        Func<MaintenanceObserverConfig, IMaintenanceObserver> create)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+        ArgumentNullException.ThrowIfNull(create);
+
+        var key = productDeploymentId.Value;
+
+        if (_entries.TryGetValue(key, out var existing) && existing.Config.Equals(config))
+        {
+            return existing.Observer;
+        }
+
+        // Either first use, or the configuration changed (redeploy/upgrade with an edited manifest).
+        // A changed config invalidates the cached observer *and* the last result, which was produced
+        // by the previous configuration — but not the check timestamp, so a config change cannot be
+        // used to poll a product database more often than its interval allows.
+        var replacement = new Entry
+        {
+            Config = config,
+            Observer = create(config),
+            LastCheckedAt = existing?.LastCheckedAt
+        };
+
+        _entries[key] = replacement;
+        return replacement.Observer;
+    }
+
+    public MaintenanceObserverConfig? GetConfig(ProductDeploymentId productDeploymentId)
+        => _entries.TryGetValue(productDeploymentId.Value, out var entry) ? entry.Config : null;
+
+    public bool ShouldCheck(ProductDeploymentId productDeploymentId, TimeSpan interval)
+    {
+        if (!_entries.TryGetValue(productDeploymentId.Value, out var entry) || entry.LastCheckedAt == null)
+        {
+            return true;
+        }
+
+        return DateTimeOffset.UtcNow - entry.LastCheckedAt.Value >= interval;
+    }
+
+    public void RecordResult(ProductDeploymentId productDeploymentId, ObserverResult result)
+    {
+        ArgumentNullException.ThrowIfNull(result);
+
+        if (!_entries.TryGetValue(productDeploymentId.Value, out var entry))
+        {
+            // No observer instance for this product — nothing to attach the result to. Callers only
+            // record results for observers they obtained from this store, so this is unreachable in
+            // practice; ignoring it keeps the store from resurrecting forgotten products.
+            return;
+        }
+
+        entry.LastResult = result;
+        entry.LastCheckedAt = DateTimeOffset.UtcNow;
+    }
+
+    public ObserverResult? GetLastResult(ProductDeploymentId productDeploymentId)
+        => _entries.TryGetValue(productDeploymentId.Value, out var entry) ? entry.LastResult : null;
+
+    public void Forget(ProductDeploymentId productDeploymentId)
+        => _entries.TryRemove(productDeploymentId.Value, out _);
+}

--- a/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
+++ b/src/ReadyStackGo.Infrastructure/DependencyInjection.cs
@@ -117,6 +117,15 @@ public static class DependencyInjection
         services.AddSingleton<IMaintenanceObserverFactory, MaintenanceObserverFactory>();
         services.AddScoped<IMaintenanceObserverService, MaintenanceObserverService>();
 
+        // Observer state (instances, last result, last check time) must survive the per-cycle scope
+        // of MaintenanceObserverBackgroundService — the service itself stays scoped because it
+        // depends on repositories and the mediator.
+        services.AddSingleton<IMaintenanceObserverStateStore, MaintenanceObserverStateStore>();
+
+        // Reads database availability from master, so a SQL observer never connects to a database a
+        // product currently holds exclusively (see SqlDatabaseAvailabilityProbe).
+        services.AddSingleton<ISqlDatabaseAvailabilityProbe, SqlDatabaseAvailabilityProbe>();
+
         // Maintenance Setter (mirror of the observer — propagates RSGO-initiated transitions)
         services.AddSingleton<IMaintenanceSetterFactory, MaintenanceSetterFactory>();
         services.AddScoped<IMaintenanceSetterService, Application.Services.Impl.MaintenanceSetterService>();

--- a/src/ReadyStackGo.Infrastructure/Services/Health/BaseMaintenanceObserver.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Health/BaseMaintenanceObserver.cs
@@ -25,6 +25,12 @@ public abstract class BaseMaintenanceObserver : IMaintenanceObserver
         {
             Logger.LogDebug("Performing maintenance check for {ObserverType}", Type.DisplayName);
 
+            var shortCircuit = await TryShortCircuitAsync(cancellationToken);
+            if (shortCircuit != null)
+            {
+                return shortCircuit;
+            }
+
             var observedValue = await GetObservedValueAsync(cancellationToken);
 
             var result = DetermineResult(observedValue);
@@ -54,6 +60,15 @@ public abstract class BaseMaintenanceObserver : IMaintenanceObserver
     /// Implemented by each specific observer type.
     /// </summary>
     protected abstract Task<string> GetObservedValueAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lets an observer answer without reading the observed value at all. Returning null means
+    /// "carry on with the regular check". Used by the SQL observers to report maintenance while the
+    /// product database is held exclusively — the value cannot be read then, and attempting to
+    /// would interfere with the product's own maintenance.
+    /// </summary>
+    protected virtual Task<ObserverResult?> TryShortCircuitAsync(CancellationToken cancellationToken)
+        => Task.FromResult<ObserverResult?>(null);
 
     /// <summary>
     /// Determines the result based on the observed value and configuration.

--- a/src/ReadyStackGo.Infrastructure/Services/Health/SqlDatabaseAvailability.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Health/SqlDatabaseAvailability.cs
@@ -1,0 +1,46 @@
+namespace ReadyStackGo.Infrastructure.Services.Health;
+
+/// <summary>Whether a product database can currently be read by RSGO.</summary>
+public enum SqlDatabaseAvailabilityKind
+{
+    /// <summary>ONLINE and MULTI_USER — safe to read.</summary>
+    Available,
+
+    /// <summary>
+    /// Held exclusively or not online (SINGLE_USER, RESTORING, OFFLINE, …). The product is
+    /// undergoing maintenance and RSGO must not connect to the database.
+    /// </summary>
+    Exclusive,
+
+    /// <summary>
+    /// The availability could not be determined (no permission on <c>master</c>, database not
+    /// visible, instance unreachable). Callers fall back to their normal check.
+    /// </summary>
+    Unknown
+}
+
+/// <summary>Result of an availability probe, with a detail string for logs and the UI.</summary>
+public sealed record SqlDatabaseAvailability(SqlDatabaseAvailabilityKind Kind, string Detail)
+{
+    public static SqlDatabaseAvailability Available(string detail) => new(SqlDatabaseAvailabilityKind.Available, detail);
+
+    public static SqlDatabaseAvailability Exclusive(string detail) => new(SqlDatabaseAvailabilityKind.Exclusive, detail);
+
+    public static SqlDatabaseAvailability Unknown(string detail) => new(SqlDatabaseAvailabilityKind.Unknown, detail);
+
+    public bool IsExclusive => Kind == SqlDatabaseAvailabilityKind.Exclusive;
+
+    public bool IsUnknown => Kind == SqlDatabaseAvailabilityKind.Unknown;
+}
+
+/// <summary>
+/// Reads a database's availability from server metadata instead of connecting to the database.
+/// </summary>
+public interface ISqlDatabaseAvailabilityProbe
+{
+    /// <summary>
+    /// Probes the database named in <paramref name="observerConnectionString"/> by querying
+    /// <c>sys.databases</c> over a <c>master</c> connection derived from the same credentials.
+    /// </summary>
+    Task<SqlDatabaseAvailability> ProbeAsync(string observerConnectionString, CancellationToken cancellationToken = default);
+}

--- a/src/ReadyStackGo.Infrastructure/Services/Health/SqlDatabaseAvailabilityProbe.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Health/SqlDatabaseAvailabilityProbe.cs
@@ -1,0 +1,85 @@
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+
+namespace ReadyStackGo.Infrastructure.Services.Health;
+
+/// <summary>
+/// Determines whether a product database may be read, by asking the server about it rather than
+/// connecting to it.
+///
+/// A product taking its database exclusively (an ERP update switching it to SINGLE_USER, a restore)
+/// makes the maintenance flag inside that database unreadable — and any connect attempt by RSGO
+/// either fails with error 924 or, worse, occupies the one available single-user slot and breaks the
+/// product's own update. <c>sys.databases</c> lives in <c>master</c>, which stays reachable
+/// throughout and takes no lock on the target database, so RSGO can observe the exclusive window
+/// from the outside and wait it out.
+/// </summary>
+public sealed class SqlDatabaseAvailabilityProbe : ISqlDatabaseAvailabilityProbe
+{
+    private const string Query = @"
+        SELECT state_desc, user_access_desc
+        FROM sys.databases
+        WHERE name = @database";
+
+    private readonly ILogger<SqlDatabaseAvailabilityProbe> _logger;
+
+    public SqlDatabaseAvailabilityProbe(ILogger<SqlDatabaseAvailabilityProbe> logger)
+    {
+        _logger = logger;
+    }
+
+    public async Task<SqlDatabaseAvailability> ProbeAsync(
+        string observerConnectionString,
+        CancellationToken cancellationToken = default)
+    {
+        var database = SqlObserverConnection.DatabaseName(observerConnectionString);
+        if (database == null)
+        {
+            // No initial catalog to reason about — nothing to gate.
+            return SqlDatabaseAvailability.Unknown("connection string names no database");
+        }
+
+        try
+        {
+            await using var connection = new SqlConnection(SqlObserverConnection.ToMaster(observerConnectionString));
+            await connection.OpenAsync(cancellationToken);
+
+            await using var command = new SqlCommand(Query, connection);
+            command.CommandTimeout = 15;
+            command.Parameters.AddWithValue("@database", database);
+
+            await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+
+            if (!await reader.ReadAsync(cancellationToken))
+            {
+                // The login cannot see the database in sys.databases (missing VIEW ANY DATABASE, or
+                // the name is wrong). Not a maintenance signal — let the caller decide.
+                return SqlDatabaseAvailability.Unknown($"database '{database}' not visible in sys.databases");
+            }
+
+            var state = reader.IsDBNull(0) ? "UNKNOWN" : reader.GetString(0);
+            var userAccess = reader.IsDBNull(1) ? "UNKNOWN" : reader.GetString(1);
+            var detail = $"{state}/{userAccess}";
+
+            var isAvailable =
+                state.Equals("ONLINE", StringComparison.OrdinalIgnoreCase) &&
+                userAccess.Equals("MULTI_USER", StringComparison.OrdinalIgnoreCase);
+
+            return isAvailable
+                ? SqlDatabaseAvailability.Available(detail)
+                : SqlDatabaseAvailability.Exclusive(detail);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            // Cannot reach master at all. Reporting Unknown (rather than Exclusive) keeps a
+            // deployment from being parked in maintenance because of an unrelated connectivity or
+            // permission problem.
+            _logger.LogDebug(ex, "Availability probe for database '{Database}' failed", database);
+            return SqlDatabaseAvailability.Unknown(ex.Message);
+        }
+    }
+}

--- a/src/ReadyStackGo.Infrastructure/Services/Health/SqlExtendedPropertyObserver.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Health/SqlExtendedPropertyObserver.cs
@@ -8,14 +8,15 @@ namespace ReadyStackGo.Infrastructure.Services.Health;
 /// Observer that reads a SQL Server Extended Property to determine maintenance state.
 /// Extended Properties are metadata attached to database objects.
 /// </summary>
-public sealed class SqlExtendedPropertyObserver : BaseMaintenanceObserver
+public sealed class SqlExtendedPropertyObserver : SqlMaintenanceObserverBase
 {
     private readonly SqlObserverSettings _settings;
 
     public SqlExtendedPropertyObserver(
         MaintenanceObserverConfig config,
+        ISqlDatabaseAvailabilityProbe availabilityProbe,
         ILogger<SqlExtendedPropertyObserver> logger)
-        : base(config, logger)
+        : base(config, availabilityProbe, logger)
     {
         _settings = config.Settings as SqlObserverSettings
             ?? throw new ArgumentException("Invalid settings type for SQL Extended Property observer");
@@ -28,9 +29,7 @@ public sealed class SqlExtendedPropertyObserver : BaseMaintenanceObserver
 
     protected override async Task<string> GetObservedValueAsync(CancellationToken cancellationToken)
     {
-        var connectionString = GetConnectionString();
-
-        await using var connection = new SqlConnection(connectionString);
+        await using var connection = new SqlConnection(ConnectionString);
         await connection.OpenAsync(cancellationToken);
 
         // Query the extended property at database level
@@ -57,16 +56,19 @@ public sealed class SqlExtendedPropertyObserver : BaseMaintenanceObserver
         return result.ToString() ?? string.Empty;
     }
 
-    private string GetConnectionString()
+    protected override string RawConnectionString
     {
-        if (!string.IsNullOrEmpty(_settings.ConnectionString))
+        get
         {
-            return _settings.ConnectionString;
-        }
+            if (!string.IsNullOrEmpty(_settings.ConnectionString))
+            {
+                return _settings.ConnectionString;
+            }
 
-        // ConnectionName resolution would be handled by manifest variable resolver
-        // For now, we expect the resolved connection string to be in ConnectionString
-        throw new InvalidOperationException(
-            "Connection string not available. ConnectionName should be resolved before creating the observer.");
+            // ConnectionName resolution would be handled by manifest variable resolver
+            // For now, we expect the resolved connection string to be in ConnectionString
+            throw new InvalidOperationException(
+                "Connection string not available. ConnectionName should be resolved before creating the observer.");
+        }
     }
 }

--- a/src/ReadyStackGo.Infrastructure/Services/Health/SqlExtendedPropertySetter.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Health/SqlExtendedPropertySetter.cs
@@ -34,7 +34,10 @@ public sealed class SqlExtendedPropertySetter : IMaintenanceSetter
 
         try
         {
-            await using var connection = new SqlConnection(_settings.ConnectionString);
+            // Non-pooled, like the observers: a setter write must not leave a session behind that a
+            // product waits on before taking its database exclusively (see SqlObserverConnection).
+            await using var connection = new SqlConnection(
+                SqlObserverConnection.Normalize(_settings.ConnectionString));
             await connection.OpenAsync(cancellationToken);
 
             // Idempotent upsert of the database-level extended property.

--- a/src/ReadyStackGo.Infrastructure/Services/Health/SqlMaintenanceObserverBase.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Health/SqlMaintenanceObserverBase.cs
@@ -1,0 +1,85 @@
+using Microsoft.Extensions.Logging;
+using ReadyStackGo.Domain.Deployment.Observers;
+
+namespace ReadyStackGo.Infrastructure.Services.Health;
+
+/// <summary>
+/// Shared behaviour of the SQL-based maintenance observers: non-pooled connections and an
+/// availability gate in front of every read.
+///
+/// The gate exists because the maintenance flag lives inside the very database a product takes
+/// exclusively while it maintains itself. During that window the flag is unreadable, so the gate
+/// answers on the observer's behalf — the database being exclusive *is* maintenance — and RSGO stays
+/// off the database until it is ONLINE and MULTI_USER again. That also covers the reverse direction:
+/// once the product is finished, the gate opens and the next poll reads the flag normally, so the
+/// automatic return to normal operation keeps working without anyone intervening.
+/// </summary>
+public abstract class SqlMaintenanceObserverBase : BaseMaintenanceObserver
+{
+    private readonly ISqlDatabaseAvailabilityProbe _availabilityProbe;
+    private bool _probeUnavailableLogged;
+    private bool _exclusiveLogged;
+
+    protected SqlMaintenanceObserverBase(
+        MaintenanceObserverConfig config,
+        ISqlDatabaseAvailabilityProbe availabilityProbe,
+        ILogger logger)
+        : base(config, logger)
+    {
+        _availabilityProbe = availabilityProbe ?? throw new ArgumentNullException(nameof(availabilityProbe));
+    }
+
+    /// <summary>
+    /// The connection string as configured in the manifest. Implementations throw when it is
+    /// missing.
+    /// </summary>
+    protected abstract string RawConnectionString { get; }
+
+    /// <summary>
+    /// The connection string RSGO actually connects with: pooling disabled so no session outlives
+    /// the read. See <see cref="SqlObserverConnection"/>.
+    /// </summary>
+    protected string ConnectionString => SqlObserverConnection.Normalize(RawConnectionString);
+
+    protected override async Task<ObserverResult?> TryShortCircuitAsync(CancellationToken cancellationToken)
+    {
+        var availability = await _availabilityProbe.ProbeAsync(RawConnectionString, cancellationToken);
+
+        if (availability.IsExclusive)
+        {
+            // Log the entry into the exclusive window once, not on every poll of a window that can
+            // last well over half an hour.
+            if (!_exclusiveLogged)
+            {
+                Logger.LogInformation(
+                    "Product database is not available for reading ({Detail}) — reporting maintenance " +
+                    "and leaving the database untouched until it is ONLINE/MULTI_USER again",
+                    availability.Detail);
+                _exclusiveLogged = true;
+            }
+
+            return ObserverResult.MaintenanceRequired($"database-exclusive ({availability.Detail})");
+        }
+
+        if (availability.IsUnknown)
+        {
+            // Degraded but functional: without the gate the observer behaves as it always did —
+            // reading the flag directly and reporting a failed check while the database is exclusive.
+            // Preferable to parking a deployment in maintenance over a permission problem.
+            if (!_probeUnavailableLogged)
+            {
+                Logger.LogWarning(
+                    "Cannot determine product database availability ({Detail}) — falling back to " +
+                    "reading the maintenance flag directly. Granting the observer login access to " +
+                    "master restores the protection against reading a database that is held exclusively",
+                    availability.Detail);
+                _probeUnavailableLogged = true;
+            }
+
+            return null;
+        }
+
+        _exclusiveLogged = false;
+        return null;
+    }
+}

--- a/src/ReadyStackGo.Infrastructure/Services/Health/SqlObserverConnection.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Health/SqlObserverConnection.cs
@@ -1,0 +1,102 @@
+using Microsoft.Data.SqlClient;
+
+namespace ReadyStackGo.Infrastructure.Services.Health;
+
+/// <summary>
+/// Connection-string handling shared by the SQL maintenance observers and the SQL setter.
+///
+/// RSGO reads a product database once per polling interval — a single scalar value. ADO.NET
+/// connection pooling keeps the physical session alive after the read, and because the next poll
+/// refreshes it, the pool's idle cleanup never reclaims it. Product maintenance workflows that
+/// wait for all sessions to close before taking a database exclusively (switching it to
+/// SINGLE_USER, restoring it) then wait on RSGO indefinitely — the observer that is supposed to
+/// react to the maintenance flag prevents the effect of its own reaction.
+///
+/// Pooling is therefore forced off for every connection RSGO opens itself: the session exists for
+/// the duration of the read and is gone afterwards. The cost is one login per poll, which is
+/// irrelevant at these intervals. Product containers are unaffected — RSGO does not build their
+/// connection strings, and they need their pools.
+/// </summary>
+public static class SqlObserverConnection
+{
+    /// <summary>
+    /// Identifies RSGO's own sessions in sys.dm_exec_sessions / sp_who2, so an operator can tell
+    /// them apart from the product's connections when diagnosing a blocked maintenance window.
+    /// </summary>
+    public const string ApplicationName = "ReadyStackGo-Maintenance";
+
+    /// <summary>
+    /// Returns the connection string with pooling disabled and an identifying application name.
+    /// A connection string RSGO cannot parse is returned unchanged — the caller surfaces the
+    /// resulting connect error instead of failing here.
+    /// </summary>
+    /// <param name="connectionString">The connection string as configured.</param>
+    /// <param name="applicationName">
+    /// Tag for the session, used unless the connection string names one itself.
+    /// </param>
+    public static string Normalize(string connectionString, string applicationName = ApplicationName)
+        => Rewrite(connectionString, database: null, applicationName);
+
+    /// <summary>
+    /// Returns the connection string pointed at <c>master</c>, otherwise identical to
+    /// <see cref="Normalize"/>. Used to read a database's availability from metadata without
+    /// connecting to the database itself — <c>master</c> stays reachable while another database is
+    /// SINGLE_USER, OFFLINE or RESTORING, and reading it cannot occupy the single-user slot.
+    /// </summary>
+    public static string ToMaster(string connectionString)
+        => Rewrite(connectionString, database: "master", ApplicationName);
+
+    /// <summary>
+    /// The initial catalog of the connection string, or null if absent or unparsable.
+    /// </summary>
+    public static string? DatabaseName(string connectionString)
+    {
+        if (!TryParse(connectionString, out var builder))
+            return null;
+
+        return string.IsNullOrWhiteSpace(builder.InitialCatalog) ? null : builder.InitialCatalog;
+    }
+
+    private static string Rewrite(string connectionString, string? database, string applicationName)
+    {
+        if (!TryParse(connectionString, out var builder))
+            return connectionString;
+
+        builder.Pooling = false;
+
+        if (database != null)
+        {
+            builder.InitialCatalog = database;
+        }
+
+        // Only tag connections whose application name was not deliberately chosen in the manifest.
+        // ShouldSerialize distinguishes an explicitly set value from the driver's default, which the
+        // ApplicationName property itself does not.
+        if (!builder.ShouldSerialize("Application Name"))
+        {
+            builder.ApplicationName = applicationName;
+        }
+
+        return builder.ConnectionString;
+    }
+
+    private static bool TryParse(string connectionString, out SqlConnectionStringBuilder builder)
+    {
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            builder = new SqlConnectionStringBuilder();
+            return false;
+        }
+
+        try
+        {
+            builder = new SqlConnectionStringBuilder(connectionString);
+            return true;
+        }
+        catch (Exception ex) when (ex is ArgumentException or FormatException)
+        {
+            builder = new SqlConnectionStringBuilder();
+            return false;
+        }
+    }
+}

--- a/src/ReadyStackGo.Infrastructure/Services/Health/SqlQueryObserver.cs
+++ b/src/ReadyStackGo.Infrastructure/Services/Health/SqlQueryObserver.cs
@@ -8,14 +8,15 @@ namespace ReadyStackGo.Infrastructure.Services.Health;
 /// Observer that executes a SQL query to determine maintenance state.
 /// The query must return a single scalar value.
 /// </summary>
-public sealed class SqlQueryObserver : BaseMaintenanceObserver
+public sealed class SqlQueryObserver : SqlMaintenanceObserverBase
 {
     private readonly SqlObserverSettings _settings;
 
     public SqlQueryObserver(
         MaintenanceObserverConfig config,
+        ISqlDatabaseAvailabilityProbe availabilityProbe,
         ILogger<SqlQueryObserver> logger)
-        : base(config, logger)
+        : base(config, availabilityProbe, logger)
     {
         _settings = config.Settings as SqlObserverSettings
             ?? throw new ArgumentException("Invalid settings type for SQL Query observer");
@@ -28,9 +29,7 @@ public sealed class SqlQueryObserver : BaseMaintenanceObserver
 
     protected override async Task<string> GetObservedValueAsync(CancellationToken cancellationToken)
     {
-        var connectionString = GetConnectionString();
-
-        await using var connection = new SqlConnection(connectionString);
+        await using var connection = new SqlConnection(ConnectionString);
         await connection.OpenAsync(cancellationToken);
 
         await using var command = new SqlCommand(_settings.Query, connection);
@@ -47,14 +46,17 @@ public sealed class SqlQueryObserver : BaseMaintenanceObserver
         return result.ToString() ?? string.Empty;
     }
 
-    private string GetConnectionString()
+    protected override string RawConnectionString
     {
-        if (!string.IsNullOrEmpty(_settings.ConnectionString))
+        get
         {
-            return _settings.ConnectionString;
-        }
+            if (!string.IsNullOrEmpty(_settings.ConnectionString))
+            {
+                return _settings.ConnectionString;
+            }
 
-        throw new InvalidOperationException(
-            "Connection string not available. ConnectionName should be resolved before creating the observer.");
+            throw new InvalidOperationException(
+                "Connection string not available. ConnectionName should be resolved before creating the observer.");
+        }
     }
 }

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/monitoring/maintenance-mode.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/de/docs/monitoring/maintenance-mode.md
@@ -127,6 +127,46 @@ Die YAML-Felder sind in der [Manifest-Format-Referenz](/de/reference/manifest-fo
 
 ---
 
+## Datenbankzugriff während der Wartung
+
+Viele Produkte brauchen ihre Datenbank während der eigenen Wartung **exklusiv** — ein Update
+schaltet sie auf `SINGLE_USER`, ein Restore nimmt sie offline. Ein SQL-Observer liest das
+Maintenance-Flag aber genau in dieser Datenbank. ReadyStackGo behandelt das explizit:
+
+**RSGO hält keine Verbindung offen.** Alle Verbindungen, die RSGO für Observer und Setter selbst
+aufbaut, sind **nicht gepoolt**: Die Session existiert nur für die Dauer eines einzelnen Lesevorgangs
+und ist danach weg. Produkt-Routinen, die vor dem exklusiven Zugriff warten, bis alle Verbindungen
+geschlossen sind, warten dadurch nie auf ReadyStackGo. Die Container des Produkts sind davon nicht
+betroffen — deren Connection-Strings baut RSGO nicht, sie behalten ihr Pooling. RSGOs eigene Sessions
+tragen den Application Name `ReadyStackGo-Maintenance` und sind so in `sys.dm_exec_sessions` bzw.
+`sp_who2` eindeutig identifizierbar.
+
+**RSGO liest keine Datenbank, die es nicht anfassen darf.** Vor jedem Lesevorgang prüft ein
+SQL-Observer über eine `master`-Verbindung in `sys.databases`, ob die Datenbank verfügbar ist.
+`master` bleibt erreichbar, während eine andere Datenbank `SINGLE_USER`, `RESTORING` oder `OFFLINE`
+ist; die Abfrage setzt kein Lock auf der Zieldatenbank und kann den Single-User-Platz nicht belegen,
+den das Produkt-Update selbst benötigt. Solange die Datenbank nicht verfügbar ist, meldet der
+Observer Maintenance mit dem beobachteten Wert `database-exclusive (<Status>/<Zugriffsmodus>)` und
+lässt die Datenbank in Ruhe.
+
+Sobald sie wieder `ONLINE` und `MULTI_USER` ist, liest der nächste Poll das Flag normal — die
+automatische Rückkehr in den Normalbetrieb funktioniert also weiter, unabhängig davon, wie lange das
+Produkt braucht.
+
+:::note[Manuelle Wartung setzt den Observer aus]
+Ist Maintenance **manuell** aktiviert, pollt der Observer gar nicht. Er dürfte manuelle Wartung
+ohnehin nicht beenden (Trigger-Ownership), könnte also auf kein Ergebnis reagieren. Während eines
+manuellen Wartungsfensters baut RSGO damit überhaupt keine Verbindung zum Produkt auf.
+:::
+
+:::caution[Zugriff auf master]
+Kann die Verfügbarkeit nicht ermittelt werden — etwa weil der Observer-Login keinen Zugriff auf
+`master` hat — loggt RSGO einmalig eine Warnung und liest das Flag wie bisher direkt. Ein Zugriff auf
+`master` für den Observer-Login stellt den Schutz wieder her.
+:::
+
+---
+
 ## API-Endpoint
 
 Der Maintenance Mode kann auch über die REST API gesteuert werden:

--- a/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/monitoring/maintenance-mode.md
+++ b/src/ReadyStackGo.PublicWeb/src/content/docs/en/docs/monitoring/maintenance-mode.md
@@ -127,6 +127,44 @@ The YAML fields are documented in the [manifest format reference](/en/reference/
 
 ---
 
+## Database access during maintenance
+
+Many products need their database **exclusively** while they maintain themselves — an update switches
+it to `SINGLE_USER`, a restore takes it offline. Yet a SQL observer reads the maintenance flag from
+exactly that database. ReadyStackGo handles this explicitly:
+
+**RSGO keeps no connection open.** Every connection RSGO opens itself for observers and setters is
+**non-pooled**: the session exists only for the duration of a single read and is gone afterwards.
+Product routines that wait for all connections to close before taking the database exclusively are
+therefore never waiting on ReadyStackGo. The product's containers are unaffected — RSGO does not build
+their connection strings, and they keep their pooling. RSGO's own sessions carry the application name
+`ReadyStackGo-Maintenance`, so they are unambiguously identifiable in `sys.dm_exec_sessions` or
+`sp_who2`.
+
+**RSGO does not read a database it must not touch.** Before every read, a SQL observer checks the
+database's availability in `sys.databases` over a `master` connection. `master` stays reachable while
+another database is `SINGLE_USER`, `RESTORING` or `OFFLINE`; the query takes no lock on the target
+database and cannot occupy the single-user slot the product's own update needs. While the database is
+unavailable, the observer reports maintenance with an observed value of
+`database-exclusive (<state>/<user access>)` and leaves the database alone.
+
+As soon as it is `ONLINE` and `MULTI_USER` again, the next poll reads the flag normally — so the
+automatic return to normal operation keeps working, however long the product takes.
+
+:::note[Manual maintenance suspends the observer]
+While maintenance is **manually** active, the observer does not poll at all. It would not be allowed
+to end manual maintenance anyway (trigger ownership), so it could not act on a result. During a manual
+maintenance window RSGO therefore opens no connection to the product whatsoever.
+:::
+
+:::caution[Access to master]
+If availability cannot be determined — for example because the observer login has no access to
+`master` — RSGO logs a warning once and reads the flag directly, as before. Granting the observer login
+access to `master` restores the protection.
+:::
+
+---
+
 ## API Endpoint
 
 Maintenance mode can also be controlled via the REST API:

--- a/tests/ReadyStackGo.UnitTests/Application/Maintenance/MaintenanceObserverServiceTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Maintenance/MaintenanceObserverServiceTests.cs
@@ -1,0 +1,282 @@
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Application.Services.Impl;
+using ReadyStackGo.Application.UseCases.Deployments.ChangeProductOperationMode;
+using ReadyStackGo.Domain.Deployment;
+using ReadyStackGo.Domain.Deployment.Deployments;
+using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.Deployment.Health;
+using ReadyStackGo.Domain.Deployment.Observers;
+using ReadyStackGo.Domain.Deployment.ProductDeployments;
+
+namespace ReadyStackGo.UnitTests.Application.Maintenance;
+
+/// <summary>
+/// Unit tests for MaintenanceObserverService — when RSGO is allowed to read a product's database.
+///
+/// The rule that matters operationally: RSGO must not connect to a product it is not able to act on.
+/// A product maintenance routine that waits for every session to close before taking its database
+/// exclusively would otherwise wait on RSGO indefinitely.
+/// </summary>
+public class MaintenanceObserverServiceTests
+{
+    private readonly Mock<IMaintenanceObserverFactory> _factory = new();
+    private readonly Mock<IMaintenanceObserver> _observer = new();
+    private readonly Mock<IProductDeploymentRepository> _productRepository = new();
+    private readonly Mock<IHealthSnapshotRepository> _healthSnapshots = new();
+    private readonly Mock<IHealthNotificationService> _notifications = new();
+    private readonly Mock<ISender> _mediator = new();
+    private readonly MaintenanceObserverStateStore _store = new();
+
+    private readonly ProductDeploymentId _productDeploymentId = new(Guid.NewGuid());
+    private readonly EnvironmentId _environmentId = new(Guid.NewGuid());
+
+    public MaintenanceObserverServiceTests()
+    {
+        _observer.SetupGet(o => o.Type).Returns(ObserverType.SqlExtendedProperty);
+        _observer
+            .Setup(o => o.CheckAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ObserverResult.NormalOperation("0"));
+
+        _factory.Setup(f => f.Create(It.IsAny<MaintenanceObserverConfig>())).Returns(_observer.Object);
+
+        _notifications
+            .Setup(n => n.NotifyObserverResultAsync(
+                It.IsAny<DeploymentId>(), It.IsAny<string>(), It.IsAny<ObserverResultDto>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _mediator
+            .Setup(m => m.Send(It.IsAny<ChangeProductOperationModeCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ChangeProductOperationModeResponse.Ok(
+                _productDeploymentId.Value.ToString(), OperationMode.Normal.Name, OperationMode.Maintenance.Name));
+    }
+
+    private MaintenanceObserverService CreateService() => new(
+        _factory.Object,
+        _store,
+        _productRepository.Object,
+        _healthSnapshots.Object,
+        _notifications.Object,
+        _mediator.Object,
+        new Mock<ILogger<MaintenanceObserverService>>().Object);
+
+    private static MaintenanceObserverConfig ObserverConfig(int intervalSeconds = 30)
+        => MaintenanceObserverConfig.Create(
+            ObserverType.SqlExtendedProperty,
+            TimeSpan.FromSeconds(intervalSeconds),
+            maintenanceValue: "1",
+            normalValue: "0",
+            SqlObserverSettings.ForExtendedProperty("app.MaintenanceMode", "Server=sql01;Database=AppDb"));
+
+    private ProductDeployment CreateProductDeployment(bool running = true)
+    {
+        var stackConfigs = new List<StackDeploymentConfig>
+        {
+            new("api", "API Server", "source:product:api:1.0", 1, new Dictionary<string, string>())
+        };
+
+        var pd = ProductDeployment.InitiateDeployment(
+            _productDeploymentId,
+            _environmentId,
+            "product-group",
+            "product-id",
+            "test-product",
+            "Test Product",
+            "1.0.0",
+            UserId.NewId(),
+            "test-deploy",
+            stackConfigs,
+            new Dictionary<string, string>());
+
+        if (running)
+        {
+            pd.StartStack("api", new DeploymentId(Guid.NewGuid()));
+            pd.CompleteStack("api");
+        }
+
+        _productRepository.Setup(r => r.Get(It.IsAny<ProductDeploymentId>())).Returns(pd);
+        return pd;
+    }
+
+    #region Manual maintenance
+
+    [Fact]
+    public async Task CheckProductObserverAsync_ManualMaintenance_DoesNotTouchTheProduct()
+    {
+        var pd = CreateProductDeployment();
+        pd.SetMaintenanceObserverConfig(ObserverConfig());
+        pd.EnterMaintenance(MaintenanceTrigger.Manual("operator is working on the database"));
+
+        var result = await CreateService().CheckProductObserverAsync(_productDeploymentId);
+
+        result.Should().BeNull();
+        _factory.Verify(f => f.Create(It.IsAny<MaintenanceObserverConfig>()), Times.Never);
+        _observer.Verify(o => o.CheckAsync(It.IsAny<CancellationToken>()), Times.Never,
+            "the observer cannot end manually activated maintenance, so reading the database would " +
+            "only keep a session open that the product may be waiting on");
+    }
+
+    [Fact]
+    public async Task CheckProductObserverAsync_ManualMaintenance_SendsNoModeChange()
+    {
+        var pd = CreateProductDeployment();
+        pd.SetMaintenanceObserverConfig(ObserverConfig());
+        pd.EnterMaintenance(MaintenanceTrigger.Manual("scheduled window"));
+
+        await CreateService().CheckProductObserverAsync(_productDeploymentId);
+
+        _mediator.Verify(
+            m => m.Send(It.IsAny<ChangeProductOperationModeCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    #endregion
+
+    #region Observer-triggered maintenance
+
+    [Fact]
+    public async Task CheckProductObserverAsync_ObserverTriggeredMaintenance_KeepsChecking()
+    {
+        var pd = CreateProductDeployment();
+        pd.SetMaintenanceObserverConfig(ObserverConfig());
+        pd.EnterMaintenance(MaintenanceTrigger.Observer("flag set by the product"));
+
+        await CreateService().CheckProductObserverAsync(_productDeploymentId);
+
+        _observer.Verify(o => o.CheckAsync(It.IsAny<CancellationToken>()), Times.Once,
+            "the observer owns this maintenance and is the only way out of it");
+    }
+
+    [Fact]
+    public async Task CheckProductObserverAsync_ObserverTriggeredMaintenance_ClearedFlagExitsMaintenance()
+    {
+        var pd = CreateProductDeployment();
+        pd.SetMaintenanceObserverConfig(ObserverConfig());
+        pd.EnterMaintenance(MaintenanceTrigger.Observer("flag set by the product"));
+
+        await CreateService().CheckProductObserverAsync(_productDeploymentId);
+
+        _mediator.Verify(
+            m => m.Send(
+                It.Is<ChangeProductOperationModeCommand>(c => c.NewMode == OperationMode.Normal.Name),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CheckProductObserverAsync_FlagSetWhileNormal_EntersMaintenance()
+    {
+        var pd = CreateProductDeployment();
+        pd.SetMaintenanceObserverConfig(ObserverConfig());
+        _observer
+            .Setup(o => o.CheckAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ObserverResult.MaintenanceRequired("1"));
+
+        await CreateService().CheckProductObserverAsync(_productDeploymentId);
+
+        _mediator.Verify(
+            m => m.Send(
+                It.Is<ChangeProductOperationModeCommand>(c =>
+                    c.NewMode == OperationMode.Maintenance.Name && c.Source == "Observer"),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CheckProductObserverAsync_ExclusiveDatabaseWhileInMaintenance_StaysInMaintenance()
+    {
+        var pd = CreateProductDeployment();
+        pd.SetMaintenanceObserverConfig(ObserverConfig());
+        pd.EnterMaintenance(MaintenanceTrigger.Observer("flag set by the product"));
+        _observer
+            .Setup(o => o.CheckAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ObserverResult.MaintenanceRequired("database-exclusive (ONLINE/SINGLE_USER)"));
+
+        await CreateService().CheckProductObserverAsync(_productDeploymentId);
+
+        _mediator.Verify(
+            m => m.Send(It.IsAny<ChangeProductOperationModeCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the product is still working on its database — nothing to change");
+    }
+
+    #endregion
+
+    #region Polling interval across scopes
+
+    [Fact]
+    public async Task CheckProductObserverAsync_WithinInterval_DoesNotRecheckInALaterScope()
+    {
+        var pd = CreateProductDeployment();
+        pd.SetMaintenanceObserverConfig(ObserverConfig(intervalSeconds: 3600));
+
+        // Two service instances, one shared store — this is what the background service does every
+        // cycle. State on the service itself would make every cycle look like a first check.
+        await CreateService().CheckProductObserverAsync(_productDeploymentId);
+        await CreateService().CheckProductObserverAsync(_productDeploymentId);
+
+        _observer.Verify(o => o.CheckAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CheckProductObserverAsync_ResultSurvivesTheScope()
+    {
+        var pd = CreateProductDeployment();
+        pd.SetMaintenanceObserverConfig(ObserverConfig(intervalSeconds: 3600));
+
+        await CreateService().CheckProductObserverAsync(_productDeploymentId);
+        var lastResult = await CreateService().GetLastResultAsync(_productDeploymentId);
+
+        lastResult.Should().NotBeNull("the observer status endpoint reads this in a different scope");
+        lastResult!.ObservedValue.Should().Be("0");
+    }
+
+    #endregion
+
+    #region Nothing to observe
+
+    [Fact]
+    public async Task CheckProductObserverAsync_NoObserverConfigured_DoesNothing()
+    {
+        CreateProductDeployment();
+
+        var result = await CreateService().CheckProductObserverAsync(_productDeploymentId);
+
+        result.Should().BeNull();
+        _factory.Verify(f => f.Create(It.IsAny<MaintenanceObserverConfig>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CheckProductObserverAsync_NotOperational_DoesNothing()
+    {
+        var pd = CreateProductDeployment(running: false);
+        pd.SetMaintenanceObserverConfig(ObserverConfig());
+
+        var result = await CreateService().CheckProductObserverAsync(_productDeploymentId);
+
+        result.Should().BeNull();
+        _observer.Verify(o => o.CheckAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CheckProductObserverAsync_UnknownProduct_ForgetsItsState()
+    {
+        var pd = CreateProductDeployment();
+        pd.SetMaintenanceObserverConfig(ObserverConfig(intervalSeconds: 3600));
+        await CreateService().CheckProductObserverAsync(_productDeploymentId);
+
+        // The deployment disappears (removed) — the cached observer must go with it.
+        _productRepository.Setup(r => r.Get(It.IsAny<ProductDeploymentId>())).Returns((ProductDeployment?)null);
+        var result = await CreateService().CheckProductObserverAsync(_productDeploymentId);
+
+        result.Should().BeNull();
+        _store.GetConfig(_productDeploymentId).Should().BeNull();
+        _store.GetLastResult(_productDeploymentId).Should().BeNull();
+    }
+
+    #endregion
+}

--- a/tests/ReadyStackGo.UnitTests/Application/Maintenance/MaintenanceObserverStateStoreTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Maintenance/MaintenanceObserverStateStoreTests.cs
@@ -1,0 +1,200 @@
+using FluentAssertions;
+using Moq;
+using ReadyStackGo.Application.Services.Impl;
+using ReadyStackGo.Domain.Deployment.Observers;
+using ReadyStackGo.Domain.Deployment.ProductDeployments;
+
+namespace ReadyStackGo.UnitTests.Application.Maintenance;
+
+/// <summary>
+/// Unit tests for MaintenanceObserverStateStore — the state that has to outlive a single check cycle.
+/// Before it existed, the state lived on the scoped observer service and was discarded every cycle,
+/// which silently defeated the configured pollingInterval.
+/// </summary>
+public class MaintenanceObserverStateStoreTests
+{
+    private readonly MaintenanceObserverStateStore _store = new();
+    private readonly ProductDeploymentId _id = new(Guid.NewGuid());
+
+    private static MaintenanceObserverConfig Config(
+        string propertyName = "app.MaintenanceMode",
+        int intervalSeconds = 30)
+        => MaintenanceObserverConfig.Create(
+            ObserverType.SqlExtendedProperty,
+            TimeSpan.FromSeconds(intervalSeconds),
+            maintenanceValue: "1",
+            normalValue: "0",
+            SqlObserverSettings.ForExtendedProperty(propertyName, "Server=sql01;Database=AppDb"));
+
+    private static IMaintenanceObserver Observer() => new Mock<IMaintenanceObserver>().Object;
+
+    #region Observer caching
+
+    [Fact]
+    public void GetOrCreateObserver_SameConfig_CreatesOnlyOnce()
+    {
+        var created = 0;
+
+        var first = _store.GetOrCreateObserver(_id, Config(), _ => { created++; return Observer(); });
+        var second = _store.GetOrCreateObserver(_id, Config(), _ => { created++; return Observer(); });
+
+        created.Should().Be(1);
+        second.Should().BeSameAs(first);
+    }
+
+    [Fact]
+    public void GetOrCreateObserver_ChangedConfig_CreatesAReplacement()
+    {
+        var first = _store.GetOrCreateObserver(_id, Config(), _ => Observer());
+
+        var second = _store.GetOrCreateObserver(_id, Config(propertyName: "other.Flag"), _ => Observer());
+
+        second.Should().NotBeSameAs(first,
+            "a manifest change picked up by a redeploy must take effect without restarting RSGO");
+        _store.GetConfig(_id)!.Settings.Should().Be(
+            SqlObserverSettings.ForExtendedProperty("other.Flag", "Server=sql01;Database=AppDb"));
+    }
+
+    [Fact]
+    public void GetOrCreateObserver_ChangedConfig_DiscardsTheResultOfThePreviousConfig()
+    {
+        _store.GetOrCreateObserver(_id, Config(), _ => Observer());
+        _store.RecordResult(_id, ObserverResult.MaintenanceRequired("1"));
+
+        _store.GetOrCreateObserver(_id, Config(propertyName: "other.Flag"), _ => Observer());
+
+        _store.GetLastResult(_id).Should().BeNull();
+    }
+
+    [Fact]
+    public void GetOrCreateObserver_ChangedConfig_KeepsTheCheckTimestamp()
+    {
+        _store.GetOrCreateObserver(_id, Config(), _ => Observer());
+        _store.RecordResult(_id, ObserverResult.NormalOperation("0"));
+
+        _store.GetOrCreateObserver(_id, Config(propertyName: "other.Flag"), _ => Observer());
+
+        _store.ShouldCheck(_id, TimeSpan.FromHours(1)).Should().BeFalse(
+            "a config change must not become a way to read the product database more often than its interval");
+    }
+
+    [Fact]
+    public void GetOrCreateObserver_DifferentProducts_AreIndependent()
+    {
+        var other = new ProductDeploymentId(Guid.NewGuid());
+
+        var first = _store.GetOrCreateObserver(_id, Config(), _ => Observer());
+        var second = _store.GetOrCreateObserver(other, Config(), _ => Observer());
+
+        second.Should().NotBeSameAs(first);
+    }
+
+    [Fact]
+    public void GetOrCreateObserver_NullArguments_Throw()
+    {
+        Assert.Throws<ArgumentNullException>(() => _store.GetOrCreateObserver(_id, null!, _ => Observer()));
+        Assert.Throws<ArgumentNullException>(() => _store.GetOrCreateObserver(_id, Config(), null!));
+    }
+
+    #endregion
+
+    #region Polling interval
+
+    [Fact]
+    public void ShouldCheck_NeverChecked_ReturnsTrue()
+    {
+        _store.GetOrCreateObserver(_id, Config(), _ => Observer());
+
+        _store.ShouldCheck(_id, TimeSpan.FromHours(1)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldCheck_UnknownProduct_ReturnsTrue()
+    {
+        _store.ShouldCheck(new ProductDeploymentId(Guid.NewGuid()), TimeSpan.FromHours(1))
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void ShouldCheck_WithinTheInterval_ReturnsFalse()
+    {
+        _store.GetOrCreateObserver(_id, Config(), _ => Observer());
+        _store.RecordResult(_id, ObserverResult.NormalOperation("0"));
+
+        _store.ShouldCheck(_id, TimeSpan.FromHours(1)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldCheck_ZeroInterval_AlwaysReturnsTrue()
+    {
+        _store.GetOrCreateObserver(_id, Config(), _ => Observer());
+        _store.RecordResult(_id, ObserverResult.NormalOperation("0"));
+
+        _store.ShouldCheck(_id, TimeSpan.Zero).Should().BeTrue();
+    }
+
+    #endregion
+
+    #region Results
+
+    [Fact]
+    public void RecordResult_IsReadableBack()
+    {
+        _store.GetOrCreateObserver(_id, Config(), _ => Observer());
+        var result = ObserverResult.MaintenanceRequired("database-exclusive (ONLINE/SINGLE_USER)");
+
+        _store.RecordResult(_id, result);
+
+        _store.GetLastResult(_id).Should().Be(result);
+    }
+
+    [Fact]
+    public void RecordResult_WithoutAnObserver_IsIgnored()
+    {
+        _store.RecordResult(_id, ObserverResult.MaintenanceRequired("1"));
+
+        _store.GetLastResult(_id).Should().BeNull("a forgotten product must not be resurrected");
+        _store.GetConfig(_id).Should().BeNull();
+    }
+
+    [Fact]
+    public void RecordResult_Null_Throws()
+    {
+        _store.GetOrCreateObserver(_id, Config(), _ => Observer());
+
+        Assert.Throws<ArgumentNullException>(() => _store.RecordResult(_id, null!));
+    }
+
+    [Fact]
+    public void GetLastResult_UnknownProduct_ReturnsNull()
+    {
+        _store.GetLastResult(new ProductDeploymentId(Guid.NewGuid())).Should().BeNull();
+    }
+
+    #endregion
+
+    #region Forget
+
+    [Fact]
+    public void Forget_DropsEverythingForTheProduct()
+    {
+        _store.GetOrCreateObserver(_id, Config(), _ => Observer());
+        _store.RecordResult(_id, ObserverResult.NormalOperation("0"));
+
+        _store.Forget(_id);
+
+        _store.GetLastResult(_id).Should().BeNull();
+        _store.GetConfig(_id).Should().BeNull();
+        _store.ShouldCheck(_id, TimeSpan.FromHours(1)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Forget_UnknownProduct_IsANoOp()
+    {
+        var act = () => _store.Forget(new ProductDeploymentId(Guid.NewGuid()));
+
+        act.Should().NotThrow();
+    }
+
+    #endregion
+}

--- a/tests/ReadyStackGo.UnitTests/Infrastructure/Observers/MaintenanceObserverFactoryTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Infrastructure/Observers/MaintenanceObserverFactoryTests.cs
@@ -22,6 +22,7 @@ public class MaintenanceObserverFactoryTests
         // Add required services
         services.AddLogging();
         services.AddHttpClient("MaintenanceObserver");
+        services.AddSingleton<ISqlDatabaseAvailabilityProbe, SqlDatabaseAvailabilityProbe>();
 
         _serviceProvider = services.BuildServiceProvider();
         _factory = new MaintenanceObserverFactory(_serviceProvider);

--- a/tests/ReadyStackGo.UnitTests/Infrastructure/Observers/SqlObserverAvailabilityGateTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Infrastructure/Observers/SqlObserverAvailabilityGateTests.cs
@@ -1,0 +1,150 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ReadyStackGo.Domain.Deployment.Observers;
+using ReadyStackGo.Infrastructure.Services.Health;
+
+namespace ReadyStackGo.UnitTests.Infrastructure.Observers;
+
+/// <summary>
+/// Unit tests for the availability gate in front of the SQL observers.
+///
+/// While a product holds its database exclusively (an update switching it to SINGLE_USER, a restore)
+/// the maintenance flag inside it cannot be read, and connecting would either fail or occupy the one
+/// single-user slot the product's own update needs. The gate answers from server metadata instead.
+///
+/// The connection string deliberately points at a closed port: any test that ends up reading the
+/// database itself fails the check instead of short-circuiting, which is exactly the distinction
+/// these tests need to make.
+/// </summary>
+public class SqlObserverAvailabilityGateTests
+{
+    private const string UnreachableDb =
+        "Server=127.0.0.1,14339;Database=AppDb;User Id=svc;Password=secret;Connect Timeout=1;TrustServerCertificate=true";
+
+    private readonly Mock<ILogger<SqlExtendedPropertyObserver>> _logger = new();
+
+    private static ISqlDatabaseAvailabilityProbe ProbeReturning(SqlDatabaseAvailability availability)
+    {
+        var probe = new Mock<ISqlDatabaseAvailabilityProbe>();
+        probe
+            .Setup(p => p.ProbeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(availability);
+        return probe.Object;
+    }
+
+    private SqlExtendedPropertyObserver CreateObserver(ISqlDatabaseAvailabilityProbe probe)
+    {
+        var config = MaintenanceObserverConfig.Create(
+            ObserverType.SqlExtendedProperty,
+            TimeSpan.FromSeconds(30),
+            maintenanceValue: "1",
+            normalValue: "0",
+            SqlObserverSettings.ForExtendedProperty("app.MaintenanceMode", UnreachableDb));
+
+        return new SqlExtendedPropertyObserver(config, probe, _logger.Object);
+    }
+
+    #region Database held exclusively
+
+    [Theory]
+    [InlineData("ONLINE/SINGLE_USER")]
+    [InlineData("RESTORING/MULTI_USER")]
+    [InlineData("OFFLINE/MULTI_USER")]
+    [InlineData("ONLINE/RESTRICTED_USER")]
+    public async Task CheckAsync_DatabaseNotAvailable_ReportsMaintenanceWithoutReadingIt(string detail)
+    {
+        var observer = CreateObserver(ProbeReturning(SqlDatabaseAvailability.Exclusive(detail)));
+
+        var result = await observer.CheckAsync();
+
+        result.IsSuccess.Should().BeTrue("an exclusive database is a valid observation, not an error");
+        result.IsMaintenanceRequired.Should().BeTrue();
+        result.ObservedValue.Should().Contain(detail,
+            "the reason belongs in the UI and the maintenance reason text");
+    }
+
+    [Fact]
+    public async Task CheckAsync_DatabaseNotAvailable_DoesNotTouchTheDatabase()
+    {
+        var probe = new Mock<ISqlDatabaseAvailabilityProbe>();
+        probe
+            .Setup(p => p.ProbeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SqlDatabaseAvailability.Exclusive("ONLINE/SINGLE_USER"));
+
+        var observer = CreateObserver(probe.Object);
+
+        var result = await observer.CheckAsync();
+
+        // Reaching the database would have produced a failed result against the closed port.
+        result.IsSuccess.Should().BeTrue();
+        result.ErrorMessage.Should().BeNull();
+        probe.Verify(p => p.ProbeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    #endregion
+
+    #region Database available
+
+    [Fact]
+    public async Task CheckAsync_DatabaseAvailable_ReadsTheFlagAsUsual()
+    {
+        var observer = CreateObserver(ProbeReturning(SqlDatabaseAvailability.Available("ONLINE/MULTI_USER")));
+
+        var result = await observer.CheckAsync();
+
+        // The read itself cannot succeed against a closed port — the point is that the gate did not
+        // answer on the observer's behalf, so the automatic return to normal operation stays possible.
+        result.IsSuccess.Should().BeFalse();
+        result.IsMaintenanceRequired.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region Probe unusable
+
+    [Fact]
+    public async Task CheckAsync_AvailabilityUnknown_FallsBackToReadingTheFlag()
+    {
+        var observer = CreateObserver(
+            ProbeReturning(SqlDatabaseAvailability.Unknown("VIEW ANY DATABASE denied")));
+
+        var result = await observer.CheckAsync();
+
+        result.IsSuccess.Should().BeFalse();
+        result.IsMaintenanceRequired.Should().BeFalse(
+            "a permission problem must not park a deployment in maintenance");
+    }
+
+    [Fact]
+    public async Task CheckAsync_ProbeThrows_IsReportedAsAFailedCheck()
+    {
+        var probe = new Mock<ISqlDatabaseAvailabilityProbe>();
+        probe
+            .Setup(p => p.ProbeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("probe exploded"));
+
+        var observer = CreateObserver(probe.Object);
+
+        var result = await observer.CheckAsync();
+
+        result.IsSuccess.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("probe exploded");
+        result.IsMaintenanceRequired.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task CheckAsync_Cancelled_PropagatesInsteadOfReportingMaintenance()
+    {
+        var probe = new Mock<ISqlDatabaseAvailabilityProbe>();
+        probe
+            .Setup(p => p.ProbeAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var observer = CreateObserver(probe.Object);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => observer.CheckAsync());
+    }
+
+    #endregion
+}

--- a/tests/ReadyStackGo.UnitTests/Infrastructure/Observers/SqlObserverConnectionTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Infrastructure/Observers/SqlObserverConnectionTests.cs
@@ -1,0 +1,183 @@
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using ReadyStackGo.Infrastructure.Services.Health;
+
+namespace ReadyStackGo.UnitTests.Infrastructure.Observers;
+
+/// <summary>
+/// Unit tests for SqlObserverConnection — the connection strings RSGO opens itself.
+///
+/// The load-bearing assertion is that pooling ends up disabled no matter what the manifest asked
+/// for: a pooled observer session survives between polls, and a product waiting for all sessions to
+/// close before taking its database exclusively then waits on RSGO forever.
+/// </summary>
+public class SqlObserverConnectionTests
+{
+    private const string Base = "Server=sql01;Database=AppDb;User Id=svc;Password=secret";
+
+    #region Pooling
+
+    [Fact]
+    public void Normalize_DisablesPooling()
+    {
+        var result = new SqlConnectionStringBuilder(SqlObserverConnection.Normalize(Base));
+
+        result.Pooling.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("Pooling=true")]
+    [InlineData("Pooling=True")]
+    [InlineData("Min Pool Size=5;Max Pool Size=50")]
+    public void Normalize_OverridesPoolingRequestedByTheManifest(string poolingOptions)
+    {
+        var result = new SqlConnectionStringBuilder(
+            SqlObserverConnection.Normalize($"{Base};{poolingOptions}"));
+
+        result.Pooling.Should().BeFalse(
+            "a manifest must not be able to re-enable pooling for connections RSGO owns");
+    }
+
+    [Fact]
+    public void ToMaster_DisablesPoolingAsWell()
+    {
+        var result = new SqlConnectionStringBuilder(
+            SqlObserverConnection.ToMaster($"{Base};Pooling=true"));
+
+        result.Pooling.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region Preserved settings
+
+    [Fact]
+    public void Normalize_PreservesServerCredentialsAndDatabase()
+    {
+        var result = new SqlConnectionStringBuilder(SqlObserverConnection.Normalize(Base));
+
+        result.DataSource.Should().Be("sql01");
+        result.InitialCatalog.Should().Be("AppDb");
+        result.UserID.Should().Be("svc");
+        result.Password.Should().Be("secret");
+    }
+
+    [Fact]
+    public void Normalize_PreservesUnrelatedOptions()
+    {
+        var result = new SqlConnectionStringBuilder(
+            SqlObserverConnection.Normalize($"{Base};TrustServerCertificate=true;Connect Timeout=7"));
+
+        result.TrustServerCertificate.Should().BeTrue();
+        result.ConnectTimeout.Should().Be(7);
+    }
+
+    #endregion
+
+    #region Application name
+
+    [Fact]
+    public void Normalize_TagsTheSessionSoOperatorsCanIdentifyIt()
+    {
+        var result = new SqlConnectionStringBuilder(SqlObserverConnection.Normalize(Base));
+
+        result.ApplicationName.Should().Be(SqlObserverConnection.ApplicationName);
+    }
+
+    [Fact]
+    public void Normalize_UsesTheCallersTagWhenGiven()
+    {
+        var result = new SqlConnectionStringBuilder(
+            SqlObserverConnection.Normalize(Base, "ReadyStackGo-ConnectionTest"));
+
+        result.ApplicationName.Should().Be("ReadyStackGo-ConnectionTest");
+        result.Pooling.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Normalize_KeepsAnApplicationNameChosenInTheManifest()
+    {
+        var result = new SqlConnectionStringBuilder(
+            SqlObserverConnection.Normalize($"{Base};Application Name=CustomerTag"));
+
+        result.ApplicationName.Should().Be("CustomerTag");
+    }
+
+    #endregion
+
+    #region master rewrite
+
+    [Fact]
+    public void ToMaster_RedirectsToMasterButKeepsServerAndCredentials()
+    {
+        var result = new SqlConnectionStringBuilder(SqlObserverConnection.ToMaster(Base));
+
+        result.InitialCatalog.Should().Be("master");
+        result.DataSource.Should().Be("sql01");
+        result.UserID.Should().Be("svc");
+        result.Password.Should().Be("secret");
+    }
+
+    [Fact]
+    public void ToMaster_WithoutInitialCatalog_StillTargetsMaster()
+    {
+        var result = new SqlConnectionStringBuilder(
+            SqlObserverConnection.ToMaster("Server=sql01;Integrated Security=true"));
+
+        result.InitialCatalog.Should().Be("master");
+    }
+
+    #endregion
+
+    #region DatabaseName
+
+    [Fact]
+    public void DatabaseName_ReturnsInitialCatalog()
+    {
+        SqlObserverConnection.DatabaseName(Base).Should().Be("AppDb");
+    }
+
+    [Fact]
+    public void DatabaseName_AcceptsInitialCatalogSpelling()
+    {
+        SqlObserverConnection.DatabaseName("Server=sql01;Initial Catalog=Other").Should().Be("Other");
+    }
+
+    [Fact]
+    public void DatabaseName_WithoutDatabase_ReturnsNull()
+    {
+        SqlObserverConnection.DatabaseName("Server=sql01;Integrated Security=true").Should().BeNull();
+    }
+
+    #endregion
+
+    #region Unparsable input
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("this is not a connection string at all")]
+    public void Normalize_UnusableInput_IsReturnedUnchanged(string connectionString)
+    {
+        // Failing here would hide the real problem; the connect attempt reports it instead.
+        SqlObserverConnection.Normalize(connectionString).Should().Be(connectionString);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("this is not a connection string at all")]
+    public void DatabaseName_UnusableInput_ReturnsNull(string connectionString)
+    {
+        SqlObserverConnection.DatabaseName(connectionString).Should().BeNull();
+    }
+
+    [Fact]
+    public void ToMaster_UnusableInput_IsReturnedUnchanged()
+    {
+        const string garbage = "not a connection string";
+
+        SqlObserverConnection.ToMaster(garbage).Should().Be(garbage);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
Fixes #463.

## The deadlock

A product that maintains itself typically follows this sequence:

1. set the maintenance flag (a SQL Server extended property)
2. wait until all connections to the database are closed
3. switch the database to `SINGLE_USER` and do the work

RSGO's SQL observer is a participant in step 1→2: it detects the flag and stops the product's containers, whose connections then go away. But the observer kept polling, and its connection was pooled — `Dispose` only returns it to the ADO.NET pool, and the next poll refreshed it, so the pool's idle cleanup never reclaimed it. Step 2 waited on RSGO. Where the product waits without a timeout, its update never completes.

## Changes

**Pooling off for connections RSGO owns.** `SqlObserverConnection` normalizes every connection string RSGO opens itself — both SQL observers, the SQL setter and the connection test endpoint — so the session lives only for the duration of a single read. Sessions are tagged (`ReadyStackGo-Maintenance`, `ReadyStackGo-ConnectionTest`) to be identifiable in `sys.dm_exec_sessions` / `sp_who2`. Product containers are unaffected: RSGO does not build their connection strings, and they keep their pooling.

**An availability gate in front of every read.** The maintenance flag lives inside the very database that becomes exclusive, so during the window it cannot be read — and a connect attempt can occupy the single-user slot the product's own update needs, failing it with error 924. `SqlDatabaseAvailabilityProbe` reads `sys.databases` over a `master` connection derived from the same credentials: `master` stays reachable while another database is `SINGLE_USER`/`RESTORING`/`OFFLINE`, and the query takes no lock on the target. While unavailable, the observer reports maintenance with an observed value of `database-exclusive (<state>/<user access>)`; once the database is `ONLINE` and `MULTI_USER` again the next poll reads the flag normally, so the automatic return to normal operation keeps working however long the product takes. Unknown availability (login without access to `master`) falls back to the previous behaviour with one warning, rather than parking a deployment in maintenance over a permission problem.

**No polling during manual maintenance.** Trigger ownership means the observer may not end manually activated maintenance, so the read could only ever leave a session behind. It is now skipped entirely — which also makes entering maintenance manually a reliable way to keep RSGO off a product.

**Observer state moved to a singleton store.** `MaintenanceObserverService` stays scoped (it depends on repositories and the mediator — a singleton would be a captive dependency), but the background service creates a fresh scope per cycle, so state on the service was discarded every time. That silently defeated the configured `pollingInterval` and left `GET /api/health/deployments/{id}/observer` permanently reporting `HasObserver=false`. `MaintenanceObserverStateStore` also replaces a cached observer when its config changes, so a manifest edit takes effect on redeploy without restarting RSGO — while keeping the check timestamp, so a config change cannot be used to read a product database more often than its interval allows.

**Documentation.** The database access behaviour is documented in `docs/Operations/Operation-Mode.md` and on the public site (DE/EN). The observer `enabled` manifest field and `PUT /api/deployments/{id}/maintenance-observer` were removed from the docs — neither exists in the manifest model or the endpoint list.

## Not included

No manifest change is required: the gate derives the `master` connection from the existing observer connection string, so the fix applies to already-deployed manifests as they are.

## Tests

`SqlObserverConnectionTests` (pooling forced off even when the manifest asks for it, `master` rewrite, unparsable input, tag precedence), `SqlObserverAvailabilityGateTests` (exclusive database short-circuits without touching it, available database falls through, unknown falls back, probe failure is a failed check, cancellation propagates), `MaintenanceObserverStateStoreTests` (interval, config change replaces observer but keeps the timestamp, forget, unknown product), `MaintenanceObserverServiceTests` (manual maintenance polls nothing, observer-triggered keeps polling and can exit, exclusive database while in maintenance changes nothing, no re-check across scopes within the interval).

3312 unit tests and 412 integration tests pass; build is clean.