### PR TITLE
fix: verify and enforce container stop when entering maintenance

### DIFF
--- a/src/ReadyStackGo.Application/Services/IDockerService.cs
+++ b/src/ReadyStackGo.Application/Services/IDockerService.cs
@@ -34,6 +34,13 @@ public interface IDockerService
     Task StopContainerAsync(string environmentId, string containerId, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Kills a container in the specified environment (SIGKILL, no grace period).
+    /// Escalation for a container that did not react to a stop — used by the maintenance
+    /// transition, which must not leave a container running.
+    /// </summary>
+    Task KillContainerAsync(string environmentId, string containerId, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Tests the connection to a Docker host.
     /// </summary>
     Task<TestConnectionResult> TestConnectionAsync(string dockerHost, CancellationToken cancellationToken = default);

--- a/src/ReadyStackGo.Application/Services/MaintenanceContainerFilter.cs
+++ b/src/ReadyStackGo.Application/Services/MaintenanceContainerFilter.cs
@@ -1,0 +1,66 @@
+using ReadyStackGo.Application.UseCases.Containers;
+
+namespace ReadyStackGo.Application.Services;
+
+/// <summary>
+/// Decides which containers a maintenance transition has to touch.
+///
+/// The selection used to be "state == running", which silently let every other live Docker state
+/// through: a container under <c>restart: always</c> that is cycling reports <c>restarting</c>, a
+/// suspended one reports <c>paused</c>, and one that was created but never started reports
+/// <c>created</c>. None of them were stopped, so they kept running through the maintenance window —
+/// connection pools on the product database included, which is exactly what maintenance mode is
+/// supposed to release.
+///
+/// The predicate is therefore inverted: everything that is not already gone is stopped. Only states
+/// that cannot hold resources any more (<c>exited</c>, <c>dead</c>) or are already being torn down
+/// (<c>removing</c>) are left alone.
+/// </summary>
+public static class MaintenanceContainerFilter
+{
+    /// <summary>Label a product uses to opt a container out of maintenance handling.</summary>
+    public const string MaintenanceLabel = "rsgo.maintenance";
+
+    /// <summary>Label carrying the deployment stack name a container belongs to.</summary>
+    public const string StackLabel = "rsgo.stack";
+
+    /// <summary>Label value that exempts a container from being stopped or started.</summary>
+    public const string IgnoreValue = "ignore";
+
+    /// <summary>
+    /// True when the container opted out of maintenance handling via
+    /// <c>rsgo.maintenance=ignore</c> (the edge proxy and product-contributed maintenance
+    /// containers rely on this to outlive the window).
+    /// </summary>
+    public static bool IsExempt(ContainerDto container)
+        => container.Labels.TryGetValue(MaintenanceLabel, out var mode)
+           && mode.Equals(IgnoreValue, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// True when the container carries the given deployment stack name.
+    /// </summary>
+    public static bool BelongsToStack(ContainerDto container, string stackName)
+        => container.Labels.TryGetValue(StackLabel, out var stack) && stack == stackName;
+
+    /// <summary>
+    /// True when the container can no longer hold resources, i.e. the stop already took effect.
+    /// </summary>
+    public static bool IsStopped(ContainerDto container)
+        => IsState(container, "exited") || IsState(container, "dead");
+
+    /// <summary>
+    /// True when a maintenance transition must stop this container: it is not exempt, not already
+    /// stopped, and not in the middle of being removed.
+    /// </summary>
+    public static bool ShouldStop(ContainerDto container)
+        => !IsExempt(container) && !IsStopped(container) && !IsState(container, "removing");
+
+    /// <summary>
+    /// True when exiting maintenance must start this container again.
+    /// </summary>
+    public static bool ShouldStart(ContainerDto container)
+        => !IsExempt(container) && (IsState(container, "exited") || IsState(container, "created"));
+
+    private static bool IsState(ContainerDto container, string state)
+        => container.State.Equals(state, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/ReadyStackGo.Application/UseCases/Deployments/ChangeProductOperationMode/ChangeProductOperationModeHandler.cs
+++ b/src/ReadyStackGo.Application/UseCases/Deployments/ChangeProductOperationMode/ChangeProductOperationModeHandler.cs
@@ -3,6 +3,7 @@ namespace ReadyStackGo.Application.UseCases.Deployments.ChangeProductOperationMo
 using MediatR;
 using Microsoft.Extensions.Logging;
 using ReadyStackGo.Application.Services;
+using ReadyStackGo.Application.UseCases.Containers;
 using ReadyStackGo.Application.UseCases.Health;
 using ReadyStackGo.Domain.Deployment.Deployments;
 using ReadyStackGo.Domain.Deployment.Health;
@@ -25,6 +26,18 @@ public class ChangeProductOperationModeHandler
     private readonly IMaintenanceSetterService _maintenanceSetterService;
     private readonly IDeploymentNotificationService _deploymentNotificationService;
     private readonly ILogger<ChangeProductOperationModeHandler> _logger;
+
+    /// <summary>
+    /// Stack statuses whose containers can still be up, and which a maintenance transition therefore
+    /// has to handle. <c>Pending</c> was never deployed, <c>Removed</c> is gone and <c>Stopped</c>
+    /// was deliberately stopped already — none of them own live containers.
+    /// </summary>
+    private static readonly StackDeploymentStatus[] MaintenanceRelevantStatuses =
+    [
+        StackDeploymentStatus.Running,
+        StackDeploymentStatus.Deploying,
+        StackDeploymentStatus.Failed
+    ];
 
     public ChangeProductOperationModeHandler(
         IProductDeploymentRepository productDeploymentRepository,
@@ -173,12 +186,23 @@ public class ChangeProductOperationModeHandler
         var isExit = previousMode == OperationMode.Maintenance && targetMode == OperationMode.Normal;
         var action = isEnter ? "enter" : "exit";
 
-        // Only stacks that are actually running are affected — this is the real
-        // denominator for the "stack X of N" progress shown to the user.
+        // Every stack that may still have containers up is affected — this is the real denominator
+        // for the "stack X of N" progress shown to the user. The set is deliberately wider than
+        // "Running": a stack recorded as Failed because a single container never became healthy
+        // still has all its other containers up, and restricting to Running skipped it wholesale,
+        // leaving those containers (and their database connections) alive through maintenance.
+        // A stack without a deployment stack name was never deployed, so there is nothing to touch.
         var affectedStacks = productDeployment.Stacks
-            .Where(s => s.Status == StackDeploymentStatus.Running)
+            .Where(s => MaintenanceRelevantStatuses.Contains(s.Status))
+            .Where(s => !string.IsNullOrEmpty(s.DeploymentStackName))
             .ToList();
         var totalStacks = affectedStacks.Count;
+
+        // Containers that survived the whole transition, across all stacks.
+        var stillRunning = new List<ContainerDto>();
+
+        // Stacks whose state could not be read back, so nothing can be claimed about them.
+        var unverifiedStacks = new List<string>();
 
         // Local helper: forwards a progress update to connected clients (no-op without a session).
         async Task NotifyAsync(
@@ -238,6 +262,23 @@ public class ChangeProductOperationModeHandler
 
                     await _dockerService.StopStackContainersAsync(
                         environmentId, stack.DeploymentStackName!, OnContainer, cancellationToken);
+
+                    // A stop that did not take effect must not pass as success — maintenance mode
+                    // exists to release the product's resources, above all its database sessions.
+                    // A verification that cannot run is not a success either: claiming the stack
+                    // stopped without having looked is what made the original bug invisible.
+                    try
+                    {
+                        stillRunning.AddRange(await EnsureStackStoppedAsync(
+                            environmentId, stack.DeploymentStackName!, stack.StackName, cancellationToken));
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        _logger.LogError(ex,
+                            "Could not verify that the containers of stack {StackName} stopped",
+                            stack.StackName);
+                        unverifiedStacks.Add(stack.StackDisplayName ?? stack.StackName);
+                    }
                 }
                 else if (isExit)
                 {
@@ -260,9 +301,116 @@ public class ChangeProductOperationModeHandler
         _deploymentRepository.SaveChanges();
 
         // Terminal update so the UI can flip every stack to done and leave the processing view.
+        // Reporting Completed while containers are still up would hide the failure entirely — the
+        // operator would start a database update against a product that is still connected.
+        if (stillRunning.Count > 0)
+        {
+            var names = string.Join(", ", stillRunning.Select(c => c.Name).Order());
+
+            _logger.LogError(
+                "Entered maintenance for product {ProductName} but {Count} container(s) are still running: {Containers}",
+                productDeployment.ProductName, stillRunning.Count, names);
+
+            await NotifyAsync(
+                "Failed", null, null, totalStacks, null, 0, 0,
+                $"{stillRunning.Count} container(s) could not be stopped: {names}");
+            return;
+        }
+
+        if (unverifiedStacks.Count > 0)
+        {
+            await NotifyAsync(
+                "Failed", null, null, totalStacks, null, 0, 0,
+                $"Could not verify that all containers stopped: {string.Join(", ", unverifiedStacks)}");
+            return;
+        }
+
         await NotifyAsync(
             "Completed", null, null, totalStacks, null, 0, 0,
             isEnter ? "All containers stopped" : "All containers started");
+    }
+
+    /// <summary>
+    /// Verifies that a stack really has no live containers left and forces the ones that remain.
+    ///
+    /// A single bulk stop is not enough: the container list is a snapshot taken before stopping, so
+    /// a container coming up during the transition is missed; individual stop calls can fail and
+    /// were only logged; and a container under a restart policy can come back up. Each round
+    /// therefore re-reads the actual state instead of trusting the previous call, escalating from
+    /// stop to kill. No delay between the rounds is needed — both Docker calls block until the
+    /// daemon has acted on the container.
+    /// </summary>
+    /// <returns>Containers that are still live after all attempts. Empty is the expected result.</returns>
+    private async Task<IReadOnlyList<ContainerDto>> EnsureStackStoppedAsync(
+        string environmentId,
+        string deploymentStackName,
+        string stackName,
+        CancellationToken cancellationToken)
+    {
+        var remaining = await GetLiveContainersAsync(environmentId, deploymentStackName, cancellationToken);
+        if (remaining.Count == 0)
+        {
+            return remaining;
+        }
+
+        _logger.LogWarning(
+            "{Count} container(s) of stack {StackName} did not stop, retrying individually: {Containers}",
+            remaining.Count, stackName, string.Join(", ", remaining.Select(c => c.Name)));
+
+        foreach (var container in remaining)
+        {
+            try
+            {
+                await _dockerService.StopContainerAsync(environmentId, container.Id, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Retrying stop failed for container {Name} ({Id})", container.Name, container.Id);
+            }
+        }
+
+        remaining = await GetLiveContainersAsync(environmentId, deploymentStackName, cancellationToken);
+        if (remaining.Count == 0)
+        {
+            return remaining;
+        }
+
+        // A container that ignored two stops gets killed. Losing its graceful shutdown is the lesser
+        // evil compared to a maintenance window that never actually starts.
+        foreach (var container in remaining)
+        {
+            _logger.LogWarning(
+                "Container {Name} ({Id}) of stack {StackName} survived two stop attempts, killing it",
+                container.Name, container.Id, stackName);
+
+            try
+            {
+                await _dockerService.KillContainerAsync(environmentId, container.Id, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Killing container {Name} ({Id}) failed", container.Name, container.Id);
+            }
+        }
+
+        return await GetLiveContainersAsync(environmentId, deploymentStackName, cancellationToken);
+    }
+
+    /// <summary>
+    /// Containers of the given stack that a maintenance stop still has to deal with. Containers the
+    /// product opted out of (<c>rsgo.maintenance=ignore</c>) and already stopped ones are excluded.
+    /// </summary>
+    private async Task<IReadOnlyList<ContainerDto>> GetLiveContainersAsync(
+        string environmentId,
+        string deploymentStackName,
+        CancellationToken cancellationToken)
+    {
+        var containers = await _dockerService.ListContainersAsync(environmentId, cancellationToken);
+
+        return containers
+            .Where(c => MaintenanceContainerFilter.BelongsToStack(c, deploymentStackName))
+            .Where(MaintenanceContainerFilter.ShouldStop)
+            .ToList();
     }
 
     private void PropagateOperationModeToChildDeployment(

--- a/src/ReadyStackGo.Infrastructure.Docker/DockerService.cs
+++ b/src/ReadyStackGo.Infrastructure.Docker/DockerService.cs
@@ -787,10 +787,8 @@ public class DockerService : IDockerService, IDisposable
 
         var containers = await ListContainersAsync(environmentId, cancellationToken);
         var stackContainers = containers
-            .Where(c => c.Labels.TryGetValue("rsgo.stack", out var stack) && stack == stackName)
-            .Where(c => !c.Labels.TryGetValue("rsgo.maintenance", out var mode) ||
-                        !mode.Equals("ignore", StringComparison.OrdinalIgnoreCase))
-            .Where(c => c.State == "running")
+            .Where(c => MaintenanceContainerFilter.BelongsToStack(c, stackName))
+            .Where(MaintenanceContainerFilter.ShouldStop)
             .ToList();
 
         var stoppedIds = new List<string>();
@@ -849,10 +847,8 @@ public class DockerService : IDockerService, IDisposable
 
         var containers = await ListContainersAsync(environmentId, cancellationToken);
         var stackContainers = containers
-            .Where(c => c.Labels.TryGetValue("rsgo.stack", out var stack) && stack == stackName)
-            .Where(c => !c.Labels.TryGetValue("rsgo.maintenance", out var mode) ||
-                        !mode.Equals("ignore", StringComparison.OrdinalIgnoreCase))
-            .Where(c => c.State == "exited" || c.State == "created")
+            .Where(c => MaintenanceContainerFilter.BelongsToStack(c, stackName))
+            .Where(MaintenanceContainerFilter.ShouldStart)
             .ToList();
 
         var startedIds = new List<string>();

--- a/src/ReadyStackGo.Infrastructure.Docker/DockerService.cs
+++ b/src/ReadyStackGo.Infrastructure.Docker/DockerService.cs
@@ -115,6 +115,18 @@ public class DockerService : IDockerService, IDisposable
         _logger.LogInformation("Stopped container {ContainerId} in environment {EnvironmentId}", containerId, environmentId);
     }
 
+    public async Task KillContainerAsync(string environmentId, string containerId, CancellationToken cancellationToken = default)
+    {
+        var client = await GetDockerClientAsync(environmentId);
+
+        await client.Containers.KillContainerAsync(
+            containerId,
+            new ContainerKillParameters(),
+            cancellationToken);
+
+        _logger.LogWarning("Killed container {ContainerId} in environment {EnvironmentId}", containerId, environmentId);
+    }
+
     public async Task<TestConnectionResult> TestConnectionAsync(string dockerHost, CancellationToken cancellationToken = default)
     {
         try

--- a/tests/ReadyStackGo.UnitTests/Application/Deployments/ChangeProductOperationModeHandlerTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Deployments/ChangeProductOperationModeHandlerTests.cs
@@ -39,6 +39,12 @@ public class ChangeProductOperationModeHandlerTests
         _deploymentNotificationMock = new Mock<IDeploymentNotificationService>();
         _loggerMock = new Mock<ILogger<ChangeProductOperationModeHandler>>();
 
+        // Default: the daemon reports no containers, so the stop verification finds nothing left
+        // running. Tests that care about surviving containers set this up themselves.
+        _dockerServiceMock
+            .Setup(d => d.ListContainersAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync([]);
+
         _handler = new ChangeProductOperationModeHandler(
             _repositoryMock.Object,
             _deploymentRepositoryMock.Object,
@@ -518,7 +524,7 @@ public class ChangeProductOperationModeHandlerTests
     }
 
     [Fact]
-    public async Task Handle_SkipsNonRunningStacks()
+    public async Task Handle_IncludesFailedStacksWhenStopping()
     {
         var stackConfigs = new List<StackDeploymentConfig>
         {
@@ -532,7 +538,6 @@ public class ChangeProductOperationModeHandlerTests
             "g", "p", "test", "Test", "1.0.0",
             UserId.Create(), "deploy", stackConfigs, new Dictionary<string, string>());
 
-        // Only complete the first stack; second is still deploying
         deployment.StartStack("db", DeploymentId.NewId());
         deployment.CompleteStack("db");
         deployment.StartStack("api", DeploymentId.NewId());
@@ -544,7 +549,38 @@ public class ChangeProductOperationModeHandlerTests
         await _handler.Handle(
             CreateCommand(deployment, mode: "Maintenance"), CancellationToken.None);
 
-        // Only the Running stack (db) should have containers stopped
+        // Both stacks are stopped. A Failed stack still has containers up — the stack is only
+        // marked Failed because one of them never became healthy (bug #468).
+        _dockerServiceMock.Verify(d => d.StopStackContainersAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Func<StackContainerProgress, Task>>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task Handle_SkipsStacksThatWereNeverDeployed()
+    {
+        var stackConfigs = new List<StackDeploymentConfig>
+        {
+            new("db", "Database", "source:db:1.0", 1, new Dictionary<string, string>()),
+            new("api", "API", "source:api:1.0", 2, new Dictionary<string, string>())
+        };
+
+        var deployment = ProductDeployment.InitiateDeployment(
+            ProductDeploymentId.NewId(),
+            new EnvironmentId(Guid.Parse(TestEnvironmentId)),
+            "g", "p", "test", "Test", "1.0.0",
+            UserId.Create(), "deploy", stackConfigs, new Dictionary<string, string>());
+
+        // 'api' is never started, so it stays Pending and has no deployment stack name.
+        deployment.StartStack("db", DeploymentId.NewId());
+        deployment.CompleteStack("db");
+        deployment.MarkAsPartiallyRunning("api not attempted");
+
+        SetupDeploymentFound(deployment);
+
+        await _handler.Handle(
+            CreateCommand(deployment, mode: "Maintenance"), CancellationToken.None);
+
         _dockerServiceMock.Verify(d => d.StopStackContainersAsync(
             It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Func<StackContainerProgress, Task>>(), It.IsAny<CancellationToken>()),
             Times.Once);
@@ -826,7 +862,7 @@ public class ChangeProductOperationModeHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithSession_SkipsNonRunningStacksInProgress()
+    public async Task Handle_WithSession_CountsFailedStacksInProgress()
     {
         var stackConfigs = new List<StackDeploymentConfig>
         {
@@ -851,13 +887,13 @@ public class ChangeProductOperationModeHandlerTests
         await _handler.Handle(
             CreateCommandWithSession(deployment, "session-1", mode: "Maintenance"), CancellationToken.None);
 
-        // Only the single running stack (db) is affected, so totalStacks must be 1 and
-        // exactly one stack-level progress event is emitted.
+        // Both stacks are affected — the Failed one still has containers up — so the denominator
+        // is 2 and one stack-level progress event is emitted per stack.
         _deploymentNotificationMock.Verify(n => n.NotifyMaintenanceProgressAsync(
             It.Is<MaintenanceProgressNotification>(m =>
-                m.Phase == "InProgress" && m.ContainerIndex == 0 && m.TotalStacks == 1),
+                m.Phase == "InProgress" && m.ContainerIndex == 0 && m.TotalStacks == 2),
             It.IsAny<CancellationToken>()),
-            Times.Once);
+            Times.Exactly(2));
     }
 
     #endregion

--- a/tests/ReadyStackGo.UnitTests/Application/Deployments/ChangeProductOperationModeStopVerificationTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Deployments/ChangeProductOperationModeStopVerificationTests.cs
@@ -458,6 +458,23 @@ public class ChangeProductOperationModeStopVerificationTests
     }
 
     [Fact]
+    public async Task EnterMaintenance_VerificationFails_ReportsFailedPhase()
+    {
+        // If the container list cannot be read, nothing is known about the stack. Claiming success
+        // without having looked is precisely what kept the original bug invisible.
+        var deployment = RunningDeployment();
+        _dockerServiceMock
+            .Setup(d => d.ListContainersAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("docker daemon unreachable"));
+
+        var response = await EnterMaintenance(deployment);
+
+        response.Success.Should().BeTrue();
+        TerminalUpdate.Phase.Should().Be("Failed");
+        TerminalUpdate.Message.Should().Contain("verify");
+    }
+
+    [Fact]
     public async Task EnterMaintenance_ContainersRemainRunning_StillReportsModeChange()
     {
         // The mode has already been propagated to the product; rolling it back would be more

--- a/tests/ReadyStackGo.UnitTests/Application/Deployments/ChangeProductOperationModeStopVerificationTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Deployments/ChangeProductOperationModeStopVerificationTests.cs
@@ -1,0 +1,477 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Application.UseCases.Containers;
+using ReadyStackGo.Application.UseCases.Deployments.ChangeProductOperationMode;
+using ReadyStackGo.Application.UseCases.Health;
+using ReadyStackGo.Domain.Deployment.Deployments;
+using ReadyStackGo.Domain.Deployment.Environments;
+using ReadyStackGo.Domain.Deployment.Health;
+using ReadyStackGo.Domain.Deployment.Observers;
+using ReadyStackGo.Domain.Deployment.ProductDeployments;
+using UserId = ReadyStackGo.Domain.Deployment.UserId;
+
+namespace ReadyStackGo.UnitTests.Application.Deployments;
+
+/// <summary>
+/// Entering maintenance must actually leave nothing running — that is the whole point of the mode,
+/// and a product update that waits for all database sessions to close depends on it.
+///
+/// These tests cover the ways a container survived the transition: a stack whose recorded status is
+/// not Running was skipped wholesale, a failed stop was never retried, and the transition reported
+/// "All containers stopped" regardless of the outcome.
+/// </summary>
+public class ChangeProductOperationModeStopVerificationTests
+{
+    private readonly Mock<IProductDeploymentRepository> _repositoryMock = new();
+    private readonly Mock<IDeploymentRepository> _deploymentRepositoryMock = new();
+    private readonly Mock<IDockerService> _dockerServiceMock = new();
+    private readonly Mock<IHealthNotificationService> _healthNotificationMock = new();
+    private readonly Mock<IMaintenanceSetterService> _setterServiceMock = new();
+    private readonly Mock<IDeploymentNotificationService> _deploymentNotificationMock = new();
+    private readonly ChangeProductOperationModeHandler _handler;
+
+    private readonly List<MaintenanceProgressNotification> _progress = new();
+
+    private static readonly string TestEnvironmentId = Guid.NewGuid().ToString();
+    private const string TestSessionId = "session-1";
+
+    /// <summary>Container list the mocked Docker daemon currently reports. Tests mutate it.</summary>
+    private List<ContainerDto> _containers = new();
+
+    public ChangeProductOperationModeStopVerificationTests()
+    {
+        _setterServiceMock
+            .Setup(s => s.ApplyAsync(It.IsAny<MaintenanceSetterConfig?>(), It.IsAny<MaintenanceState>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SetterResult.WasSkipped("no setter configured"));
+
+        _deploymentNotificationMock
+            .Setup(n => n.NotifyMaintenanceProgressAsync(It.IsAny<MaintenanceProgressNotification>(), It.IsAny<CancellationToken>()))
+            .Callback<MaintenanceProgressNotification, CancellationToken>((n, _) => _progress.Add(n))
+            .Returns(Task.CompletedTask);
+
+        _dockerServiceMock
+            .Setup(d => d.ListContainersAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => _containers.ToList());
+
+        _dockerServiceMock
+            .Setup(d => d.StopStackContainersAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<Func<StackContainerProgress, Task>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<string>());
+
+        _dockerServiceMock
+            .Setup(d => d.StartStackContainersAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<Func<StackContainerProgress, Task>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<string>());
+
+        _handler = new ChangeProductOperationModeHandler(
+            _repositoryMock.Object,
+            _deploymentRepositoryMock.Object,
+            _dockerServiceMock.Object,
+            _healthNotificationMock.Object,
+            _setterServiceMock.Object,
+            _deploymentNotificationMock.Object,
+            Mock.Of<ILogger<ChangeProductOperationModeHandler>>());
+    }
+
+    #region Helpers
+
+    private static ProductDeployment InitiateDeployment(int stackCount)
+    {
+        var stackConfigs = Enumerable.Range(0, stackCount).Select(i =>
+            new StackDeploymentConfig(
+                $"stack-{i}", $"Stack {i}", $"source:product:stack-{i}:1.0",
+                i + 1, new Dictionary<string, string>()))
+            .ToList();
+
+        return ProductDeployment.InitiateDeployment(
+            ProductDeploymentId.NewId(),
+            new EnvironmentId(Guid.Parse(TestEnvironmentId)),
+            "product-group", "product-id",
+            "test-product", "Test Product", "1.0.0",
+            UserId.Create(),
+            "test-deploy",
+            stackConfigs,
+            new Dictionary<string, string>());
+    }
+
+    /// <summary>A product where every stack came up: all stacks Running, product Running.</summary>
+    private ProductDeployment RunningDeployment(int stackCount = 1)
+    {
+        var deployment = InitiateDeployment(stackCount);
+
+        foreach (var stack in deployment.GetStacksInDeployOrder().ToList())
+        {
+            deployment.StartStack(stack.StackName, DeploymentId.NewId());
+            deployment.CompleteStack(stack.StackName);
+        }
+
+        Register(deployment);
+        return deployment;
+    }
+
+    /// <summary>
+    /// A product where the second stack failed — the realistic case behind the bug: one container
+    /// never became healthy, so the whole stack is recorded as Failed while its other containers
+    /// are up and running.
+    /// </summary>
+    private ProductDeployment PartiallyRunningDeploymentWithFailedStack()
+    {
+        var deployment = InitiateDeployment(2);
+        var stacks = deployment.GetStacksInDeployOrder().ToList();
+
+        deployment.StartStack(stacks[0].StackName, DeploymentId.NewId());
+        deployment.CompleteStack(stacks[0].StackName);
+
+        deployment.StartStack(stacks[1].StackName, DeploymentId.NewId());
+        deployment.FailStack(stacks[1].StackName, "container never became healthy");
+
+        deployment.MarkAsPartiallyRunning("one stack failed");
+
+        Register(deployment);
+        return deployment;
+    }
+
+    /// <summary>
+    /// A product where the second stack was never started: status Pending, and therefore no
+    /// deployment stack name. Nothing to stop, and nothing that may be dereferenced.
+    /// </summary>
+    private ProductDeployment PartiallyRunningDeploymentWithPendingStack()
+    {
+        var deployment = InitiateDeployment(2);
+        var stacks = deployment.GetStacksInDeployOrder().ToList();
+
+        deployment.StartStack(stacks[0].StackName, DeploymentId.NewId());
+        deployment.CompleteStack(stacks[0].StackName);
+        deployment.MarkAsPartiallyRunning("second stack not attempted");
+
+        Register(deployment);
+        return deployment;
+    }
+
+    private void Register(ProductDeployment deployment)
+        => _repositoryMock.Setup(r => r.Get(It.Is<ProductDeploymentId>(id => id == deployment.Id)))
+                          .Returns(deployment);
+
+    private static string StackNameOf(ProductDeployment deployment, StackDeploymentStatus status)
+        => deployment.Stacks.First(s => s.Status == status).DeploymentStackName!;
+
+    private static ContainerDto Container(
+        string name, string stackName, string state = "running", string? maintenance = null)
+    {
+        var labels = new Dictionary<string, string> { ["rsgo.stack"] = stackName };
+        if (maintenance != null) labels["rsgo.maintenance"] = maintenance;
+
+        return new ContainerDto
+        {
+            Id = $"id-{name}",
+            Name = name,
+            Image = "test:1.0",
+            State = state,
+            Status = state,
+            Labels = labels
+        };
+    }
+
+    private Task<ChangeProductOperationModeResponse> EnterMaintenance(ProductDeployment deployment)
+        => _handler.Handle(
+            new ChangeProductOperationModeCommand(
+                TestEnvironmentId, deployment.Id.Value.ToString(), "Maintenance",
+                Reason: "test", Source: "Manual", SessionId: TestSessionId),
+            CancellationToken.None);
+
+    private Task<ChangeProductOperationModeResponse> ExitMaintenance(ProductDeployment deployment)
+        => _handler.Handle(
+            new ChangeProductOperationModeCommand(
+                TestEnvironmentId, deployment.Id.Value.ToString(), "Normal",
+                Reason: "test", Source: "Manual", SessionId: TestSessionId),
+            CancellationToken.None);
+
+    /// <summary>Makes the mocked daemon report the container as stopped after N bulk stop calls.</summary>
+    private void StopTakesEffectAfter(int bulkStopCalls)
+    {
+        var calls = 0;
+        _dockerServiceMock
+            .Setup(d => d.StopStackContainersAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<Func<StackContainerProgress, Task>>(), It.IsAny<CancellationToken>()))
+            .Returns(() =>
+            {
+                calls++;
+                if (calls >= bulkStopCalls)
+                {
+                    _containers = _containers.Select(c => c with { State = "exited" }).ToList();
+                }
+
+                return Task.FromResult<IReadOnlyList<string>>(Array.Empty<string>());
+            });
+    }
+
+    private MaintenanceProgressNotification TerminalUpdate
+        => _progress.Last();
+
+    #endregion
+
+    #region Stacks that are not Running (gap: whole stack skipped)
+
+    [Fact]
+    public async Task EnterMaintenance_FailedStack_StopsItsContainersToo()
+    {
+        // A stack recorded as Failed still has running containers holding database connections.
+        var deployment = PartiallyRunningDeploymentWithFailedStack();
+        var failedStack = StackNameOf(deployment, StackDeploymentStatus.Failed);
+
+        await EnterMaintenance(deployment);
+
+        _dockerServiceMock.Verify(d => d.StopStackContainersAsync(
+                TestEnvironmentId, failedStack,
+                It.IsAny<Func<StackContainerProgress, Task>>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "containers of a Failed stack keep running and must be stopped as well");
+    }
+
+    [Fact]
+    public async Task EnterMaintenance_FailedStack_IsCountedInProgress()
+    {
+        var deployment = PartiallyRunningDeploymentWithFailedStack();
+
+        await EnterMaintenance(deployment);
+
+        _progress.Should().Contain(p => p.TotalStacks == 2,
+            "the progress denominator must include the Failed stack, otherwise the user cannot see it was handled");
+    }
+
+    [Fact]
+    public async Task EnterMaintenance_PendingStack_IsSkippedWithoutFailing()
+    {
+        // A Pending stack has no deployment stack name — it must not be dereferenced.
+        var deployment = PartiallyRunningDeploymentWithPendingStack();
+        var runningStack = StackNameOf(deployment, StackDeploymentStatus.Running);
+
+        var response = await EnterMaintenance(deployment);
+
+        response.Success.Should().BeTrue();
+        _dockerServiceMock.Verify(d => d.StopStackContainersAsync(
+                TestEnvironmentId, runningStack,
+                It.IsAny<Func<StackContainerProgress, Task>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        _dockerServiceMock.Verify(d => d.StopStackContainersAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<Func<StackContainerProgress, Task>>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the Pending stack has nothing deployed, so exactly one stack is stopped");
+    }
+
+    [Fact]
+    public async Task ExitMaintenance_FailedStack_StartsItsContainersAgain()
+    {
+        // Symmetry: whatever maintenance stopped, exiting maintenance has to start again.
+        var deployment = PartiallyRunningDeploymentWithFailedStack();
+        var failedStack = StackNameOf(deployment, StackDeploymentStatus.Failed);
+        await EnterMaintenance(deployment);
+
+        await ExitMaintenance(deployment);
+
+        _dockerServiceMock.Verify(d => d.StartStackContainersAsync(
+                TestEnvironmentId, failedStack,
+                It.IsAny<Func<StackContainerProgress, Task>>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    #endregion
+
+    #region Verification, retry and kill escalation
+
+    [Fact]
+    public async Task EnterMaintenance_ContainerStillRunningAfterBulkStop_IsRetriedIndividually()
+    {
+        var deployment = RunningDeployment();
+        var stack = StackNameOf(deployment, StackDeploymentStatus.Running);
+        _containers = [Container("web-1", stack)];
+        StopTakesEffectAfter(bulkStopCalls: int.MaxValue); // bulk stop never takes effect
+
+        await EnterMaintenance(deployment);
+
+        _dockerServiceMock.Verify(
+            d => d.StopContainerAsync(TestEnvironmentId, "id-web-1", It.IsAny<CancellationToken>()),
+            Times.AtLeastOnce,
+            "a container still running after the bulk stop must be stopped again, individually");
+    }
+
+    [Fact]
+    public async Task EnterMaintenance_ContainerNeverStops_IsKilled()
+    {
+        var deployment = RunningDeployment();
+        var stack = StackNameOf(deployment, StackDeploymentStatus.Running);
+        _containers = [Container("web-1", stack)];
+
+        await EnterMaintenance(deployment);
+
+        _dockerServiceMock.Verify(
+            d => d.KillContainerAsync(TestEnvironmentId, "id-web-1", It.IsAny<CancellationToken>()),
+            Times.Once,
+            "a container that survives stop and retry must be killed — maintenance may not leave it running");
+    }
+
+    [Fact]
+    public async Task EnterMaintenance_RestartingContainer_IsTreatedAsStillRunning()
+    {
+        // The field case: restart: always plus a crash loop means state 'restarting', which the old
+        // 'state == running' check ignored completely.
+        var deployment = RunningDeployment();
+        var stack = StackNameOf(deployment, StackDeploymentStatus.Running);
+        _containers = [Container("web-1", stack, state: "restarting")];
+
+        await EnterMaintenance(deployment);
+
+        _dockerServiceMock.Verify(
+            d => d.KillContainerAsync(TestEnvironmentId, "id-web-1", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task EnterMaintenance_StopTakesEffect_DoesNotRetryOrKill()
+    {
+        var deployment = RunningDeployment();
+        var stack = StackNameOf(deployment, StackDeploymentStatus.Running);
+        _containers = [Container("web-1", stack)];
+        StopTakesEffectAfter(bulkStopCalls: 1);
+
+        await EnterMaintenance(deployment);
+
+        _dockerServiceMock.Verify(
+            d => d.StopContainerAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _dockerServiceMock.Verify(
+            d => d.KillContainerAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EnterMaintenance_AlreadyExitedContainer_IsNotTouched()
+    {
+        var deployment = RunningDeployment();
+        var stack = StackNameOf(deployment, StackDeploymentStatus.Running);
+        _containers = [Container("web-1", stack, state: "exited")];
+
+        await EnterMaintenance(deployment);
+
+        _dockerServiceMock.Verify(
+            d => d.StopContainerAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _dockerServiceMock.Verify(
+            d => d.KillContainerAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EnterMaintenance_ExemptContainer_IsNeitherRetriedNorKilled()
+    {
+        // rsgo.maintenance=ignore containers (edge proxy, maintenance page) must survive untouched.
+        var deployment = RunningDeployment();
+        var stack = StackNameOf(deployment, StackDeploymentStatus.Running);
+        _containers = [Container("edge", stack, maintenance: "ignore")];
+
+        await EnterMaintenance(deployment);
+
+        _dockerServiceMock.Verify(
+            d => d.StopContainerAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _dockerServiceMock.Verify(
+            d => d.KillContainerAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EnterMaintenance_ContainerOfAnotherStack_IsNotTouched()
+    {
+        var deployment = RunningDeployment();
+        _containers = [Container("other", "some-foreign-stack")];
+
+        await EnterMaintenance(deployment);
+
+        _dockerServiceMock.Verify(
+            d => d.KillContainerAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task EnterMaintenance_KillFails_DoesNotThrow()
+    {
+        var deployment = RunningDeployment();
+        var stack = StackNameOf(deployment, StackDeploymentStatus.Running);
+        _containers = [Container("web-1", stack)];
+        _dockerServiceMock
+            .Setup(d => d.KillContainerAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("daemon gone"));
+
+        var response = await EnterMaintenance(deployment);
+
+        response.Success.Should().BeTrue("a failed kill is reported, not thrown at the caller");
+        TerminalUpdate.Phase.Should().Be("Failed");
+    }
+
+    #endregion
+
+    #region Honest reporting
+
+    [Fact]
+    public async Task EnterMaintenance_ContainersRemainRunning_ReportsFailedPhase()
+    {
+        var deployment = RunningDeployment();
+        var stack = StackNameOf(deployment, StackDeploymentStatus.Running);
+        _containers = [Container("web-1", stack), Container("web-2", stack)];
+
+        await EnterMaintenance(deployment);
+
+        TerminalUpdate.Phase.Should().Be("Failed",
+            "reporting Completed while containers are still running hides the failure completely");
+        TerminalUpdate.Message.Should().Contain("2");
+    }
+
+    [Fact]
+    public async Task EnterMaintenance_EverythingStopped_ReportsCompletedPhase()
+    {
+        var deployment = RunningDeployment();
+        var stack = StackNameOf(deployment, StackDeploymentStatus.Running);
+        _containers = [Container("web-1", stack)];
+        StopTakesEffectAfter(bulkStopCalls: 1);
+
+        await EnterMaintenance(deployment);
+
+        TerminalUpdate.Phase.Should().Be("Completed");
+        TerminalUpdate.Message.Should().Contain("stopped");
+    }
+
+    [Fact]
+    public async Task EnterMaintenance_NoContainersAtAll_ReportsCompletedPhase()
+    {
+        var deployment = RunningDeployment();
+        _containers = [];
+
+        await EnterMaintenance(deployment);
+
+        TerminalUpdate.Phase.Should().Be("Completed");
+    }
+
+    [Fact]
+    public async Task EnterMaintenance_ContainersRemainRunning_StillReportsModeChange()
+    {
+        // The mode has already been propagated to the product; rolling it back would be more
+        // surprising than reporting the failed stop. The caller still learns the mode changed.
+        var deployment = RunningDeployment();
+        var stack = StackNameOf(deployment, StackDeploymentStatus.Running);
+        _containers = [Container("web-1", stack)];
+
+        var response = await EnterMaintenance(deployment);
+
+        response.Success.Should().BeTrue();
+        response.NewMode.Should().Be("Maintenance");
+        deployment.OperationMode.Should().Be(OperationMode.Maintenance);
+    }
+
+    #endregion
+}

--- a/tests/ReadyStackGo.UnitTests/Application/Services/MaintenanceContainerFilterTests.cs
+++ b/tests/ReadyStackGo.UnitTests/Application/Services/MaintenanceContainerFilterTests.cs
@@ -1,0 +1,134 @@
+using FluentAssertions;
+using ReadyStackGo.Application.Services;
+using ReadyStackGo.Application.UseCases.Containers;
+
+namespace ReadyStackGo.UnitTests.Application.Services;
+
+/// <summary>
+/// The selection predicate behind maintenance stop/start. The states that matter are the ones the
+/// old "state == running" check silently skipped — a cycling container reports <c>restarting</c>,
+/// not <c>running</c>, and kept its database connections through the whole maintenance window.
+/// </summary>
+public class MaintenanceContainerFilterTests
+{
+    private static ContainerDto Container(
+        string state,
+        string? maintenanceLabel = null,
+        string? stackLabel = null,
+        string id = "c1")
+    {
+        var labels = new Dictionary<string, string>();
+        if (maintenanceLabel != null) labels["rsgo.maintenance"] = maintenanceLabel;
+        if (stackLabel != null) labels["rsgo.stack"] = stackLabel;
+
+        return new ContainerDto
+        {
+            Id = id,
+            Name = id,
+            Image = "test:1.0",
+            State = state,
+            Status = state,
+            Labels = labels
+        };
+    }
+
+    [Theory]
+    [InlineData("running")]
+    [InlineData("restarting")]
+    [InlineData("paused")]
+    [InlineData("created")]
+    public void ShouldStop_LiveState_IsTrue(string state)
+    {
+        MaintenanceContainerFilter.ShouldStop(Container(state)).Should().BeTrue(
+            "a container in state '{0}' still holds resources and must be stopped", state);
+    }
+
+    [Theory]
+    [InlineData("exited")]
+    [InlineData("dead")]
+    [InlineData("removing")]
+    public void ShouldStop_AlreadyGoneOrGoing_IsFalse(string state)
+    {
+        MaintenanceContainerFilter.ShouldStop(Container(state)).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("RUNNING")]
+    [InlineData("Exited")]
+    public void ShouldStop_IsCaseInsensitive(string state)
+    {
+        // Docker reports lowercase, but nothing in the contract guarantees it.
+        var expected = !state.Equals("Exited", StringComparison.OrdinalIgnoreCase);
+
+        MaintenanceContainerFilter.ShouldStop(Container(state)).Should().Be(expected);
+    }
+
+    [Theory]
+    [InlineData("running")]
+    [InlineData("restarting")]
+    public void ShouldStop_ExemptContainer_IsFalse(string state)
+    {
+        // The edge proxy and product-contributed maintenance containers must survive the window.
+        MaintenanceContainerFilter.ShouldStop(Container(state, maintenanceLabel: "ignore"))
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldStop_ExemptLabelIsCaseInsensitive()
+    {
+        MaintenanceContainerFilter.ShouldStop(Container("running", maintenanceLabel: "Ignore"))
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldStop_UnknownMaintenanceLabelValue_IsTrue()
+    {
+        // Only "ignore" exempts. Anything else is a normal container.
+        MaintenanceContainerFilter.ShouldStop(Container("running", maintenanceLabel: "whatever"))
+            .Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("exited", true)]
+    [InlineData("created", true)]
+    [InlineData("running", false)]
+    [InlineData("dead", false)]
+    public void ShouldStart_OnlyStartsStartableStates(string state, bool expected)
+    {
+        MaintenanceContainerFilter.ShouldStart(Container(state)).Should().Be(expected);
+    }
+
+    [Fact]
+    public void ShouldStart_ExemptContainer_IsFalse()
+    {
+        MaintenanceContainerFilter.ShouldStart(Container("exited", maintenanceLabel: "ignore"))
+            .Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("exited", true)]
+    [InlineData("dead", true)]
+    [InlineData("running", false)]
+    [InlineData("restarting", false)]
+    [InlineData("removing", false)]
+    public void IsStopped_OnlyTerminalStates(string state, bool expected)
+    {
+        MaintenanceContainerFilter.IsStopped(Container(state)).Should().Be(expected);
+    }
+
+    [Fact]
+    public void BelongsToStack_MatchesExactLabel()
+    {
+        var container = Container("running", stackLabel: "prod-web");
+
+        MaintenanceContainerFilter.BelongsToStack(container, "prod-web").Should().BeTrue();
+        MaintenanceContainerFilter.BelongsToStack(container, "prod-web-2").Should().BeFalse();
+        MaintenanceContainerFilter.BelongsToStack(container, "prod").Should().BeFalse();
+    }
+
+    [Fact]
+    public void BelongsToStack_WithoutLabel_IsFalse()
+    {
+        MaintenanceContainerFilter.BelongsToStack(Container("running"), "prod-web").Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Bug

Entering maintenance mode could leave product containers running while the deployment reported being
in maintenance — silently, with the UI showing "All containers stopped". Observed on an `ams.project`
deployment whose containers kept pooled SQL Server sessions on `dev-amsproject` throughout the
window.

This undermines the guarantee v0.83.0 (#463) was built for: a product update that waits for all
database sessions to close ends up waiting on containers RSGO believed it had stopped.

## Root Cause

Four independent defects in the enter-maintenance path, each sufficient on its own:

1. **Container selection was `state == "running"`** (`DockerService.cs:781`). Docker also reports
   `restarting`, `paused` and `created`. A container under `restart: always` that is cycling reports
   `restarting` and was never stopped — the case seen in the field.
2. **A failed stop was only logged.** The container state was never read back, and there was no retry
   and no kill escalation.
3. **Only stacks with status `Running` were considered** (`ChangeProductOperationModeHandler.cs:178`).
   A stack marked `Failed` because a single container never became healthy was skipped wholesale,
   although its other containers were up. `totalStacks` came from the same list, so the progress
   display gave no hint either.
4. **Success was reported unconditionally.** The terminal notification was `"All containers stopped"`
   regardless of the outcome, and the return value of `StopStackContainersAsync` was discarded.

## Fix

- New `MaintenanceContainerFilter` (Application layer) holds the selection predicates. `ShouldStop`
  is inverted: stop everything that is not already `exited`/`dead`/`removing`. The
  `rsgo.maintenance=ignore` exemption is unchanged, so the edge proxy and product-contributed
  maintenance containers still survive the window. `DockerService` uses it for both stop and start.
- The handler verifies after stopping: read the container state back, retry the survivors
  individually via `StopContainerAsync`, then escalate to the new `IDockerService.KillContainerAsync`
  for anything that ignored two stop attempts. Each round re-reads actual state rather than trusting
  the previous call, which also catches a container that came up during the transition. No delay
  between rounds — both Docker calls block until the daemon has acted.
- Stack selection widened to `Running`, `Deploying` and `Failed`, restricted to stacks that have a
  deployment stack name (a `Pending` stack has none — dereferencing it is why the filter was narrow
  in the first place). Enter and exit use the same set, so whatever maintenance stopped is started
  again.
- Honest reporting: phase `Failed` with the surviving container names instead of `Completed`, and
  likewise when the verification itself could not run. The frontend already maps the `Failed` phase
  to an error state (`useDeploymentHub.ts:130-131`), so no contract change was needed.

The operation mode is deliberately **not** rolled back on a partial stop: the flag has already been
propagated to the product, and reverting it would be more surprising than reporting the failure.

## Tests

New: `MaintenanceContainerFilterTests` (24) and `ChangeProductOperationModeStopVerificationTests`
(18). 8 of them failed against the previous behaviour before the fix. Beyond the happy path they
cover: `restarting`/`paused`/`created` states, case-insensitive state and label matching, a container
that stops only on retry, one that never stops, a failing kill, an unreachable daemon during
verification, already-`exited` containers, exempt containers, containers of a foreign stack, and
`Pending` stacks without a deployment name.

Two existing tests asserted the defective behaviour (`Handle_SkipsNonRunningStacks`,
`Handle_WithSession_SkipsNonRunningStacksInProgress`) and were corrected — a `Failed` stack is now
included. The legitimate skip case is covered by the new `Handle_SkipsStacksThatWereNeverDeployed`.

## Verification

- [x] Tests reproduce the bug (Red — 8 failures)
- [x] Fix implemented
- [x] Tests confirm the fix (Green)
- [x] Full unit suite: 3421 passed, 0 failed
- [x] Build passes (0 errors; 11 warnings, all pre-existing and unrelated)

Fixes #468